### PR TITLE
[WIP] Add mypy and static type checking to Habitat Lab

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: master
     hooks:
     -   id: autoflake
-        args: ['--expand-star-imports', '--ignore-init-module-imports', '--in-place', '-c']
+        args: ['--expand-star-imports', '--ignore-init-module-imports', '--in-place']
         exclude: docs/
 
 -   repo: https://gitlab.com/pycqa/flake8

--- a/habitat/core/agent.py
+++ b/habitat/core/agent.py
@@ -8,9 +8,10 @@ the user should subclass ``habitat.Agent`` and implement the ``act()``
 and ``reset()`` methods.
 """
 
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
-from habitat.core.simulator import Observations
+if TYPE_CHECKING:
+    from habitat.core.simulator import Observations
 
 
 class Agent:
@@ -24,7 +25,7 @@ class Agent:
         raise NotImplementedError
 
     def act(
-        self, observations: Observations
+        self, observations: "Observations"
     ) -> Union[int, str, Dict[str, Any]]:
         r"""Called to produce an action to perform in an environment.
 

--- a/habitat/core/benchmark.py
+++ b/habitat/core/benchmark.py
@@ -11,18 +11,20 @@ and is implemented through metrics defined for ``habitat.EmbodiedTask``.
 
 import os
 from collections import defaultdict
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from habitat.config.default import get_config
-from habitat.core.agent import Agent
-from habitat.core.env import Env
+
+if TYPE_CHECKING:
+    from habitat.core.agent import Agent
+    from habitat.core.env import Env
 
 
 class Benchmark:
     r"""Benchmark for evaluating agents in environments."""
 
     def __init__(
-        self, config_paths: Optional[str] = None, eval_remote=False
+        self, config_paths: Optional[str] = None, eval_remote: bool = False
     ) -> None:
         r"""..
 
@@ -38,7 +40,7 @@ class Benchmark:
             self._env = Env(config=config_env)
 
     def remote_evaluate(
-        self, agent: Agent, num_episodes: Optional[int] = None
+        self, agent: "Agent", num_episodes: Optional[int] = None
     ):
         # The modules imported below are specific to habitat-challenge remote evaluation.
         # These modules are not part of the habitat-lab repository.
@@ -113,7 +115,9 @@ class Benchmark:
 
         return avg_metrics
 
-    def local_evaluate(self, agent: Agent, num_episodes: Optional[int] = None):
+    def local_evaluate(
+        self, agent: "Agent", num_episodes: Optional[int] = None
+    ) -> Dict[str, float]:
         if num_episodes is None:
             num_episodes = len(self._env.episodes)
         else:
@@ -147,7 +151,7 @@ class Benchmark:
         return avg_metrics
 
     def evaluate(
-        self, agent: Agent, num_episodes: Optional[int] = None
+        self, agent: "Agent", num_episodes: Optional[int] = None
     ) -> Dict[str, float]:
         r"""..
 

--- a/habitat/core/benchmark.py
+++ b/habitat/core/benchmark.py
@@ -14,10 +14,10 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, Optional
 
 from habitat.config.default import get_config
+from habitat.core.env import Env
 
 if TYPE_CHECKING:
     from habitat.core.agent import Agent
-    from habitat.core.env import Env
 
 
 class Benchmark:

--- a/habitat/core/dataset.py
+++ b/habitat/core/dataset.py
@@ -21,6 +21,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Sequence,
     TypeVar,
     Union,
 )
@@ -60,7 +61,7 @@ class Episode:
     start_rotation: List[float] = attr.ib(
         default=None, validator=not_none_validator
     )
-    info: Optional[Dict[str, str]] = None
+    info: Optional[Dict[str, Any]] = None
     _shortest_path_cache: Any = attr.ib(init=False, default=None)
 
     def __getstate__(self):
@@ -336,7 +337,7 @@ class EpisodeIterator(Iterator):
 
     def __init__(
         self,
-        episodes: List[T],
+        episodes: Sequence[T],
         cycle: bool = True,
         shuffle: bool = False,
         group_by_scene: bool = True,
@@ -377,7 +378,7 @@ class EpisodeIterator(Iterator):
                 episodes, num_episode_sample, replace=False
             )
 
-        self.episodes = episodes
+        self.episodes = list(episodes)
         self.cycle = cycle
         self.group_by_scene = group_by_scene
         self.shuffle = shuffle
