### PR TITLE
Extract ckpt_id from ckpt_path

### DIFF
--- a/habitat_baselines/common/base_trainer.py
+++ b/habitat_baselines/common/base_trainer.py
@@ -12,7 +12,10 @@ import torch
 
 from habitat import Config, logger
 from habitat_baselines.common.tensorboard_utils import TensorboardWriter
-from habitat_baselines.utils.common import get_ckpt_idx, poll_checkpoint_folder
+from habitat_baselines.utils.common import (
+    get_checkpoint_id,
+    poll_checkpoint_folder,
+)
 
 
 class BaseTrainer:
@@ -92,7 +95,9 @@ class BaseTrainer:
         ) as writer:
             if os.path.isfile(self.config.EVAL_CKPT_PATH_DIR):
                 # evaluate singe checkpoint
-                proposed_index = get_ckpt_idx(self.config.EVAL_CKPT_PATH_DIR)
+                proposed_index = get_checkpoint_id(
+                    self.config.EVAL_CKPT_PATH_DIR
+                )
                 if proposed_index is not None:
                     ckpt_idx = proposed_index
                 else:

--- a/habitat_baselines/common/base_trainer.py
+++ b/habitat_baselines/common/base_trainer.py
@@ -57,10 +57,9 @@ class BaseTrainer:
             logger.info("Saved config is outdated, using solely eval config")
             config = self.config.clone()
             config.merge_from_list(eval_cmd_opts)
-        if config.TASK_CONFIG.DATASET.SPLIT == "train":
-            config.TASK_CONFIG.defrost()
-            config.TASK_CONFIG.DATASET.SPLIT = "val"
         config.defrost()
+        if config.TASK_CONFIG.DATASET.SPLIT == "train":
+            config.TASK_CONFIG.DATASET.SPLIT = "val"
         config.TASK_CONFIG.SIMULATOR.AGENT_0.SENSORS = self.config.SENSORS
         config.freeze()
 

--- a/habitat_baselines/common/base_trainer.py
+++ b/habitat_baselines/common/base_trainer.py
@@ -12,7 +12,7 @@ import torch
 
 from habitat import Config, logger
 from habitat_baselines.common.tensorboard_utils import TensorboardWriter
-from habitat_baselines.utils.common import poll_checkpoint_folder
+from habitat_baselines.utils.common import get_ckpt_idx, poll_checkpoint_folder
 
 
 class BaseTrainer:
@@ -57,7 +57,7 @@ class BaseTrainer:
         if config.TASK_CONFIG.DATASET.SPLIT == "train":
             config.TASK_CONFIG.defrost()
             config.TASK_CONFIG.DATASET.SPLIT = "val"
-
+        config.defrost()
         config.TASK_CONFIG.SIMULATOR.AGENT_0.SENSORS = self.config.SENSORS
         config.freeze()
 
@@ -92,7 +92,16 @@ class BaseTrainer:
         ) as writer:
             if os.path.isfile(self.config.EVAL_CKPT_PATH_DIR):
                 # evaluate singe checkpoint
-                self._eval_checkpoint(self.config.EVAL_CKPT_PATH_DIR, writer)
+                proposed_index = get_ckpt_idx(self.config.EVAL_CKPT_PATH_DIR)
+                if proposed_index is not None:
+                    ckpt_idx = proposed_index
+                else:
+                    ckpt_idx = 0
+                self._eval_checkpoint(
+                    self.config.EVAL_CKPT_PATH_DIR,
+                    writer,
+                    checkpoint_index=ckpt_idx,
+                )
             else:
                 # evaluate multiple checkpoints in order
                 prev_ckpt_ind = -1

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -105,8 +105,9 @@ def batch_obs(
     return batch
 
 
-def get_ckpt_idx(ckpt_path: str) -> Optional[int]:
-    r"""Attempts to extract the ckpt_id from the filename of a checkpoint.abs
+def get_checkpoint_id(ckpt_path: str) -> Optional[int]:
+    r"""Attempts to extract the ckpt_id from the filename of a checkpoint.
+    Assumes structure of ckpt.ID.path .
 
     Args:
         ckpt_path: the path to the ckpt file

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -105,6 +105,22 @@ def batch_obs(
     return batch
 
 
+def get_ckpt_idx(ckpt_path: str) -> Optional[int]:
+    r"""Attempts to extract the ckpt_id from the filename of a checkpoint.abs
+
+    Args:
+        ckpt_path: the path to the ckpt file
+
+    Returns:
+        returns an int if it is able to extract the ckpt_path else None
+    """
+    ckpt_path = os.path.basename(ckpt_path)
+    nums: List[int] = [int(s) for s in ckpt_path.split(".") if s.isdigit()]
+    if len(nums) > 0:
+        return nums[-1]
+    return None
+
+
 def poll_checkpoint_folder(
     checkpoint_folder: str, previous_ckpt_ind: int
 ) -> Optional[str]:


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It means the BaseTrainer will try to extract ckpt_idx if you are evaluating on a single checkpoint. This means you can evaluate on multiple single checkpoints in a folder and have them output videos to the same folder without overwriting each other. 
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Evaluated ckpts locally, tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
