### PR TITLE
add profiling_utils.py

### DIFF
--- a/habitat/utils/__init__.py
+++ b/habitat/utils/__init__.py
@@ -5,4 +5,4 @@
 # LICENSE file in the root directory of this source tree.
 from habitat.utils import geometry_utils
 
-__all__ = ["visualizations", "geometry_utils"]
+__all__ = ["visualizations", "geometry_utils", "profiling_utils"]

--- a/habitat/utils/profiling_utils.py
+++ b/habitat/utils/profiling_utils.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+r"""Helper functions for profiling. Profilers like Nvidia Nsight can capture the
+time spent in annotated ranges.
+
+Example usage for marking ranges. For convenience, there are three syntax
+options; they're all functionally equivalent:
+
+# use the decorator to mark an entire function as a range
+@profiling_utils.RangeContext("my_function")
+def my_function():
+
+    # use range_push/range_pop explicitly
+    range_push("create and sort widgets")
+    create_widgets()
+    sort_widgets()
+    range_pop()
+
+    # use RangeContext and a with statement
+    with profiling_utils.RangeContext("print and save widgets"):
+        print_widgets()
+        save_widgets()
+
+Example of capturing an Nsight Systems profile:
+apt-get install nvidia-nsight
+export HABITAT_PROFILING=1
+path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=cuda,nvtx
+--trace-fork-before-exec=true --output=my_profile python my_program.py
+# look for my_profile.qdrep in working directory
+"""
+import os
+from contextlib import ContextDecorator
+
+from habitat.core.logging import logger
+
+env_var = os.environ.get("HABITAT_PROFILING", "0")
+enable_profiling = env_var != "0"
+if enable_profiling:
+    logger.info("HABITAT_PROFILING={}".format(env_var))
+    logger.info(
+        "profiling_utils.py range_push/range_pop annotation is enabled"
+    )
+    from torch.cuda import nvtx
+
+
+def range_push(msg: str):
+    r"""Annotates the start of a range for profiling. Requires HABITAT_PROFILING
+    environment variable to be set, otherwise the function is a no-op. Pushes a
+    range onto a stack of nested ranges. Every range_push should have a
+    corresponding range_pop. Attached profilers can capture the time spent in
+    ranges."
+    """
+    if enable_profiling:
+        nvtx.range_push(msg)
+
+
+def range_pop():
+    r"""Annotates the end of a range for profiling. See also range_push."
+    """
+    if enable_profiling:
+        nvtx.range_pop()
+
+
+class RangeContext(ContextDecorator):
+    def __init__(self, msg: str):
+        self._msg = msg
+
+    def __enter__(self):
+        range_push(self._msg)
+        return self
+
+    def __exit__(self, *exc):
+        range_pop()
+        return False

--- a/habitat/utils/profiling_utils.py
+++ b/habitat/utils/profiling_utils.py
@@ -58,13 +58,17 @@ def range_push(msg: str):
 
 
 def range_pop():
-    r"""Annotates the end of a range for profiling. See also range_push."
+    r"""Annotates the end of a range for profiling. See also range_push.
     """
     if enable_profiling:
         nvtx.range_pop()
 
 
 class RangeContext(ContextDecorator):
+    r"""Annotate a range for profiling. Use as a function decorator or in a with
+    statement. See also range_push.
+    """
+
     def __init__(self, msg: str):
         self._msg = msg
 

--- a/test/test_profiling_utils.py
+++ b/test/test_profiling_utils.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import importlib
+import os
+import sys
+
+from habitat.utils import profiling_utils
+
+env_var_name = "HABITAT_PROFILING"
+
+# Based on the env var, reloading the profiling_utils module should set
+# profiling_utils.enable_profiling to True or False.
+def test_env_var_enable():
+
+    # test with env var not set
+    os.environ.pop(env_var_name, None)
+    importlib.reload(profiling_utils)
+    assert not profiling_utils.enable_profiling
+    # We also call range_push/range_pop to verify they run without error.
+    profiling_utils.range_push("test, env var not set")
+    profiling_utils.range_pop()
+
+    # test with env var set to "0". This is equivalent to
+    # `export HABITAT_PROFILING=0` on the command line.
+    os.environ[env_var_name] = "0"
+    importlib.reload(profiling_utils)
+    assert not profiling_utils.enable_profiling
+    profiling_utils.range_push("test, HABITAT_PROFILING='0'")
+    profiling_utils.range_pop()
+
+    # test with env var set to "1"
+    os.environ[env_var_name] = "1"
+    importlib.reload(profiling_utils)
+    assert profiling_utils.enable_profiling
+    profiling_utils.range_push("test, HABITAT_PROFILING=True")
+    profiling_utils.range_pop()
+
+
+# Create nested ranges and verify the code runs without error.
+def test_nested_range_push_pop():
+    # Unfortunately, there isn't a way to verify correct behavior here. Ranges
+    # get recorded in the Nvidia driver/profiler. Documentation for
+    # torch.cuda.nvtx.range_push claims that it returns range stack depth, so I
+    # hoped to use it as a behavior checker, but it seems to just return -1 or
+    # -2 in practice.
+
+    os.environ[env_var_name] = "1"
+    importlib.reload(profiling_utils)
+
+    profiling_utils.range_push("A")
+    profiling_utils.range_push("B")
+    profiling_utils.range_push("C")
+    profiling_utils.range_pop()
+    profiling_utils.range_pop()
+    profiling_utils.range_pop()
+
+
+# Create ranges via RangeContext and verify the code runs without error.
+def test_range_context():
+
+    os.environ[env_var_name] = "1"
+    importlib.reload(profiling_utils)
+
+    with profiling_utils.RangeContext("A"):
+        pass
+
+    @profiling_utils.RangeContext("B")
+    def my_example_profiled_function():
+        pass
+
+    my_example_profiled_function()
+
+    with profiling_utils.RangeContext("C"):
+        my_example_profiled_function()
+        with profiling_utils.RangeContext("D"):
+            my_example_profiled_function()


### PR DESCRIPTION
## Motivation and Context

profiling_utils.py adds helper functions for profiling. Profilers like Nvidia Nsight can capture the time spent in annotated ranges.

I introduce the `HABITAT_PROFILING` environment variable to selectively enable these and future profiling-related stuff. 

Currently, `range_push`/`range_pop` are thin wrappers over the NVTX versions. In the future, we might add a different backend that doesn't depend on Nvidia or that works across multiple machines.

Example usage for marking ranges. For convenience, there are three syntax options; they're all functionally equivalent:
```
# use the decorator to mark an entire function as a range
@profiling_utils.RangeContext("my_function")
def my_function():
    # use range_push/range_pop explicitly
    range_push("create and sort widgets")
    create_widgets()
    sort_widgets()
    range_pop()
    # use RangeContext and a with statement
    with profiling_utils.RangeContext("print and save widgets"):
        print_widgets()
        save_widgets()
```
Example of capturing an Nsight Systems profile:
```
apt-get install nvidia-nsight
export HABITAT_PROFILING=1
path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=cuda,nvtx
--trace-fork-before-exec=true --output=my_profile python my_program.py
# look for my_profile.qdrep in working directory
```

## How Has This Been Tested

I added some test ranges to PPO and DDPPO train scripts. I tested the scripts with and without `HABITAT_PROFILING`, on my Fedora desktop and my devfair machine.

I added `test_profiling_utils.py`, although this only tests that the code runs without error (not behavior correctness). See comments in the file.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
