### PR TITLE
[CIRCLECI] Enable pytest_sugar pytest plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,6 @@ jobs:
                 ~/miniconda.sh -b -p $HOME/miniconda
                 rm ~/miniconda.sh
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-                conda config --set pip_interop_enabled True
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,11 @@ jobs:
                 ~/miniconda.sh -b -p $HOME/miniconda
                 rm ~/miniconda.sh
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+                conda config --set pip_interop_enabled True
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov
+                pip install pytest-sugar
               fi
       - run:
           name: Install pytorch


### PR DESCRIPTION
Add pytest-sugar and enable pip_interop to habitat-lab pytest / conda.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Make testing output consistent with: https://github.com/facebookresearch/habitat-sim/pull/919

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
CircleCI
## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- CIRCLECI change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
