### PR TITLE
Fix more incorrect typehints in Habitat Core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov
-                pip install typeguard pytest-sugar
+                pip install pytest-sugar
               fi
       - run:
           name: Install pytorch
@@ -245,8 +245,7 @@ jobs:
               . activate habitat; cd habitat-lab
               python setup.py develop --all
               export PYTHONPATH=.:$PYTHONPATH
-              pytest --typeguard-packages=habitat,habitat_baselines .
-              #python setup.py test
+              python setup.py test
 
               bash <(curl -s https://codecov.io/bash) -f coverage.xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov
-                pip install pytest-sugar
+                pip install typeguard pytest-sugar
               fi
       - run:
           name: Install pytorch
@@ -245,7 +245,8 @@ jobs:
               . activate habitat; cd habitat-lab
               python setup.py develop --all
               export PYTHONPATH=.:$PYTHONPATH
-              python setup.py test
+              pytest --typeguard-packages=habitat,habitat_baselines .
+              #python setup.py test
 
               bash <(curl -s https://codecov.io/bash) -f coverage.xml
       - run:

--- a/habitat/core/embodied_task.py
+++ b/habitat/core/embodied_task.py
@@ -8,7 +8,7 @@ r"""Implements tasks and measurements needed for training and benchmarking of
 """
 
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List, Optional, Type, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import numpy as np
 
@@ -276,7 +276,7 @@ class EmbodiedTask:
             )
         return entities
 
-    def reset(self, episode: Type[Episode]):
+    def reset(self, episode: Episode):
         observations = self._sim.reset()
         observations.update(
             self.sensor_suite.get_observations(
@@ -289,7 +289,7 @@ class EmbodiedTask:
 
         return observations
 
-    def step(self, action: Dict[str, Any], episode: Type[Episode]):
+    def step(self, action: Dict[str, Any], episode: Episode):
         if "action_args" not in action or action["action_args"] is None:
             action["action_args"] = {}
         action_name = action["action"]
@@ -331,7 +331,7 @@ class EmbodiedTask:
         )
 
     def overwrite_sim_config(
-        self, sim_config: Config, episode: Type[Episode]
+        self, sim_config: Config, episode: Episode
     ) -> Config:
         r"""Update config merging information from :p:`sim_config` and
         :p:`episode`.
@@ -345,7 +345,7 @@ class EmbodiedTask:
         self,
         *args: Any,
         action: Union[int, Dict[str, Any]],
-        episode: Type[Episode],
+        episode: Episode,
         **kwargs: Any,
     ) -> bool:
         raise NotImplementedError

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -6,17 +6,7 @@
 
 import random
 import time
-from typing import (
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 import gym
 import numba
@@ -52,9 +42,9 @@ class Env:
     _config: Config
     _dataset: Optional[Dataset]
     number_of_episodes: Optional[int]
-    _episodes: List[Type[Episode]]
+    _episodes: List[Episode]
     _current_episode_index: Optional[int]
-    _current_episode: Optional[Type[Episode]]
+    _current_episode: Optional[Episode]
     _episode_iterator: Optional[Iterator]
     _sim: Simulator
     _task: EmbodiedTask
@@ -91,7 +81,7 @@ class Env:
         self._episodes = (
             self._dataset.episodes
             if self._dataset
-            else cast(List[Type[Episode]], [])
+            else cast(List[Episode], [])
         )
         self._current_episode = None
         iter_option_dict = {
@@ -141,12 +131,12 @@ class Env:
         self._episode_over = False
 
     @property
-    def current_episode(self) -> Type[Episode]:
+    def current_episode(self) -> Episode:
         assert self._current_episode is not None
         return self._current_episode
 
     @current_episode.setter
-    def current_episode(self, episode: Type[Episode]) -> None:
+    def current_episode(self, episode: Episode) -> None:
         self._current_episode = episode
 
     @property
@@ -158,11 +148,11 @@ class Env:
         self._episode_iterator = new_iter
 
     @property
-    def episodes(self) -> List[Type[Episode]]:
+    def episodes(self) -> List[Episode]:
         return self._episodes
 
     @episodes.setter
-    def episodes(self, episodes: List[Type[Episode]]) -> None:
+    def episodes(self, episodes: List[Episode]) -> None:
         assert (
             len(episodes) > 0
         ), "Environment doesn't accept empty episodes list."
@@ -354,15 +344,15 @@ class RLEnv(gym.Env):
         return self._env
 
     @property
-    def episodes(self) -> List[Type[Episode]]:
+    def episodes(self) -> List[Episode]:
         return self._env.episodes
 
     @episodes.setter
-    def episodes(self, episodes: List[Type[Episode]]) -> None:
+    def episodes(self, episodes: List[Episode]) -> None:
         self._env.episodes = episodes
 
     @property
-    def current_episode(self) -> Type[Episode]:
+    def current_episode(self) -> Episode:
         return self._env.current_episode
 
     @profiling_wrapper.RangeContext("RLEnv.reset")

--- a/habitat/core/simulator.py
+++ b/habitat/core/simulator.py
@@ -16,7 +16,7 @@ from gym import Space, spaces
 from habitat.config import Config
 from habitat.core.dataset import Episode
 
-VisualObservation = Union["torch.Tensor", "np.ndarray"]
+VisualObservation = Union[torch.Tensor, np.ndarray]
 
 
 @attr.s(auto_attribs=True)

--- a/habitat/datasets/pointnav/pointnav_generator.py
+++ b/habitat/datasets/pointnav/pointnav_generator.py
@@ -9,16 +9,7 @@ considered  as a target or source location. Used to filter isolated points
 that aren't part of a floor.
 """
 
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import Dict, Generator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from numpy import float64
@@ -31,8 +22,10 @@ try:
     from habitat_sim.errors import GreedyFollowerError
 except ImportError:
     GreedyFollower = BaseException
-if TYPE_CHECKING:
+try:
     from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
+except ImportError:
+    habitat_sim = BaseException
 ISLAND_RADIUS_LIMIT = 1.5
 
 

--- a/habitat/datasets/utils.py
+++ b/habitat/datasets/utils.py
@@ -10,7 +10,7 @@
 import re
 import typing
 from collections import Counter
-from typing import TYPE_CHECKING, Iterable, List, Union
+from typing import Iterable, List, Union
 
 from numpy import float64
 
@@ -20,9 +20,10 @@ from habitat.sims.habitat_simulator.actions import HabitatSimActions
 from habitat.tasks.nav.shortest_path_follower import ShortestPathFollower
 from habitat.utils.geometry_utils import quaternion_to_list
 
-if TYPE_CHECKING:
+try:
     from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
-
+except ImportError:
+    pass
 
 SENTENCE_SPLIT_REGEX = re.compile(r"([^\w-]+)")
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -4,21 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Union,
-    cast,
-)
+from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
 import numpy as np
 from gym import spaces
 from gym.spaces.box import Box
 from numpy import ndarray
+from torch import Tensor
 
 import habitat_sim
 from habitat.core.dataset import Episode
@@ -36,9 +28,6 @@ from habitat.core.simulator import (
     Simulator,
 )
 from habitat.core.spaces import Space
-
-if TYPE_CHECKING:
-    from torch import Tensor
 
 RGBSENSOR_DIMENSION = 3
 
@@ -288,7 +277,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         self._prev_sim_obs = sim_obs
         return self._sensor_suite.get_observations(sim_obs)
 
-    def step(self, action: int) -> Observations:
+    def step(self, action: Union[str, int]) -> Observations:
         sim_obs = super().step(action)
         self._prev_sim_obs = sim_obs
         observations = self._sensor_suite.get_observations(sim_obs)

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -37,6 +37,7 @@ from habitat.core.simulator import (
     SensorSuite,
     ShortestPathPoint,
     Simulator,
+    VisualObservation,
 )
 from habitat.core.spaces import Space
 
@@ -83,8 +84,8 @@ class HabitatSimRGBSensor(RGBSensor):
 
     def get_observation(
         self, sim_obs: Dict[str, Union[ndarray, bool, "Tensor"]]
-    ) -> Union[ndarray, "Tensor"]:
-        obs = sim_obs.get(self.uuid, None)
+    ) -> VisualObservation:
+        obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)
 
         # remove alpha channel
