### PR TITLE
add profiling config and ranges for PPO/DDPPO training

### DIFF
--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -30,7 +30,7 @@ from habitat.core.simulator import Observations, Simulator
 from habitat.datasets import make_dataset
 from habitat.sims import make_sim
 from habitat.tasks import make_task
-from habitat_sim.utils import profiling_utils
+from habitat.utils import profiling_wrapper
 
 
 class Env:
@@ -365,7 +365,7 @@ class RLEnv(gym.Env):
     def current_episode(self) -> Type[Episode]:
         return self._env.current_episode
 
-    @profiling_utils.RangeContext("RLEnv.reset")
+    @profiling_wrapper.RangeContext("RLEnv.reset")
     def reset(self) -> Observations:
         return self._env.reset()
 
@@ -405,7 +405,7 @@ class RLEnv(gym.Env):
         """
         raise NotImplementedError
 
-    @profiling_utils.RangeContext("RLEnv.step")
+    @profiling_wrapper.RangeContext("RLEnv.step")
     def step(self, *args, **kwargs) -> Tuple[Observations, Any, bool, dict]:
         r"""Perform an action in the environment.
 

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -30,6 +30,7 @@ from habitat.core.simulator import Observations, Simulator
 from habitat.datasets import make_dataset
 from habitat.sims import make_sim
 from habitat.tasks import make_task
+from habitat_sim.utils import profiling_utils
 
 
 class Env:
@@ -364,6 +365,7 @@ class RLEnv(gym.Env):
     def current_episode(self) -> Type[Episode]:
         return self._env.current_episode
 
+    @profiling_utils.RangeContext("RLEnv.reset")
     def reset(self) -> Observations:
         return self._env.reset()
 
@@ -403,6 +405,7 @@ class RLEnv(gym.Env):
         """
         raise NotImplementedError
 
+    @profiling_utils.RangeContext("RLEnv.step")
     def step(self, *args, **kwargs) -> Tuple[Observations, Any, bool, dict]:
         r"""Perform an action in the environment.
 

--- a/habitat/core/vector_env.py
+++ b/habitat/core/vector_env.py
@@ -32,6 +32,7 @@ from habitat.config import Config
 from habitat.core.env import Env, Observations, RLEnv
 from habitat.core.logging import logger
 from habitat.core.utils import tile_images
+from habitat_sim.utils import profiling_utils
 
 try:
     # Use torch.multiprocessing if we can.
@@ -165,6 +166,7 @@ class VectorEnv:
         return self._num_envs - len(self._paused)
 
     @staticmethod
