### PR TITLE
Bug fix in Cube2Fisheye.

### DIFF
--- a/habitat_baselines/common/obs_transformers.py
+++ b/habitat_baselines/common/obs_transformers.py
@@ -602,8 +602,9 @@ class Cube2Fisheye(nn.Module):
         unprojected_unit[..., 1] *= -1
 
         # Calculate fov
-        z_axis = torch.tensor([0, 0, 1], dtype=torch.float32)
-        unprojected_fov_cos = torch.matmul(unprojected_unit, z_axis)
+        unprojected_fov_cos = unprojected_unit[
+            ..., 2
+        ]  # unprojected_unit @ z_axis
         fov_mask = unprojected_fov_cos >= fov_cos
         if alpha > 0.5:
             fov_mask *= r2 <= (1 / (2 * alpha - 1))

--- a/habitat_baselines/common/obs_transformers.py
+++ b/habitat_baselines/common/obs_transformers.py
@@ -606,7 +606,7 @@ class Cube2Fisheye(nn.Module):
         unprojected_fov_cos = torch.matmul(unprojected_unit, z_axis)
         fov_mask = unprojected_fov_cos >= fov_cos
         if alpha > 0.5:
-            fov_mask *= r2 <= (1 - (2 * alpha - 1))
+            fov_mask *= r2 <= (1 / (2 * alpha - 1))
 
         return unprojected_unit, fov_mask
 


### PR DESCRIPTION
## Motivation and Context
Hi  @Skylion007,
I've implemented Cube2Fisheye in #486, but I found a bug in calculating valid areas.
Calculating valid areas is formulated in Eq.(51) in [The Double Sphere Camera Model](https://arxiv.org/abs/1807.08957). So this implementation should be fine.

Besides, I remove unnecessary computation for calculating the cosine value of `unprojected_unit`.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)

