### PR TITLE
Added proper check of test data installed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,8 +150,7 @@ jobs:
       - run:
           name: Download test data
           command: |
-
-              if [ ! -d ./habitat-sim/data ]
+              if [ ! -d ./habitat-sim/data/scene_datasets/habitat-test-scenes/van-gogh-room.glb ]
               then
                 cd habitat-sim
                 wget http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip


### PR DESCRIPTION
## Motivation and Context
Fixed check if test data was loaded for CI, as `data` folder was added to habitat_sim repo, that made the check passing, while Habitat test scenes were not loaded. It was fixed on Habitat Sim side, but missing on Habitat API.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