@@ -119,9 +120,9 @@ class HabitatSimDepthSensor(DepthSensor):
         )
 
     def get_observation(
-        self, sim_obs: Dict[str, Union[ndarray, "Tensor"]]
-    ) -> Union[ndarray, "Tensor"]:
-        obs = sim_obs.get(self.uuid, None)
+        self, sim_obs: Dict[str, Union[ndarray, bool, "Tensor"]]
+    ) -> VisualObservation:
+        obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)
         if isinstance(obs, np.ndarray):
             obs = np.clip(obs, self.config.MIN_DEPTH, self.config.MAX_DEPTH)
@@ -159,8 +160,10 @@ class HabitatSimSemanticSensor(SemanticSensor):
             dtype=np.uint32,
         )
 
-    def get_observation(self, sim_obs):
-        obs = sim_obs.get(self.uuid, None)
+    def get_observation(
+        self, sim_obs: Dict[str, Union[ndarray, bool, "Tensor"]]
+    ) -> VisualObservation:
+        obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)
         return obs
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -4,13 +4,24 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Sequence, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
 
 import numpy as np
 from gym import spaces
 from gym.spaces.box import Box
 from numpy import ndarray
-from torch import Tensor
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 import habitat_sim
 from habitat.core.dataset import Episode

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -6,7 +6,7 @@
 
 # TODO, lots of typing errors in here
 
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple
 
 import attr
 import numpy as np