@@ -462,7 +463,7 @@ class EpisodeIterator(Iterator):
         self._iterator = iter(episodes)
 
     def _group_scenes(
-        self, episodes: Union[List[Episode], ndarray]
+        self, episodes: Union[Sequence[Episode], List[Episode], ndarray]
     ) -> List[T]:
         r"""Internal method that groups episodes by scene
         Groups will be ordered by the order the first episode of a given

--- a/habitat/core/embodied_task.py
+++ b/habitat/core/embodied_task.py
@@ -288,7 +288,7 @@ class EmbodiedTask:
 
         return observations
 
-    def step(self, action: Union[int, Dict[str, Any]], episode: Type[Episode]):
+    def step(self, action: Dict[str, Any], episode: Type[Episode]):
         if "action_args" not in action or action["action_args"] is None:
             action["action_args"] = {}
         action_name = action["action"]

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -346,10 +346,6 @@ class RLEnv(gym.Env):
     def current_episode(self) -> Type[Episode]:
         return self._env.current_episode
 
-    @episodes.setter
-    def episodes(self, episodes: List[Type[Episode]]) -> None:
-        self._env.episodes = episodes
-
     def reset(self) -> Observations:
         return self._env.reset()
 

--- a/habitat/core/logging.py
+++ b/habitat/core/logging.py
@@ -21,9 +21,9 @@ class HabitatLogger(logging.Logger):
     ):
         super().__init__(name, level)
         if filename is not None:
-            handler = logging.FileHandler(filename, filemode)
+            handler = logging.FileHandler(filename, filemode)  # type:ignore
         else:
-            handler = logging.StreamHandler(stream)
+            handler = logging.StreamHandler(stream)  # type:ignore
         self._formatter = logging.Formatter(format, dateformat, style)
         handler.setFormatter(self._formatter)
         super().addHandler(handler)

--- a/habitat/core/registry.py
+++ b/habitat/core/registry.py
@@ -28,16 +28,29 @@ Various decorators for registry different kind of classes with unique keys
 """
 
 import collections
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Optional, Type
 
 from habitat.core.utils import Singleton
 
+if TYPE_CHECKING:
+    from habitat.core.dataset import Dataset
+    from habitat.core.embodied_task import Measure
+    from habitat.core.simulator import ActionSpaceConfiguration, Sensor
+    from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
+    from habitat.tasks.nav.nav import NavigationTask, SimulatorTaskAction
+
 
 class Registry(metaclass=Singleton):
-    mapping = collections.defaultdict(dict)
+    mapping: DefaultDict[str, Any] = collections.defaultdict(dict)
 
     @classmethod
