### PR TITLE
[CIRCLECI] Relax waiting timeout for CUDA install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
             ccache --max-size=10.0G
       - run:
           name: Build, install habitat-sim and run benchmark
-          no_output_timeout: 20m
+          no_output_timeout: 30m
           command: |
               if [ ! -d ./habitat-sim ]
               then
@@ -176,7 +176,7 @@ jobs:
               . activate habitat;
               cd habitat-sim
               pip install -r requirements.txt --progress-bar off
-              python setup.py install --headless --with-cuda --bullet
+              python -u setup.py install --headless --with-cuda --bullet
       - run:
           name: Ccache stats
           when: always


### PR DESCRIPTION
Allows a step that waits for CUDA installation to have a more relaxed timeout.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Occasionally the CUDA install is too slow and causes a timeout this should solve it. (We could also have the wait loop print things, but since it works occasionally, I suspect relaxing the timeout will be sufficient.)
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- CI