+    @profiling_utils.RangeContext("_worker_env")
     def _worker_env(
         connection_read_fn: Callable,
         connection_write_fn: Callable,
@@ -198,7 +200,12 @@ class VectorEnv:
                         observations, reward, done, info = env.step(**data)
                         if auto_reset_done and done:
                             observations = env.reset()
-                        connection_write_fn((observations, reward, done, info))
+                        with profiling_utils.RangeContext(
+                            "worker write after step"
+                        ):
+                            connection_write_fn(
+                                (observations, reward, done, info)
+                            )
                     elif isinstance(env, habitat.Env):
                         # habitat.Env
                         observations = env.step(**data)
@@ -246,7 +253,8 @@ class VectorEnv:
                 else:
                     raise NotImplementedError
 
-                command, data = connection_read_fn()
+                with profiling_utils.RangeContext("worker wait for command"):
+                    command, data = connection_read_fn()
 
             if child_pipe is not None:
                 child_pipe.close()
@@ -384,6 +392,7 @@ class VectorEnv:
         for write_fn, args in zip(self._connection_write_fns, data):
             write_fn((STEP_COMMAND, args))
 
+    @profiling_utils.RangeContext("wait_step")
     def wait_step(self) -> List[Observations]:
         r"""Wait until all the asynchronized environments have synchronized."""
         observations = []

--- a/habitat/core/vector_env.py
+++ b/habitat/core/vector_env.py
@@ -32,7 +32,7 @@ from habitat.config import Config
 from habitat.core.env import Env, Observations, RLEnv
 from habitat.core.logging import logger
 from habitat.core.utils import tile_images
-from habitat_sim.utils import profiling_utils
+from habitat.utils import profiling_wrapper
 
 try:
     # Use torch.multiprocessing if we can.
@@ -166,7 +166,7 @@ class VectorEnv:
         return self._num_envs - len(self._paused)
 
     @staticmethod
-    @profiling_utils.RangeContext("_worker_env")
+    @profiling_wrapper.RangeContext("_worker_env")
     def _worker_env(
         connection_read_fn: Callable,
         connection_write_fn: Callable,
@@ -200,7 +200,7 @@ class VectorEnv:
                         observations, reward, done, info = env.step(**data)
                         if auto_reset_done and done:
                             observations = env.reset()
-                        with profiling_utils.RangeContext(
+                        with profiling_wrapper.RangeContext(
                             "worker write after step"
                         ):
                             connection_write_fn(
@@ -253,7 +253,7 @@ class VectorEnv:
                 else:
                     raise NotImplementedError
 
-                with profiling_utils.RangeContext("worker wait for command"):
+                with profiling_wrapper.RangeContext("worker wait for command"):
                     command, data = connection_read_fn()
 
             if child_pipe is not None:
@@ -392,7 +392,7 @@ class VectorEnv:
         for write_fn, args in zip(self._connection_write_fns, data):
             write_fn((STEP_COMMAND, args))
 
-    @profiling_utils.RangeContext("wait_step")
+    @profiling_wrapper.RangeContext("wait_step")
     def wait_step(self) -> List[Observations]:
         r"""Wait until all the asynchronized environments have synchronized."""
         observations = []

--- a/habitat/utils/profiling_wrapper.py
+++ b/habitat/utils/profiling_wrapper.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+r"""Wrappers for habitat_sim profiling_utils functions. The wrappers are no-ops
+if habitat_sim isn't installed.
+
+Example of capturing an Nsight Systems profile with Habitat-lab:
+export HABITAT_PROFILING=1
+export NSYS_NVTX_PROFILER_REGISTER_ONLY=0  # required when using capture range
+path/to/nvidia/nsight-systems/bin/nsys profile --sample=none --trace=nvtx --trace-fork-before-exec=true --capture-range=nvtx -p "habitat_capture_range" --stop-on-range-end=true --output=my_profile --export=sqlite python habitat_baselines/run.py --exp-config habitat_baselines/config/pointnav/ppo_pointnav.yaml --run-type train PROFILING.CAPTURE_START_STEP 200 PROFILING.NUM_STEPS_TO_CAPTURE 100
+# look for my_profile.qdrep in working directory
+"""
+
+from contextlib import ContextDecorator
+
+try:
+    from habitat_sim.utils import profiling_utils
+except ImportError:
+    profiling_utils = None
+
+
+def configure(capture_start_step=-1, num_steps_to_capture=-1):
+    r"""Wrapper for habitat_sim profiling_utils.configure"""
+    if profiling_utils:
+        profiling_utils.configure(capture_start_step, num_steps_to_capture)
+
+
+def on_start_step():
+    r"""Wrapper for habitat_sim profiling_utils.on_start_step"""
+    if profiling_utils:
+        profiling_utils.on_start_step()
+
+
+def range_push(msg: str):
+    r"""Wrapper for habitat_sim profiling_utils.range_push"""
+    if profiling_utils:
+        profiling_utils.range_push(msg)
+
+
+def range_pop():
+    r"""Wrapper for habitat_sim profiling_utils.range_pop"""
+    if profiling_utils:
+        profiling_utils.range_pop()
+
+
+class RangeContext(ContextDecorator):
+    r"""Annotate a range for profiling. Use as a function decorator or in a with
+    statement. See habitat_sim profiling_utils.
+    """
+
+    def __init__(self, msg: str):
+        self._msg = msg
+
+    def __enter__(self):
+        range_push(self._msg)
+        return self
+
+    def __exit__(self, *exc):
+        range_pop()
+        return False

--- a/habitat_baselines/config/default.py
+++ b/habitat_baselines/config/default.py
@@ -146,6 +146,12 @@ _C.ORBSLAM2.NUM_ACTIONS = 3
 _C.ORBSLAM2.DIST_TO_STOP = 0.05
 _C.ORBSLAM2.PLANNER_MAX_STEPS = 500
 _C.ORBSLAM2.DEPTH_DENORM = get_task_config().SIMULATOR.DEPTH_SENSOR.MAX_DEPTH
+# -----------------------------------------------------------------------------
+# PROFILING
+# -----------------------------------------------------------------------------
+_C.PROFILING = CN()
+_C.PROFILING.CAPTURE_START_STEP = -1
+_C.PROFILING.NUM_STEPS_TO_CAPTURE = -1
 
 
 def get_config(

--- a/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
+++ b/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
@@ -19,6 +19,7 @@ from torch import nn as nn
 from torch.optim.lr_scheduler import LambdaLR
 
 from habitat import Config, logger
+from habitat.utils import profiling_wrapper
 from habitat_baselines.common.baseline_registry import baseline_registry
 from habitat_baselines.common.environments import get_env_class
 from habitat_baselines.common.obs_transformers import (
@@ -44,7 +45,6 @@ from habitat_baselines.rl.ddppo.policy.resnet_policy import (  # noqa: F401
 from habitat_baselines.rl.ppo.ppo_trainer import PPOTrainer
 from habitat_baselines.utils.common import batch_obs, linear_decay
 from habitat_baselines.utils.env_utils import construct_envs
-from habitat_sim.utils import profiling_utils
 
 
 @baseline_registry.register_trainer(name="ddppo")
@@ -134,7 +134,7 @@ class DDPPOTrainer(PPOTrainer):
             use_normalized_advantage=ppo_cfg.use_normalized_advantage,
         )
 
-    @profiling_utils.RangeContext("train")
+    @profiling_wrapper.RangeContext("train")
     def train(self) -> None:
         r"""Main method for DD-PPO.
 
@@ -145,12 +145,11 @@ class DDPPOTrainer(PPOTrainer):
             self.config.RL.DDPPO.distrib_backend
         )
         add_signal_handlers()
-        # Reference code. profiling_utils.configure is not available yet but it
-        # will merge to Habitat-sim soon.
-        # profiling_utils.configure(
-        #     capture_start_step=self.config.PROFILING.CAPTURE_START_STEP,
-        #     num_steps_to_capture=self.config.PROFILING.NUM_STEPS_TO_CAPTURE,
-        # )
+
+        profiling_wrapper.configure(
+            capture_start_step=self.config.PROFILING.CAPTURE_START_STEP,
+            num_steps_to_capture=self.config.PROFILING.NUM_STEPS_TO_CAPTURE,
+        )
 
         # Stores the number of workers that have finished their rollout
         num_rollouts_done_store = distrib.PrefixStore(
@@ -295,8 +294,8 @@ class DDPPOTrainer(PPOTrainer):
             else contextlib.suppress()
         ) as writer:
             for update in range(start_update, self.config.NUM_UPDATES):
-                # profiling_utils.on_start_step()
-                profiling_utils.range_push("train update")
+                profiling_wrapper.on_start_step()
+                profiling_wrapper.range_push("train update")
 
                 if ppo_cfg.use_linear_lr_decay:
                     lr_scheduler.step()  # type: ignore
@@ -307,7 +306,7 @@ class DDPPOTrainer(PPOTrainer):
                     )
 
                 if EXIT.is_set():
-                    profiling_utils.range_pop()  # train update
+                    profiling_wrapper.range_pop()  # train update
 
                     self.envs.close()
 
@@ -335,7 +334,7 @@ class DDPPOTrainer(PPOTrainer):
 
                 count_steps_delta = 0
                 self.agent.eval()
-                profiling_utils.range_push("rollouts loop")
+                profiling_wrapper.range_push("rollouts loop")
                 for step in range(ppo_cfg.num_steps):
 
                     (
@@ -358,7 +357,7 @@ class DDPPOTrainer(PPOTrainer):
                         self.config.RL.DDPPO.sync_frac * self.world_size
                     ):
                         break
-                profiling_utils.range_pop()  # rollouts loop
+                profiling_wrapper.range_pop()  # rollouts loop
 
                 num_rollouts_done_store.add("num_done", 1)
 
@@ -464,6 +463,6 @@ class DDPPOTrainer(PPOTrainer):
                         )
                         count_checkpoints += 1
 
-                profiling_utils.range_pop()  # train update
+                profiling_wrapper.range_pop()  # train update
 
             self.envs.close()

--- a/habitat_baselines/rl/ppo/ppo.py
+++ b/habitat_baselines/rl/ppo/ppo.py
@@ -13,6 +13,7 @@ from torch import optim as optim
 
 from habitat_baselines.common.rollout_storage import RolloutStorage
 from habitat_baselines.rl.ppo.policy import Policy
+from habitat_sim.utils import profiling_utils
 
 EPS_PPO = 1e-5
 
@@ -73,6 +74,7 @@ class PPO(nn.Module):
         dist_entropy_epoch = 0.0
 
         for _e in range(self.ppo_epoch):
+            profiling_utils.range_push("PPO.update epoch")
             data_generator = rollouts.recurrent_generator(
                 advantages, self.num_mini_batch
             )
@@ -149,6 +151,8 @@ class PPO(nn.Module):
                 value_loss_epoch += value_loss.item()
                 action_loss_epoch += action_loss.item()
                 dist_entropy_epoch += dist_entropy.item()
+
+            profiling_utils.range_pop()  # PPO.update epoch
 
         num_updates = self.ppo_epoch * self.num_mini_batch
 

--- a/habitat_baselines/rl/ppo/ppo.py
+++ b/habitat_baselines/rl/ppo/ppo.py
@@ -11,9 +11,9 @@ from torch import Tensor
 from torch import nn as nn
 from torch import optim as optim
 
+from habitat.utils import profiling_wrapper
 from habitat_baselines.common.rollout_storage import RolloutStorage
 from habitat_baselines.rl.ppo.policy import Policy
-from habitat_sim.utils import profiling_utils
 
 EPS_PPO = 1e-5
 
@@ -74,7 +74,7 @@ class PPO(nn.Module):
         dist_entropy_epoch = 0.0
 
         for _e in range(self.ppo_epoch):
-            profiling_utils.range_push("PPO.update epoch")
+            profiling_wrapper.range_push("PPO.update epoch")
             data_generator = rollouts.recurrent_generator(
                 advantages, self.num_mini_batch
             )
@@ -152,7 +152,7 @@ class PPO(nn.Module):
                 action_loss_epoch += action_loss.item()
                 dist_entropy_epoch += dist_entropy.item()
 
-            profiling_utils.range_pop()  # PPO.update epoch
+            profiling_wrapper.range_pop()  # PPO.update epoch
 
         num_updates = self.ppo_epoch * self.num_mini_batch
 

--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -33,6 +33,7 @@ from habitat_baselines.utils.common import (
     linear_decay,
 )
 from habitat_baselines.utils.env_utils import construct_envs
+from habitat_sim.utils import profiling_utils
 
 
 @baseline_registry.register_trainer(name="ppo")
@@ -90,6 +91,7 @@ class PPOTrainer(BaseRLTrainer):
             use_normalized_advantage=ppo_cfg.use_normalized_advantage,
         )
 
+    @profiling_utils.RangeContext("save_checkpoint")
     def save_checkpoint(
         self, file_name: str, extra_state: Optional[Dict] = None
     ) -> None:
@@ -165,6 +167,7 @@ class PPOTrainer(BaseRLTrainer):
 
         return results
 
+    @profiling_utils.RangeContext("_collect_rollout_step")
     def _collect_rollout_step(
         self, rollouts, current_episode_reward, running_episode_stats
     ):
@@ -178,6 +181,7 @@ class PPOTrainer(BaseRLTrainer):
                 k: v[rollouts.step] for k, v in rollouts.observations.items()
             }
 
+            profiling_utils.range_push("compute actions")
             (
                 values,
                 actions,
@@ -194,7 +198,10 @@ class PPOTrainer(BaseRLTrainer):
 
         t_step_env = time.time()
 
-        outputs = self.envs.step([a[0].item() for a in actions])
+        step_data = [a[0].item() for a in actions]
+        profiling_utils.range_pop()  # compute actions
+
+        outputs = self.envs.step(step_data)
         observations, rewards_l, dones, infos = [
             list(x) for x in zip(*outputs)
         ]
@@ -250,6 +257,7 @@ class PPOTrainer(BaseRLTrainer):
 
         return pth_time, env_time, self.envs.num_envs
 
+    @profiling_utils.RangeContext("_update_agent")
     def _update_agent(self, ppo_cfg, rollouts):
         t_update_model = time.time()
         with torch.no_grad():
@@ -278,12 +286,19 @@ class PPOTrainer(BaseRLTrainer):
             dist_entropy,
         )
 
+    @profiling_utils.RangeContext("train")
     def train(self) -> None:
         r"""Main method for training PPO.
 
         Returns:
             None
         """
+        # Reference code. profiling_utils.configure is not available yet but it
+        # will merge to Habitat-sim soon.
+        # profiling_utils.configure(
+        #     capture_start_step=self.config.PROFILING.CAPTURE_START_STEP,
+        #     num_steps_to_capture=self.config.PROFILING.NUM_STEPS_TO_CAPTURE,
+        # )
 
         self.envs = construct_envs(
             self.config, get_env_class(self.config.ENV_NAME)
@@ -350,6 +365,9 @@ class PPOTrainer(BaseRLTrainer):
             self.config.TENSORBOARD_DIR, flush_secs=self.flush_secs
         ) as writer:
             for update in range(self.config.NUM_UPDATES):
+                # profiling_utils.on_start_step()
+                profiling_utils.range_push("train update")
+
                 if ppo_cfg.use_linear_lr_decay:
                     lr_scheduler.step()  # type: ignore
 
@@ -358,6 +376,7 @@ class PPOTrainer(BaseRLTrainer):
                         update, self.config.NUM_UPDATES
                     )
 
+                profiling_utils.range_push("rollouts loop")
                 for _step in range(ppo_cfg.num_steps):
                     (
                         delta_pth_time,
@@ -369,6 +388,7 @@ class PPOTrainer(BaseRLTrainer):
                     pth_time += delta_pth_time
                     env_time += delta_env_time
                     count_steps += delta_steps
+                profiling_utils.range_pop()  # rollouts loop
 
                 (
                     delta_pth_time,
@@ -444,6 +464,8 @@ class PPOTrainer(BaseRLTrainer):
                         f"ckpt.{count_checkpoints}.pth", dict(step=count_steps)
                     )
                     count_checkpoints += 1
+
+                profiling_utils.range_pop()  # train update
 
             self.envs.close()
 

--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -15,6 +15,7 @@ import tqdm
 from torch.optim.lr_scheduler import LambdaLR
 
 from habitat import Config, logger
+from habitat.utils import profiling_wrapper
 from habitat.utils.visualizations.utils import observations_to_image
 from habitat_baselines.common.base_trainer import BaseRLTrainer
 from habitat_baselines.common.baseline_registry import baseline_registry
@@ -33,7 +34,6 @@ from habitat_baselines.utils.common import (
     linear_decay,
 )
 from habitat_baselines.utils.env_utils import construct_envs
-from habitat_sim.utils import profiling_utils
 
 
 @baseline_registry.register_trainer(name="ppo")
@@ -91,7 +91,7 @@ class PPOTrainer(BaseRLTrainer):
             use_normalized_advantage=ppo_cfg.use_normalized_advantage,
         )
 
-    @profiling_utils.RangeContext("save_checkpoint")
+    @profiling_wrapper.RangeContext("save_checkpoint")
     def save_checkpoint(
         self, file_name: str, extra_state: Optional[Dict] = None
     ) -> None:
@@ -167,7 +167,7 @@ class PPOTrainer(BaseRLTrainer):
 
         return results
 
-    @profiling_utils.RangeContext("_collect_rollout_step")
+    @profiling_wrapper.RangeContext("_collect_rollout_step")
     def _collect_rollout_step(
         self, rollouts, current_episode_reward, running_episode_stats
     ):
@@ -181,7 +181,7 @@ class PPOTrainer(BaseRLTrainer):
                 k: v[rollouts.step] for k, v in rollouts.observations.items()
             }
 
-            profiling_utils.range_push("compute actions")
+            profiling_wrapper.range_push("compute actions")
             (
                 values,
                 actions,
@@ -199,7 +199,7 @@ class PPOTrainer(BaseRLTrainer):
         t_step_env = time.time()
 
         step_data = [a[0].item() for a in actions]
-        profiling_utils.range_pop()  # compute actions
+        profiling_wrapper.range_pop()  # compute actions
 
         outputs = self.envs.step(step_data)
         observations, rewards_l, dones, infos = [
@@ -257,7 +257,7 @@ class PPOTrainer(BaseRLTrainer):
 
         return pth_time, env_time, self.envs.num_envs
 
-    @profiling_utils.RangeContext("_update_agent")
+    @profiling_wrapper.RangeContext("_update_agent")
     def _update_agent(self, ppo_cfg, rollouts):
         t_update_model = time.time()
         with torch.no_grad():
@@ -286,19 +286,18 @@ class PPOTrainer(BaseRLTrainer):
             dist_entropy,
         )
 
-    @profiling_utils.RangeContext("train")
+    @profiling_wrapper.RangeContext("train")
     def train(self) -> None:
         r"""Main method for training PPO.
 
         Returns:
             None
         """
-        # Reference code. profiling_utils.configure is not available yet but it
-        # will merge to Habitat-sim soon.
-        # profiling_utils.configure(
-        #     capture_start_step=self.config.PROFILING.CAPTURE_START_STEP,
-        #     num_steps_to_capture=self.config.PROFILING.NUM_STEPS_TO_CAPTURE,
-        # )
+
+        profiling_wrapper.configure(
+            capture_start_step=self.config.PROFILING.CAPTURE_START_STEP,
+            num_steps_to_capture=self.config.PROFILING.NUM_STEPS_TO_CAPTURE,
+        )
 
         self.envs = construct_envs(
             self.config, get_env_class(self.config.ENV_NAME)
@@ -365,8 +364,8 @@ class PPOTrainer(BaseRLTrainer):
             self.config.TENSORBOARD_DIR, flush_secs=self.flush_secs
         ) as writer:
             for update in range(self.config.NUM_UPDATES):
-                # profiling_utils.on_start_step()
-                profiling_utils.range_push("train update")
+                profiling_wrapper.on_start_step()
+                profiling_wrapper.range_push("train update")
 
                 if ppo_cfg.use_linear_lr_decay:
                     lr_scheduler.step()  # type: ignore
@@ -376,7 +375,7 @@ class PPOTrainer(BaseRLTrainer):
                         update, self.config.NUM_UPDATES
                     )
 
-                profiling_utils.range_push("rollouts loop")
+                profiling_wrapper.range_push("rollouts loop")
                 for _step in range(ppo_cfg.num_steps):
                     (
                         delta_pth_time,
@@ -388,7 +387,7 @@ class PPOTrainer(BaseRLTrainer):
                     pth_time += delta_pth_time
                     env_time += delta_env_time
                     count_steps += delta_steps
-                profiling_utils.range_pop()  # rollouts loop
+                profiling_wrapper.range_pop()  # rollouts loop
 
                 (
                     delta_pth_time,
@@ -465,7 +464,7 @@ class PPOTrainer(BaseRLTrainer):
                     )
                     count_checkpoints += 1
 
-                profiling_utils.range_pop()  # train update
+                profiling_wrapper.range_pop()  # train update
 
             self.envs.close()
 

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -26,9 +26,9 @@ from numpy import ndarray
 from torch import Size, Tensor
 from torch import nn as nn
 
+from habitat.utils import profiling_wrapper
 from habitat.utils.visualizations.utils import images_to_video
 from habitat_baselines.common.tensorboard_utils import TensorboardWriter
-from habitat_sim.utils import profiling_utils
 
 
 class Flatten(nn.Module):
@@ -92,7 +92,7 @@ def _to_tensor(v: Union[Tensor, ndarray]) -> torch.Tensor:
 
 
 @torch.no_grad()
-@profiling_utils.RangeContext("batch_obs")
+@profiling_wrapper.RangeContext("batch_obs")
 def batch_obs(
     observations: List[Dict],
     device: Optional[torch.device] = None,

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -28,6 +28,7 @@ from torch import nn as nn
 
 from habitat.utils.visualizations.utils import images_to_video
 from habitat_baselines.common.tensorboard_utils import TensorboardWriter
+from habitat_sim.utils import profiling_utils
 
 
 class Flatten(nn.Module):
@@ -91,6 +92,7 @@ def _to_tensor(v: Union[Tensor, ndarray]) -> torch.Tensor:
 
 
 @torch.no_grad()
+@profiling_utils.RangeContext("batch_obs")
 def batch_obs(
     observations: List[Dict],
     device: Optional[torch.device] = None,


### PR DESCRIPTION
## Motivation and Context

This PR adds profiling ranges to PPO/DDPPO training.

It also adds a PROFILING section to our config. In general, we won't author a PROFILING section into our yaml files. We'll just override values via the command line. See https://github.com/facebookresearch/habitat-lab/pull/476/files#diff-9a47df42fe45fb85dac9db9bcaa60eceR124 .

For an overview of profiling and optimization in Habitat, see:
https://colab.research.google.com/gist/eundersander/b62bb497519b44cf4ceb10e2079525dc/faster-rl-training-profiling-and-optimization.ipynb

This PR uses a fairly new `habitat_sim.profiling_utils` API. It's in Hab-sim nightly but not Hab-sim stable. I assume it's safe to merge as long as CI passes. After this merges, Hab-lab users that pull latest will also need to update Hab-sim.

Example output viewed in Nsight GUI tool:
![nsight_multithreaded_trace1](https://user-images.githubusercontent.com/6557808/92414491-469e4a80-f109-11ea-8db7-a040ef7b7cd7.png)

Example with CUDA capture:
![nsight_multithreaded_trace4](https://user-images.githubusercontent.com/6557808/92415091-28861980-f10c-11ea-8e03-b042c997e757.png)

Example with OpenGL capture:
![nsight_multithread_trace3](https://user-images.githubusercontent.com/6557808/92414494-4900a480-f109-11ea-83f4-348287ee9404.png)

## How Has This Been Tested

Ad hoc testing on my linux desktop and FAIR cluster.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