-    def _register_impl(cls, _type, to_register, name, assert_type=None):
+    def _register_impl(
+        cls,
+        _type: str,
+        to_register: Optional[Any],
+        name: str,
+        assert_type: Optional[Type] = None,
+    ) -> Callable:
         def wrap(to_register):
             if assert_type is not None:
                 assert issubclass(
@@ -87,7 +100,7 @@ class Registry(metaclass=Singleton):
 
     @classmethod
     def register_simulator(
-        cls, to_register=None, *, name: Optional[str] = None
+        cls, to_register: None = None, *, name: Optional[str] = None
     ):
         r"""Register a simulator to registry with key :p:`name`
 
@@ -193,35 +206,37 @@ class Registry(metaclass=Singleton):
         )
 
     @classmethod
-    def _get_impl(cls, _type, name):
+    def _get_impl(cls, _type: str, name: str) -> Type:
         return cls.mapping[_type].get(name, None)
 
     @classmethod
-    def get_task(cls, name):
+    def get_task(cls, name: str) -> Type["NavigationTask"]:
         return cls._get_impl("task", name)
 
     @classmethod
-    def get_task_action(cls, name):
+    def get_task_action(cls, name: str) -> Type["SimulatorTaskAction"]:
         return cls._get_impl("task_action", name)
 
     @classmethod
-    def get_simulator(cls, name):
+    def get_simulator(cls, name: str) -> Type["HabitatSim"]:
         return cls._get_impl("sim", name)
 
     @classmethod
-    def get_sensor(cls, name):
+    def get_sensor(cls, name: str) -> Type["Sensor"]:
         return cls._get_impl("sensor", name)
 
     @classmethod
-    def get_measure(cls, name):
+    def get_measure(cls, name: str) -> Type["Measure"]:
         return cls._get_impl("measure", name)
 
     @classmethod
-    def get_dataset(cls, name):
+    def get_dataset(cls, name: str) -> Type["Dataset"]:
         return cls._get_impl("dataset", name)
 
     @classmethod
-    def get_action_space_configuration(cls, name):
+    def get_action_space_configuration(
+        cls, name: str
+    ) -> Type["ActionSpaceConfiguration"]:
         return cls._get_impl("action_space_config", name)
 
 

--- a/habitat/core/spaces.py
+++ b/habitat/core/spaces.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import OrderedDict
-from typing import Sized
+from collections.abs import Collection
+from typing import Dict, List, Union
 
 import gym
 from gym import Space
@@ -44,7 +45,7 @@ class ActionSpace(gym.spaces.Dict):
         })
     """
 
-    def __init__(self, spaces):
+    def __init__(self, spaces: Union[List, Dict]):
         if isinstance(spaces, dict):
             self.spaces = OrderedDict(sorted(spaces.items()))
         if isinstance(spaces, list):
@@ -52,7 +53,7 @@ class ActionSpace(gym.spaces.Dict):
         self.actions_select = gym.spaces.Discrete(len(self.spaces))
 
     @property
-    def n(self):
+    def n(self) -> int:
         return len(self.spaces)
 
     def sample(self):
@@ -90,7 +91,12 @@ class ListSpace(Space):
             dataset.question_vocab.get_size()))
     """
 
-    def __init__(self, space, min_seq_length=0, max_seq_length=1 << 15):
+    def __init__(
+        self,
+        space: Space,
+        min_seq_length: int = 0,
+        max_seq_length: int = 1 << 15,
+    ):
         self.min_seq_length = min_seq_length
         self.max_seq_length = max_seq_length
         self.space = space
@@ -103,7 +109,7 @@ class ListSpace(Space):
         return [self.space.sample() for _ in range(seq_length)]
 
     def contains(self, x):
-        if not isinstance(x, Sized):
+        if not isinstance(x, Collection):
             return False
 
         if not (self.min_seq_length <= len(x) <= self.max_seq_length):

--- a/habitat/core/spaces.py
+++ b/habitat/core/spaces.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import OrderedDict
-from collections.abs import Collection
+from collections.abc import Collection
 from typing import Dict, List, Union
 
 import gym

--- a/habitat/core/utils.py
+++ b/habitat/core/utils.py
@@ -7,7 +7,7 @@
 import cmath
 import json
 import math
-from typing import List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import quaternion  # noqa: F401
@@ -17,13 +17,13 @@ from habitat.utils.geometry_utils import quaternion_to_list
 # Internals from inner json library needed for patching functionality in
 # DatasetFloatJSONEncoder.
 try:
-    from _json import encode_basestring_ascii
+    from _json import encode_basestring_ascii  # type: ignore
 except ImportError:
-    encode_basestring_ascii = None
+    encode_basestring_ascii = None  # type: ignore
 try:
-    from _json import encode_basestring
+    from _json import encode_basestring  # type: ignore
 except ImportError:
-    encode_basestring = None
+    encode_basestring = None  # type: ignore
 
 
 def tile_images(images: List[np.ndarray]) -> np.ndarray:
@@ -59,7 +59,9 @@ def tile_images(images: List[np.ndarray]) -> np.ndarray:
     return out_image
 
 
-def not_none_validator(self, attribute, value):
+def not_none_validator(  # type: ignore
+    self: Any, attribute: Any, value: Optional[Any]
+) -> None:
     if value is None:
         raise ValueError(f"Argument '{attribute.name}' must be set")
 
@@ -87,7 +89,7 @@ def try_cv2_import():
 
 
 class Singleton(type):
-    _instances = {}
+    _instances: Dict["Singleton", "Singleton"] = {}
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
@@ -134,10 +136,7 @@ class DatasetFloatJSONEncoder(json.JSONEncoder):
     # precision.
     def iterencode(self, o, _one_shot=False):
 
-        if self.check_circular:
-            markers = {}
-        else:
-            markers = None
+        markers: Optional[Dict] = {} if self.check_circular else None
         if self.ensure_ascii:
             _encoder = encode_basestring_ascii
         else:
@@ -167,7 +166,7 @@ class DatasetFloatJSONEncoder(json.JSONEncoder):
 
             return text
 
-        _iterencode = json.encoder._make_iterencode(
+        _iterencode = json.encoder._make_iterencode(  # type: ignore
             markers,
             self.default,
             _encoder,

--- a/habitat/datasets/eqa/mp3d_eqa_dataset.py
+++ b/habitat/datasets/eqa/mp3d_eqa_dataset.py
@@ -65,10 +65,14 @@ class Matterport3dDatasetV1(Dataset):
         self, json_str: str, scenes_dir: Optional[str] = None
     ) -> None:
         deserialized = json.loads(json_str)
-        self.__dict__.update(deserialized)
-        self.answer_vocab = VocabDict(word_list=self.answer_vocab["word_list"])
+        self.__dict__.update(
+            deserialized
+        )  # This is a messy hack... Why do we do this.
+        self.answer_vocab = VocabDict(
+            word_list=self.answer_vocab["word_list"]
+        )  # type:ignore
         self.question_vocab = VocabDict(
-            word_list=self.question_vocab["word_list"]
+            word_list=self.question_vocab["word_list"]  # type: ignore
         )
 
         for ep_index, episode in enumerate(deserialized["episodes"]):

--- a/habitat/datasets/pointnav/pointnav_dataset.py
+++ b/habitat/datasets/pointnav/pointnav_dataset.py
@@ -66,8 +66,10 @@ class PointNavDatasetV1(Dataset):
             return list(map(cls.scene_from_scene_path, dataset.scene_ids))
 
     @staticmethod
-    def _get_scenes_from_folder(content_scenes_path, dataset_dir):
-        scenes = []
+    def _get_scenes_from_folder(
+        content_scenes_path: str, dataset_dir: str
+    ) -> List[str]:
+        scenes: List[str] = []
         content_dir = content_scenes_path.split("{scene}")[0]
         scene_dataset_ext = content_scenes_path.split("{scene}")[1]
         content_dir = content_dir.format(data_path=dataset_dir)

--- a/habitat/datasets/pointnav/pointnav_generator.py
+++ b/habitat/datasets/pointnav/pointnav_generator.py
@@ -9,12 +9,14 @@ considered  as a target or source location. Used to filter isolated points
 that aren't part of a floor.
 """
 