@@ -38,17 +38,17 @@ from habitat.utils.geometry_utils import (
 )
 from habitat.utils.visualizations import fog_of_war, maps
 
-if TYPE_CHECKING:
+try:
     from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
+except ImportError:
+    pass
 cv2 = try_cv2_import()
 
 
 MAP_THICKNESS_SCALAR: int = 128
 
 
-def merge_sim_episode_config(
-    sim_config: Config, episode: Type[Episode]
-) -> Any:
+def merge_sim_episode_config(sim_config: Config, episode: Episode) -> Any:
     sim_config.defrost()
     sim_config.SCENE = episode.scene_id
     sim_config.freeze()
@@ -1093,9 +1093,7 @@ class NavigationTask(EmbodiedTask):
     ) -> None:
         super().__init__(config=config, sim=sim, dataset=dataset)
 
-    def overwrite_sim_config(
-        self, sim_config: Any, episode: Type[Episode]
-    ) -> Any:
+    def overwrite_sim_config(self, sim_config: Any, episode: Episode) -> Any:
         return merge_sim_episode_config(sim_config, episode)
 
     def _check_episode_is_active(self, *args: Any, **kwargs: Any) -> bool:

--- a/habitat/tasks/nav/object_nav_task.py
+++ b/habitat/tasks/nav/object_nav_task.py
@@ -3,7 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import Any, List, Optional
 
 import attr
 import numpy as np
@@ -20,10 +20,12 @@ from habitat.tasks.nav.nav import (
     NavigationTask,
 )
 
-if TYPE_CHECKING:
+try:
     from habitat.datasets.object_nav.object_nav_dataset import (
         ObjectNavDatasetV1,
     )
+except ImportError:
+    pass
 
 
 @attr.s(auto_attribs=True, kw_only=True)

--- a/habitat/utils/visualizations/maps.py
+++ b/habitat/utils/visualizations/maps.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import imageio
 import numpy as np
@@ -14,9 +14,10 @@ import scipy.ndimage
 from habitat.core.utils import try_cv2_import
 from habitat.utils.visualizations import utils
 
-if TYPE_CHECKING:
+try:
     from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
-
+except ImportError:
+    pass
 
 cv2 = try_cv2_import()
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,5 +32,8 @@ python_version = 3.6
 [mypy-habitat.*]
 ignore_errors = False
 
+[mypy-habitat_sim.*]
+ignore_errors = False
+
 [mypy-habitat_baselines.*]
 ignore_errors = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ max-line-length = 88
 ignore =
 	A003,
 	C401,C402,C408,
-	SIM105,SIM106
+	SIM105,SIM106,SIM113
 	R504,
 	W503
 per-file-ignores =


### PR DESCRIPTION
## Motivation and Context
I verified a bunch of the typehints using typeguard and caught numerous issues in habitat.core . I went ahead fixed most of these issues. I also enabled including habitat_sim in the mypy type checker so we get any errors at the interface between habitat-lab and habitat-sim.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Typeguard + MYPY
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
