### PR TITLE
Make cube2eq batched

### DIFF
--- a/habitat_baselines/common/obs_transformers.py
+++ b/habitat_baselines/common/obs_transformers.py
@@ -440,9 +440,7 @@ class Cube2Equirec(nn.Module):
         """Takes a batch of cubemaps stacked in proper order and converts thems to equirects, reduces batch size by 6"""
         batch_size, ch, _H, _W = batch.shape
         if batch_size == 0 or batch_size % 6 != 0:
-            raise ValueError(
-                f"Batch size mismatch: {batch_size} is not a positive mulitple of 6"
-            )
+            raise ValueError(f"Batch size mismatch: {batch_size} is not 6x")
 
         sampled_image = torch.nn.functional.grid_sample(
             batch,  # NCHW
@@ -459,9 +457,9 @@ class Cube2Equirec(nn.Module):
             .view(-1, 6, 1, self.equ_h, self.equ_w)
             .expand(1, 6, ch, -1, -1)
         )  # batch_size//6, 6, ch, self.equ_h, self.equ_w
-        output = torch.sum(sampled_image_masked, dim=1)
-
-        return output  # batch_size//6, ch, self.equ_h, self.equ_w
+        return torch.sum(
+            sampled_image_masked, dim=1
+        )  # batch_size//6, ch, self.equ_h, self.equ_w
 
     # Convert input cubic tensor to output equirectangular image
     def to_equirec_tensor(self, batch: torch.Tensor):
@@ -471,7 +469,7 @@ class Cube2Equirec(nn.Module):
         # Check whether batch size is 6x
         cubemap_sides = batch.size()[0]
         if cubemap_sides == 0 or cubemap_sides % 6 != 0:
-            raise ValueError("Batch size should be 6")
+            raise ValueError("Batch size should be 6x")
 
         return self._to_equirec(batch)
 

--- a/habitat_baselines/common/obs_transformers.py
+++ b/habitat_baselines/common/obs_transformers.py
@@ -456,10 +456,10 @@ class Cube2Equirec(nn.Module):
             self.mask.float()
             .view(-1, 6, 1, self.equ_h, self.equ_w)
             .expand(1, 6, ch, -1, -1)
-        )  # batch_size//6, 6, ch, self.equ_h, self.equ_w
+        )  # batch_size // 6, 6, ch, self.equ_h, self.equ_w
         return torch.sum(
             sampled_image_masked, dim=1
-        )  # batch_size//6, ch, self.equ_h, self.equ_w
+        )  # batch_size // 6, ch, self.equ_h, self.equ_w
 
     # Convert input cubic tensor to output equirectangular image
     def to_equirec_tensor(self, batch: torch.Tensor):

--- a/test/test_baseline_trainers.py
+++ b/test/test_baseline_trainers.py
@@ -42,12 +42,13 @@ def _powerset(s):
         glob("habitat_baselines/config/test/*"),
         ["train", "eval"],
         [True, False],
-        _powerset(
+        [
+            [],
             [
                 "CenterCropper",
                 "ResizeShortestEdge",
-            ]
-        ),
+            ],
+        ],
     ),
 )
 def test_trainers(test_cfg_path, mode, gpu2gpu, observation_transforms):
@@ -81,10 +82,9 @@ def test_trainers(test_cfg_path, mode, gpu2gpu, observation_transforms):
 )
 @pytest.mark.parametrize(
     "test_cfg_path,mode",
-    itertools.product(
-        glob("habitat_baselines/config/test/*pointnav_test.yaml"),
-        ["train", "eval"],
-    ),
+    [
+        ["habitat_baselines/config/test/ppo_pointnav_test.yaml", "train"],
+    ],
 )
 def test_equirect_stiching(test_cfg_path, mode: str):
     meta_config = get_config(config_paths=test_cfg_path)


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It improves the speed of the Cube2Equirectangular ObservationTransformer by fulling batching the input. Improve speed by nearly 10%, the overhead of the transformation is now minimal. Also fixes a bug where it couldn't get properly send input to more than two target sensors.

Finally, it reduces the number of tests run in test_baseline_trainers so that the massive testing time regression is now fixed.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally with PyTest and manually looking at the output + benchmarking. Increases FPS from 100-120 locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
-  refactoring 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