-from typing import Optional
+from typing import Dict, Generator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
+from numpy import float64
 
-from habitat.core.simulator import Simulator
+from habitat.core.simulator import ShortestPathPoint
 from habitat.datasets.utils import get_action_shortest_path
+from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
 from habitat.tasks.nav.nav import NavigationEpisode, NavigationGoal
 from habitat_sim.errors import GreedyFollowerError
 
@@ -36,8 +38,13 @@ def _ratio_sample_rate(ratio: float, ratio_threshold: float) -> float:
 
 
 def is_compatible_episode(
-    s, t, sim, near_dist, far_dist, geodesic_to_euclid_ratio
-):
+    s: Sequence[float],
+    t: Sequence[float],
+    sim: HabitatSim,
+    near_dist: float,
+    far_dist: float,
+    geodesic_to_euclid_ratio: float,
+) -> Union[Tuple[bool, float], Tuple[bool, int]]:
     euclid_dist = np.power(np.power(np.array(s) - np.array(t), 2).sum(0), 0.5)
     if np.abs(s[1] - t[1]) > 0.5:  # check height difference to assure s and
         #  t are from same floor
@@ -59,14 +66,14 @@ def is_compatible_episode(
 
 
 def _create_episode(
-    episode_id,
-    scene_id,
-    start_position,
-    start_rotation,
-    target_position,
-    shortest_paths=None,
-    radius=None,
-    info=None,
+    episode_id: int,
+    scene_id: str,
+    start_position: List[float],
+    start_rotation: List[Union[int, float64]],
+    target_position: List[float],
+    shortest_paths: Optional[List[List[ShortestPathPoint]]] = None,
+    radius: Optional[float] = None,
+    info: Optional[Dict[str, float]] = None,
 ) -> Optional[NavigationEpisode]:
     goals = [NavigationGoal(position=target_position, radius=radius)]
     return NavigationEpisode(
@@ -81,7 +88,7 @@ def _create_episode(
 
 
 def generate_pointnav_episode(
-    sim: Simulator,
+    sim: HabitatSim,
     num_episodes: int = -1,
     is_gen_shortest_path: bool = True,
     shortest_path_success_distance: float = 0.2,
@@ -90,7 +97,7 @@ def generate_pointnav_episode(
     furthest_dist_limit: float = 30,
     geodesic_to_euclid_min_ratio: float = 1.1,
     number_retries_per_target: int = 10,
-) -> NavigationEpisode:
+) -> Generator[NavigationEpisode, None, None]:
     r"""Generator function that generates PointGoal navigation episodes.
 
     An episode is trivial if there is an obstacle-free, straight line between

--- a/habitat/datasets/registration.py
+++ b/habitat/datasets/registration.py
@@ -17,7 +17,7 @@ def make_dataset(id_dataset, **kwargs):
     _dataset = registry.get_dataset(id_dataset)
     assert _dataset is not None, "Could not find dataset {}".format(id_dataset)
 
-    return _dataset(**kwargs)
+    return _dataset(**kwargs)  # type: ignore
 
 
 _try_register_objectnavdatasetv1()

--- a/habitat/datasets/utils.py
+++ b/habitat/datasets/utils.py
@@ -8,12 +8,16 @@
  taken from Pythia.
 """
 import re
+import typing
 from collections import Counter
-from typing import List
+from typing import List, Union
+
+from numpy import float64
 
 from habitat.core.logging import logger
 from habitat.core.simulator import ShortestPathPoint
 from habitat.sims.habitat_simulator.actions import HabitatSimActions
+from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
 from habitat.tasks.nav.shortest_path_follower import ShortestPathFollower
 from habitat.utils.geometry_utils import quaternion_to_list
 
@@ -22,7 +26,7 @@ SENTENCE_SPLIT_REGEX = re.compile(r"([^\w-]+)")
 
 def tokenize(
     sentence, regex=SENTENCE_SPLIT_REGEX, keep=("'s"), remove=(",", "?")
-):
+) -> List[str]:
     sentence = sentence.lower()
 
     for token in keep:
@@ -140,7 +144,7 @@ class VocabFromText(VocabDict):
         remove=(),
         only_unk_extra=False,
     ):
-        token_counter = Counter()
+        token_counter: typing.Counter[str] = Counter()
 
         for sentence in sentences:
             tokens = tokenize(sentence, regex=regex, keep=keep, remove=remove)
@@ -160,12 +164,12 @@ class VocabFromText(VocabDict):
 
 
 def get_action_shortest_path(
-    sim,
-    source_position,
-    source_rotation,
-    goal_position,
-    success_distance=0.05,
-    max_episode_steps=500,
+    sim: HabitatSim,
+    source_position: List[float],
+    source_rotation: List[Union[int, float64]],
+    goal_position: List[float],
+    success_distance: float = 0.05,
+    max_episode_steps: int = 500,
 ) -> List[ShortestPathPoint]:
     sim.reset()
     sim.set_agent_state(source_position, source_rotation)

--- a/habitat/sims/pyrobot/pyrobot.py
+++ b/habitat/sims/pyrobot/pyrobot.py
@@ -81,7 +81,9 @@ class PyRobotRGBSensor(RGBSensor):
             dtype=np.uint8,
         )
 
