### PR TITLE
Add compare_profiles.py

### DIFF
--- a/habitat/utils/compare_profiles.py
+++ b/habitat/utils/compare_profiles.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+r"""Helper script to print summary timings for one or more profiles captured by
+Nvidia Nsight containing NVTX events. The script reads all sqlite files in the
+working directory. To add NVTX ranges to your program, see profiling_utils.py.
+
+Exampe usage:
+
+apt-get install nvidia-nsight
+export HABITAT_PROFILING=1
+# capture two profiles, named profile1.sqlite and profile2.sqlite
+path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=nvtx
+--trace-fork-before-exec=true --output=profile1 --export=sqlite python
+my_program.py
+path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=nvtx
+--trace-fork-before-exec=true --output=profile2 --export=sqlite python
+my_program.py
+python habitat/utils/compare_profiles.py --relative
+
+Example output, from a PPO train script that was annotated using
+profiling_utils.py:
+                                profile1.sqlite             profile2.sqlite
+event name                        incl (ms)     excl (ms)
+_worker_env                          87,102        10,843        -2,615          -933
+train                                44,376         7,820          -942          -272
+_worker_env recv                     37,993        37,993          -784          -784
+train loop body                      36,555           264          -669           -12
+_collect_rollout_step                28,733         1,990          -469           -75
+wait_step                            19,079        19,079          -143          -143
+habitat_simulator.py step            18,523        18,523          -109          -109
+_worker_env send                     10,597        10,597          -414          -414
+nav.py update_metric                  9,145         9,145          -375          -375
+_update_agent                         7,559         1,357          -188            -9
+act (run policy)                      5,750         5,750          -106          -106
+evaluate_actions                      3,058         3,058           -95           -95
+batch_obs                             1,915         1,915          -144          -144
+before_step (for optimize)            1,681         1,681           -62           -62
+backward (for surrogate loss)         1,463         1,463           -22           -22
+"""
+import argparse
+import glob
+import os
+import sqlite3
+
+
+class Event:
+    """Python in-memory representation for an NVTX event from an sqlite
+    database"""
+
+    def __init__(self, name, thread_id, start, end):
+        self._name = name
+        self._thread_id = thread_id
+        self._start = start
+        self._end = end
+
+
+class SummaryItem:
+    """Summary item, for accumulating time for a set of events."""
+
+    def __init__(self):
+        self._time_exclusive = 0
+        self._time_inclusive = 0
+
+
+def get_sqlite_events(conn):
+    """Parse an sqlite database containing an NVTX_EVENTS table and return a
+    list of Events."""
+    events = []
+
+    # check if table exists
+    cursor = conn.execute(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='NVTX_EVENTS'"
+    )
+    does_table_exist = cursor.fetchone()[0] > 0
+    if not does_table_exist:
+        return events
+
+    # select events
+    cursor = conn.execute(
+        "SELECT text, globalTid, start, end from NVTX_EVENTS"
+    )
+
+    for row in cursor:
+        events.append(Event(row[0], row[1], row[2], row[3]))
+
+    return events
+
+
+def create_summary_from_events(events):
+    """From a list of events, group by name and create summary items. Returns a
+    dictionary of items keyed by name."""
+    # sort by start time (ascending). For ties, sort by end time (descending). In this way,
+    # a (shorter) child event that starts at the same time as a (longer) parent event
+    # will occur later in the sort.
+    events.sort(reverse=True, key=lambda event: event._end)
+    events.sort(reverse=False, key=lambda event: event._start)
+
+    items = {}
+
+    for i in range(len(events)):
+
+        event = events[i]
+
+        item = items.setdefault(event._name, SummaryItem())
+
+        event_duration = event._end - event._start
+        item._time_inclusive += event_duration
+
+        exclusive_duration = 0
+
+        # iterate chronologically through later events. Our accumulated
+        #  "exclusive duration" is time during which we aren't inside any
+        #  overlapping, same-thread event ("child event").
+        recent_exclusive_start_time = event._start
+        child_end_times = set()
+        for j in range(i + 1, len(events) + 1):  # note one extra iteration
+
+            other_event = None if j == len(events) else events[j]
+            if other_event:
+                if other_event._thread_id != event._thread_id:
+                    continue
+                if other_event._start > event._end:
+                    other_event = None
+
+            current_time = other_event._start if other_event else event._end
+
+            if len(child_end_times):
+                latest_child_end_time = max(child_end_times)
+
+                # remove any child which ends prior to current_time
+                child_end_times = set(
+                    filter(lambda t: t > current_time, child_end_times)
+                )
+
+                if len(child_end_times) == 0:
+                    recent_exclusive_start_time = latest_child_end_time
+                else:
+                    recent_exclusive_start_time = None
+
+            # handle exclusive time leading up to current_time
+            if recent_exclusive_start_time:
+                assert recent_exclusive_start_time <= current_time
+                exclusive_duration += (
+                    current_time - recent_exclusive_start_time
+                )
+
+            if other_event:
+                child_end_times.add(other_event._end)
+            else:
+                break
+
+        assert event_duration >= exclusive_duration
+        item._time_exclusive += exclusive_duration
+
+        items[event._name] = item
+
+    return items
+
+
+def _display_time_ms(time, args, show_sign=False):
+    seconds_to_ms = 0.001
+    return "{}{:,.0f}".format(
+        "+" if time > 0 and show_sign else "",
+        time / (args.source_time_units_per_second * seconds_to_ms),
+    )
+
+
+def print_summaries(summaries, args, labels=None):
+    """Print a dictionary of summaries to stdout. See create_arg_parser for
+    formatting options available in the args object. See also
+    create_summary_from_events."""
+    sort_by_exclusive = args.sort_by == "exclusive"
+    print_relative_timings = args.relative
+
+    if len(summaries) == 0:
+        print("no summaries to print")
+        return
+
+    all_names_with_times = {}
+    max_name_len = 0
+    for summary in summaries:
+        for name in summary:
+            all_names_with_times.setdefault(
+                name,
+                summary[name]._time_exclusive
+                if sort_by_exclusive
+                else summary[name]._time_inclusive,
+            )
+            max_name_len = max(max_name_len, len(name))
+
+    if len(all_names_with_times.items()) == 0:
+        print(
+            "All summaries are empty. The sqlite databases are missing NVTX events."
+        )
+        return
+
+    all_names_with_times_list = list(all_names_with_times.items())
+    # sort by time, decreasing
+    all_names_with_times_list.sort(reverse=True, key=lambda x: x[1])
+
+    column_pad = 2
+    time_width = 12
+
+    if labels:
+        assert len(labels) == len(summaries)
+        max_label_len = time_width * 2 + column_pad
+        print("".ljust(max_name_len + column_pad), end="")
+        for label in labels:
+            short_label = label[-max_label_len:]
+            print(short_label.ljust(max_label_len + column_pad), end="")
+        print("")
+
+    print(
+        "event name".ljust(max_name_len + column_pad)
+        + "incl (ms)".rjust(time_width).ljust(time_width + column_pad)
+        + "excl (ms)".rjust(time_width).ljust(time_width + column_pad)
+    )
+
+    for tup in all_names_with_times_list:
+        name = tup[0]
+        print(name.ljust(max_name_len + column_pad), end="")
+        for (index, summary) in enumerate(summaries):
+            base_summary = summaries[0] if index > 0 else None
+            if name in summary:
+                item = summary[name]
+                if (
+                    base_summary
+                    and print_relative_timings
+                    and name in base_summary
+                ):
+                    base_item = base_summary[name]
+                    time_inclusive = (
+                        item._time_inclusive - base_item._time_inclusive
+                    )
+                    time_exclusive = (
+                        item._time_exclusive - base_item._time_exclusive
+                    )
+                    show_sign = True
+                else:
+                    time_inclusive = item._time_inclusive
+                    time_exclusive = item._time_exclusive
+                    show_sign = False
+                print(
+                    _display_time_ms(time_inclusive, args, show_sign=show_sign)
+                    .rjust(time_width)
+                    .ljust(time_width + column_pad)
+                    + _display_time_ms(
+                        time_exclusive, args, show_sign=show_sign
+                    )
+                    .rjust(time_width)
+                    .ljust(time_width + column_pad),
+                    end="",
+                )
+            else:
+                print(
+                    "-".ljust(time_width + column_pad)
+                    + "-".ljust(time_width + column_pad),
+                    end="",
+                )
+        print("")
+
+
+def get_sqlite_filepaths_from_directory(directory):
+    """Returns a list of filepaths."""
+    filepaths = []
+    os.chdir(directory)
+    for filepath in glob.glob("*.sqlite"):
+        filepaths.append(filepath)
+    return filepaths
+
+
+def create_arg_parser():
+    """For compare_profiles.py script. Includes print formatting options."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sort-by",
+        default="inclusive",
+        choices=["inclusive", "exclusive"],
+        help="Sort rows by inclusive or exclusive time.",
+    )
+    parser.add_argument(
+        "--source_time_units_per_second",
+        type=int,
+        default=1000 * 1000 * 1000,
+        metavar="N",
+        help="If your source NVTX event times were recorded as nanoseconds, use 1000000000 here.",
+    )
+    parser.add_argument(
+        "--relative",
+        action="store_true",
+        default=False,
+        help="When comparing 2+ profiles, display times as relative to the first profile's times.",
+    )
+    return parser
+
+
+def main():
+    args = create_arg_parser().parse_args()
+
+    filepaths = get_sqlite_filepaths_from_directory("./")
+
+    if len(filepaths) == 0:
+        print("No sqlite files were found in the working directory.")
+        return
+
+    filepaths.sort()  # sort alphabetically
+
+    summaries = []
+    for filepath in filepaths:
+        events = get_sqlite_events(sqlite3.connect(filepath))
+        summaries.append(create_summary_from_events(events))
+
+    print_summaries(summaries, args, labels=filepaths)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_compare_profiles.py
+++ b/test/test_compare_profiles.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+import os
+import sqlite3
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+from habitat.utils import compare_profiles
+
+
+# Create an sqlite database profile in memory. Populate the NVTX table with
+# profiling events. Verify compare_profiles functionality including creating and
+# printing a timing summary.
+def test_compare_profiles():
+
+    c = sqlite3.connect(":memory:")
+
+    # Parse a sqlite database which is missing the expected table.
+    events = compare_profiles.get_sqlite_events(c)
+    assert len(events) == 0
+
+    # This create statement corresponds to the sqlite database that Nsight Nsys
+    # creates.
+    c.execute(
+        """CREATE TABLE NVTX_EVENTS (start INTEGER NOT NULL, end INTEGER, text TEXT, globalTid INTEGER)"""
+    )
+
+    # Save (commit) the changes
+    c.commit()
+
+    # Parse a table with no rows.
+    events = compare_profiles.get_sqlite_events(c)
+    assert len(events) == 0
+
+    # Try to print a list of empty summaries.
+    expected_output = """All summaries are empty. The sqlite databases are missing NVTX events.\n"""
+
+    summary = compare_profiles.create_summary_from_events(events)
+    with patch("sys.stdout", new=StringIO()) as fake_out:
+        compare_profiles.print_summaries(
+            [summary], compare_profiles.create_arg_parser().parse_args([]),
+        )
+        assert fake_out.getvalue() == expected_output
+
+    # Insert some events. An event has a start time, end time, name, and thread
+    # ID.
+    # Thread 1
+    # 01234567890
+    # .[        )   incl 90   excl 20  root A
+    # .[ ).......   incl 20   excl 10  child 0
+    # ..[).......   incl 10   excl 10  child 1
+    # ....[...)..   incl 40   excl 10  child 2
+    # .....[...).   incl 40   excl 30  child 3
+    # ......[)...   incl 10   excl 10  child 4
+
+    # Thread 2
+    # 01234567890
+    # ..[......).   incl 70   excl 10  root B
+    # ...[.....).   incl 60   excl 60  child 6
+
+    # note on child 3: it's unrealistic for a child event to extend beyond the
+    # end time of its parent (child 2 in this case), but we expect to handle it
+    # anyway.
+
+    # event names are numbered here based on chronological ordering, but we
+    # insert them in random order.
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (60, 70, 'child 4', 1)")
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (20, 30, 'child 1', 1)")
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (10, 30, 'child 0', 1)")
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (10, 100, 'root A', 1)")
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (50, 90, 'child 3', 1)")
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (40, 80, 'child 2', 1)")
+
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (20, 90, 'root B', 2)")
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (30, 90, 'child 6', 2)")
+
+    # Save (commit) the changes
+    c.commit()
+
+    # use compare_profiles functionality to create timing summary
+    events = compare_profiles.get_sqlite_events(c)
+    summary = compare_profiles.create_summary_from_events(events)
+
+    assert summary["root A"]._time_inclusive == 90
+    assert summary["root A"]._time_exclusive == 20
+    assert summary["child 0"]._time_inclusive == 20
+    assert summary["child 0"]._time_exclusive == 10
+    assert summary["child 1"]._time_inclusive == 10
+    assert summary["child 1"]._time_exclusive == 10
+    assert summary["child 2"]._time_inclusive == 40
+    assert summary["child 2"]._time_exclusive == 10
+    assert summary["child 3"]._time_inclusive == 40
+    assert summary["child 3"]._time_exclusive == 30
+    assert summary["child 4"]._time_inclusive == 10
+    assert summary["child 4"]._time_exclusive == 10
+
+    assert summary["root B"]._time_inclusive == 70
+    assert summary["root B"]._time_exclusive == 10
+    assert summary["child 6"]._time_inclusive == 60
+    assert summary["child 6"]._time_exclusive == 60
+
+    # verify print output (exact string match)
+    expected_output = """event name   incl (ms)     excl (ms)  \nroot A             90            20  \nroot B             70            10  \nchild 6            60            60  \nchild 2            40            10  \nchild 3            40            30  \nchild 0            20            10  \nchild 1            10            10  \nchild 4            10            10  \n"""
+
+    with patch("sys.stdout", new=StringIO()) as fake_out:
+        compare_profiles.print_summaries(
+            [summary],
+            compare_profiles.create_arg_parser().parse_args(
+                ["--source_time_units_per_second", "1000"]
+            ),
+        )
+        assert fake_out.getvalue() == expected_output

--- a/test/test_compare_profiles.py
+++ b/test/test_compare_profiles.py
@@ -112,7 +112,7 @@ def test_compare_profiles():
         compare_profiles.print_summaries(
             [summary],
             compare_profiles.create_arg_parser().parse_args(
-                ["--source_time_units_per_second", "1000"]
+                ["--source-time-units-per-second", "1000"]
             ),
         )
         assert fake_out.getvalue() == expected_output


### PR DESCRIPTION
## Motivation and Context

Helper script to print summary timings for one or more profiles captured by Nvidia Nsight containing NVTX events. The script reads all sqlite files in the working directory. To add NVTX ranges to your program, see profiling_utils.py.

Exampe usage:
```
apt-get install nvidia-nsight
export HABITAT_PROFILING=1
# capture two profiles, named profile1.sqlite and profile2.sqlite
path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=nvtx
--trace-fork-before-exec=true --output=profile1 --export=sqlite python
my_program.py
path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=nvtx
--trace-fork-before-exec=true --output=profile2 --export=sqlite python
my_program.py
python habitat/utils/compare_profiles.py --relative
```
Example output, from a PPO train script that was annotated using profiling_utils.py:
```
                                profile1.sqlite             profile2.sqlite
event name                        incl (ms)     excl (ms)
_worker_env                          87,102        10,843        -2,615          -933
train                                44,376         7,820          -942          -272
_worker_env recv                     37,993        37,993          -784          -784
train loop body                      36,555           264          -669           -12
_collect_rollout_step                28,733         1,990          -469           -75
wait_step                            19,079        19,079          -143          -143
habitat_simulator.py step            18,523        18,523          -109          -109
_worker_env send                     10,597        10,597          -414          -414
nav.py update_metric                  9,145         9,145          -375          -375
_update_agent                         7,559         1,357          -188            -9
act (run policy)                      5,750         5,750          -106          -106
evaluate_actions                      3,058         3,058           -95           -95
batch_obs                             1,915         1,915          -144          -144
before_step (for optimize)            1,681         1,681           -62           -62
backward (for surrogate loss)         1,463         1,463           -22           -22
```
## How Has This Been Tested

PR includes test_compare_profiles.py with unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
