### PR TITLE
--Refactor for removal of Habsim:SceneConfiguration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
           command: |
               if [ ! -d ./habitat-sim ]
               then
-                git clone --single-branch --branch Remove_SceneConfiguration https://github.com/jturner65/habitat-sim.git --recursive
+                git clone https://github.com/facebookresearch/habitat-sim.git --recursive
               fi
               while [ ! -f ./cuda_installed ]; do sleep 2; done # wait for CUDA
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
           command: |
               if [ ! -d ./habitat-sim ]
               then
-                git clone https://github.com/facebookresearch/habitat-sim.git --recursive
+                git clone --single-branch --branch Remove_SceneConfiguration https://github.com/jturner65/habitat-sim.git --recursive
               fi
               while [ ! -f ./cuda_installed ]; do sleep 2; done # wait for CUDA
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH

--- a/docs/pages/habitat-sim-demo.rst
+++ b/docs/pages/habitat-sim-demo.rst
@@ -43,7 +43,7 @@ Habitat Sim Demo
     def make_cfg(settings):
         sim_cfg = habitat_sim.SimulatorConfiguration()
         sim_cfg.gpu_device_id = 0
-        sim_cfg.scene.id = settings["scene"]
+        sim_cfg.scene_id = settings["scene"]
 
         # Note: all sensors must have the same resolution
         sensors = {

--- a/examples/tutorials/colabs/Habitat_Interactive_Tasks.ipynb
+++ b/examples/tutorials/colabs/Habitat_Interactive_Tasks.ipynb
@@ -256,7 +256,7 @@
     "    sim_cfg = habitat_sim.SimulatorConfiguration()\n",
     "    sim_cfg.gpu_device_id = 0\n",
     "    sim_cfg.default_agent_id = settings[\"default_agent_id\"]\n",
-    "    sim_cfg.scene.id = settings[\"scene\"]\n",
+    "    sim_cfg.scene_id = settings[\"scene\"]\n",
     "    sim_cfg.enable_physics = settings[\"enable_physics\"]\n",
     "    sim_cfg.physics_config_file = settings[\"physics_config_file\"]\n",
     "\n",

--- a/examples/tutorials/nb_python/Habitat_Interactive_Tasks.py
+++ b/examples/tutorials/nb_python/Habitat_Interactive_Tasks.py
@@ -253,7 +253,7 @@ def make_cfg(settings):
     sim_cfg = habitat_sim.SimulatorConfiguration()
     sim_cfg.gpu_device_id = 0
     sim_cfg.default_agent_id = settings["default_agent_id"]
-    sim_cfg.scene.id = settings["scene"]
+    sim_cfg.scene_id = settings["scene"]
     sim_cfg.enable_physics = settings["enable_physics"]
     sim_cfg.physics_config_file = settings["physics_config_file"]
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -203,7 +203,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
 
         self._sensor_suite = SensorSuite(sim_sensors)
         self.sim_config = self.create_sim_config(self._sensor_suite)
-        self._current_scene = self.sim_config.sim_cfg.scene.id
+        self._current_scene = self.sim_config.sim_cfg.scene_id
         super().__init__(self.sim_config)
         self._action_space = spaces.Discrete(
             len(self.sim_config.agents[0].action_space)
@@ -218,7 +218,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
             config_from=self.habitat_config.HABITAT_SIM_V0,
             config_to=sim_config,
         )
-        sim_config.scene.id = self.habitat_config.SCENE
+        sim_config.scene_id = self.habitat_config.SCENE
         agent_config = habitat_sim.AgentConfiguration()
         overwrite_config(
             config_from=self._get_agent_config(), config_to=agent_config


### PR DESCRIPTION
## Motivation and Context
SceneConfiguration class has been removed from Habitat Sim.  SimulatorConfiguration's reference to "scene" has been changed to "scene_id" so that old code that required "scene.id" could be refactored easily.

**This is a breaking change**  If you reference a SceneConfiguration object, this is no longer supported.  If you wish to specify the name of a scene in your SimulatorConfiguration you must modify your code like so (where cfg is a habitat-sim : SimulatorConfiguration object) : 

From : 
`cfg.scene.id = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"`

To:
`cfg.scene_id = "data/scene_datasets/habitat-test-scenes/van-gogh-room.glb"`


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Existing tests passed locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
x - Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ x I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