-    def get_observation(self, robot_obs, *args: Any, **kwargs: Any):
+    def get_observation(  # type: ignore
+        self, robot_obs, *args: Any, **kwargs: Any
+    ):
         obs = robot_obs.get(self.uuid, None)
 
         assert obs is not None, "Invalid observation for {} sensor".format(
@@ -116,7 +118,9 @@ class PyRobotDepthSensor(DepthSensor):
             dtype=np.float32,
         )
 
-    def get_observation(self, robot_obs, *args: Any, **kwargs: Any):
+    def get_observation(  # type: ignore
+        self, robot_obs, *args: Any, **kwargs: Any
+    ):
         obs = robot_obs.get(self.uuid, None)
 
         assert obs is not None, "Invalid observation for {} sensor".format(
@@ -144,7 +148,9 @@ class PyRobotBumpSensor(BumpSensor):
     def _get_observation_space(self, *args: Any, **kwargs: Any):
         return spaces.Box(low=False, high=True, shape=(1,), dtype=np.bool)
 
-    def get_observation(self, robot_obs, *args: Any, **kwargs: Any):
+    def get_observation(  # type: ignore
+        self, robot_obs, *args: Any, **kwargs: Any
+    ):
         return np.array(robot_obs["bump"])
 
 

--- a/habitat/tasks/eqa/eqa.py
+++ b/habitat/tasks/eqa/eqa.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# type: ignore
+
 from typing import Any, Dict, List, Optional
 
 import attr

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, List, Optional, Type
+# TODO, lots of typing errors in here
+# type: ignore
+
+from typing import Any, List, Optional, Tuple, Type
 
 import attr
 import numpy as np
@@ -100,7 +103,7 @@ class NavigationEpisode(Episode):
         default=None, validator=not_none_validator
     )
     start_room: Optional[str] = None
-    shortest_paths: Optional[List[ShortestPathPoint]] = None
+    shortest_paths: Optional[List[List[ShortestPathPoint]]] = None
 
 
 @registry.register_sensor
@@ -192,7 +195,7 @@ class PointGoalSensor(Sensor):
 
     def get_observation(
         self, observations, episode: Episode, *args: Any, **kwargs: Any
-    ):
+    ):  # type: ignore[override]
         source_position = np.array(episode.start_position, dtype=np.float32)
         rotation_world_start = quaternion_from_coeff(episode.start_rotation)
         goal_position = np.array(episode.goals[0].position, dtype=np.float32)
@@ -504,7 +507,7 @@ class Success(Measure):
     def _get_uuid(self, *args: Any, **kwargs: Any) -> str:
         return self.cls_uuid
 
-    def reset_metric(self, episode, task, *args: Any, **kwargs: Any):
+    def reset_metric(self, episode, task, *args: Any, **kwargs: Any):  # type: ignore[override]
         task.measurements.check_measure_dependencies(
             self.uuid, [DistanceToGoal.cls_uuid]
         )
@@ -553,7 +556,7 @@ class SPL(Measure):
     def _get_uuid(self, *args: Any, **kwargs: Any) -> str:
         return "spl"
 
-    def reset_metric(self, episode, task, *args: Any, **kwargs: Any):
+    def reset_metric(self, episode, task, *args: Any, **kwargs: Any):  # type: ignore[override]
         task.measurements.check_measure_dependencies(
             self.uuid, [DistanceToGoal.cls_uuid, Success.cls_uuid]
         )
@@ -670,12 +673,12 @@ class TopDownMap(Measure):
         self._grid_delta = config.MAP_PADDING
         self._step_count = None
         self._map_resolution = config.MAP_RESOLUTION
-        self._ind_x_min = None
-        self._ind_x_max = None
-        self._ind_y_min = None
-        self._ind_y_max = None
+        self._ind_x_min: Optional[int] = None
+        self._ind_x_max: Optional[int] = None
+        self._ind_y_min: Optional[int] = None
+        self._ind_y_max: Optional[int] = None
         self._previous_xy_location = None
-        self._top_down_map = None
+        self._top_down_map: Optional[TopDownMap] = None
         self._shortest_path_points = None
         self.line_thickness = int(
             np.round(self._map_resolution * 2 / MAP_THICKNESS_SCALAR)
@@ -786,7 +789,7 @@ class TopDownMap(Measure):
                     pass
 
     def _draw_shortest_path(
-        self, episode: Episode, agent_position: AgentState
+        self, episode: NavigationEpisode, agent_position: AgentState
     ):
         if self._config.DRAW_SHORTEST_PATH:
             self._shortest_path_points = (
@@ -911,10 +914,12 @@ class DistanceToGoal(Measure):
     def __init__(
         self, sim: Simulator, config: Config, *args: Any, **kwargs: Any
     ):
-        self._previous_position = None
+        self._previous_position: Optional[Tuple[float, float, float]] = None
         self._sim = sim
         self._config = config
-        self._episode_view_points = None
+        self._episode_view_points: Optional[
+            List[Tuple[float, float, float]]
+        ] = None
 
         super().__init__(**kwargs)
 
@@ -990,7 +995,7 @@ class TurnRightAction(SimulatorTaskAction):
 class StopAction(SimulatorTaskAction):
     name: str = "STOP"
 
-    def reset(self, task: EmbodiedTask, *args: Any, **kwargs: Any):
+    def reset(self, task: EmbodiedTask, *args: Any, **kwargs: Any):  # type: ignore[override]
         task.is_stop_called = False
 
     def step(self, task: EmbodiedTask, *args: Any, **kwargs: Any):

--- a/habitat/tasks/nav/object_nav_task.py
+++ b/habitat/tasks/nav/object_nav_task.py
@@ -1,18 +1,15 @@
-#!/usr/bin/env python3
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 import attr
 import numpy as np
 from gym import spaces
 
 from habitat.config import Config
-from habitat.core.dataset import Dataset
 from habitat.core.logging import logger
 from habitat.core.registry import registry
 from habitat.core.simulator import AgentState, Sensor, SensorTypes
@@ -22,6 +19,11 @@ from habitat.tasks.nav.nav import (
     NavigationGoal,
     NavigationTask,
 )
+
+if TYPE_CHECKING:
+    from habitat.datasets.object_nav.object_nav_dataset import (
+        ObjectNavDatasetV1,
+    )
 
 
 @attr.s(auto_attribs=True, kw_only=True)
@@ -109,7 +111,12 @@ class ObjectGoalSensor(Sensor):
     cls_uuid: str = "objectgoal"
 
     def __init__(
-        self, sim, config: Config, dataset: Dataset, *args: Any, **kwargs: Any
+        self,
+        sim,
+        config: Config,
+        dataset: ObjectNavDatasetV1,
+        *args: Any,
+        **kwargs: Any,
     ):
         self._sim = sim
         self._dataset = dataset
@@ -125,39 +132,42 @@ class ObjectGoalSensor(Sensor):
         sensor_shape = (1,)
         max_value = (self.config.GOAL_SPEC_MAX_VAL - 1,)
         if self.config.GOAL_SPEC == "TASK_CATEGORY_ID":
-            max_value = max(
-                self._dataset.category_to_task_category_id.values()
+            max_value = (
+                max(self._dataset.category_to_task_category_id.values()),
             )
 
         return spaces.Box(
             low=0, high=max_value, shape=sensor_shape, dtype=np.int64
         )
 
-    def get_observation(
+    def get_observation(  # type: ignore
         self,
         observations,
         *args: Any,
         episode: ObjectGoalNavEpisode,
         **kwargs: Any,
     ) -> Optional[int]:
+
+        if len(episode.goals) == 0:
+            logger.error(
+                f"No goal specified for episode {episode.episode_id}."
+            )
+            return None
+        if not isinstance(episode.goals[0], ObjectGoal):
+            logger.error(
+                f"First goal should be ObjectGoal, episode {episode.episode_id}."
+            )
+            return None
+        category_name = episode.object_category
         if self.config.GOAL_SPEC == "TASK_CATEGORY_ID":
-            if len(episode.goals) == 0:
-                logger.error(
-                    f"No goal specified for episode {episode.episode_id}."
-                )
-                return None
-            if not isinstance(episode.goals[0], ObjectGoal):
-                logger.error(
-                    f"First goal should be ObjectGoal, episode {episode.episode_id}."
-                )
-                return None
-            category_name = episode.object_category
             return np.array(
                 [self._dataset.category_to_task_category_id[category_name]],
                 dtype=np.int64,
             )
         elif self.config.GOAL_SPEC == "OBJECT_ID":
-            return np.array([episode.goals[0].object_name_id], dtype=np.int64)
+            obj_goal = episode.goals[0]
+            assert isinstance(obj_goal, ObjectGoal)  # for type checking
+            return np.array([obj_goal.object_name_id], dtype=np.int64)  # type: ignore[attr-defined]
         else:
             raise RuntimeError(
                 "Wrong GOAL_SPEC specified for ObjectGoalSensor."

--- a/habitat/tasks/nav/shortest_path_follower.py
+++ b/habitat/tasks/nav/shortest_path_follower.py
@@ -73,6 +73,7 @@ class ShortestPathFollower:
     ) -> Optional[Union[int, np.array]]:
         """Returns the next action along the shortest path."""
         self._build_follower()
+        assert self._follower is not None
         try:
             next_action = self._follower.next_action_along(goal_pos)
         except habitat_sim.errors.GreedyFollowerError as e:

--- a/habitat/utils/visualizations/maps.py
+++ b/habitat/utils/visualizations/maps.py
@@ -11,8 +11,8 @@ import imageio
 import numpy as np
 import scipy.ndimage
 
-from habitat.core.simulator import Simulator
 from habitat.core.utils import try_cv2_import
+from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
 from habitat.utils.visualizations import utils
 
 cv2 = try_cv2_import()
@@ -185,7 +185,7 @@ def to_grid(
     realworld_x: float,
     realworld_y: float,
     grid_resolution: Tuple[int, int],
-    sim: Optional[Simulator] = None,
+    sim: Optional[HabitatSim] = None,
     pathfinder=None,
 ) -> Tuple[int, int]:
     r"""Return gridworld index of realworld coordinates assuming top-left corner
@@ -216,7 +216,7 @@ def from_grid(
     grid_x: int,
     grid_y: int,
     grid_resolution: Tuple[int, int],
-    sim: Optional[Simulator] = None,
+    sim: Optional[HabitatSim] = None,
     pathfinder=None,
 ) -> Tuple[float, float]:
     r"""Inverse of _to_grid function. Return real world coordinate from
@@ -267,7 +267,7 @@ def _outline_border(top_down_map):
 
 
 def calculate_meters_per_pixel(
-    map_resolution: int, sim: Optional[Simulator] = None, pathfinder=None
+    map_resolution: int, sim: Optional[HabitatSim] = None, pathfinder=None
 ):
     r"""Calculate the meters_per_pixel for a given map resolution"""
     if sim is None and pathfinder is None:
@@ -322,7 +322,7 @@ def get_topdown_map(
 
 
 def get_topdown_map_from_sim(
-    sim: Simulator,
+    sim: HabitatSim,
     map_resolution: int = 1024,
     draw_border: bool = True,
     meters_per_pixel: Optional[float] = None,

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -163,13 +163,13 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
     Returns:
         generated image of a single frame.
     """
-    egocentric_view = []
+    egocentric_view_l: List[np.ndarray] = []
     if "rgb" in observation:
         rgb = observation["rgb"]
         if not isinstance(rgb, np.ndarray):
             rgb = rgb.cpu().numpy()
 
-        egocentric_view.append(rgb)
+        egocentric_view_l.append(rgb)
 
     # draw depth map if observation has depth info
     if "depth" in observation:
@@ -179,7 +179,7 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
 
         depth_map = depth_map.astype(np.uint8)
         depth_map = np.stack([depth_map for _ in range(3)], axis=2)
-        egocentric_view.append(depth_map)
+        egocentric_view_l.append(depth_map)
 
     # add image goal if observation has image_goal info
     if "imagegoal" in observation:
@@ -187,12 +187,12 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
         if not isinstance(rgb, np.ndarray):
             rgb = rgb.cpu().numpy()
 
-        egocentric_view.append(rgb)
+        egocentric_view_l.append(rgb)
 
     assert (
-        len(egocentric_view) > 0
+        len(egocentric_view_l) > 0
     ), "Expected at least one visual sensor enabled."
-    egocentric_view = np.concatenate(egocentric_view, axis=1)
+    egocentric_view = np.concatenate(egocentric_view_l, axis=1)
 
     # draw collision
     if "collisions" in info and info["collisions"]["is_collision"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,40 @@ per-file-ignores =
     */__init__.py:F401
     examples/tutorials/nb_python/*.py:B008,F841
 
+[mypy]
+# do not follow imports (except for ones found in typeshed)
+ignore_missing_imports = True
+#Ignore errors for third parties
+ignore_errors = True
+follow_imports="silent"
+
+# treat Optional per PEP 484
+strict_optional = False
+
+warn_unused_configs = True
+warn_redundant_casts = True
+# ensure all execution paths are returning
+warn_no_return=True
+show_error_codes = True
+check_untyped_defs = True
+
+files=
+    habitat
+python_version = 3.6
+
+# Third Party Dependencies
+
+[mypy-habitat.*]
+ignore_errors = False
+
+[mypy-habitat_baselines.*]
+ignore_errors = False
+
+[mypy-magnum.*]
+ignore_errors = True
+
+[mypy-torch.*]
+ignore_errors = True
 
 [tool:pytest]
 addopts = --verbose -rsxX -q --cov-report=xml --cov=./


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Actually uses all the TypeHints we have in Habitat-Lab by adding a pre-commit hook for them.
Before doing that, there are quite a lot of type signature errors that need to be fixed in habitat. 

This actually required quite a lot of refactoring just to get the base habitat to use properly use these type hints and to fix existing errors in typing. I had to add quite a few "ignores" to fix some pretty serious issues we have with inheritance and overloading variables / types of Python classes.

As of this typing, I have fixed all except the eqa_task and tasks/nav/nav.py. These two classes alone account for 84 typing errors in Habitat, currently.


<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
With PyTest and MyPy
Like with Habitat-Sim I used monkeytype to help out, but since so many existing type hints were wrong and the fact that we have class names that are the same throughout habitat, it required quite a large number of manual changes so far.


<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Large Refactor and Dev Tools update
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
