### PR TITLE
[baselines] Allow PointNav_GPSCompass to support dimensionality 3

### DIFF
--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -355,6 +355,7 @@ class PointNavResNetNet(Net):
             ]
             if goal_observations.shape[1] == 2:
                 # Polar Dimensionality 2
+                # 2D polar transform
                 goal_observations = torch.stack(
                     [
                         goal_observations[:, 0],
@@ -367,14 +368,16 @@ class PointNavResNetNet(Net):
                 assert (
                     goal_observations.shape[1] == 3
                 ), "Unsupported dimensionality"
-
-                vertical_angle = torch.sin(goal_observations[:, 2])
+                vertical_angle_sin = torch.sin(goal_observations[:, 2])
                 # Polar Dimensionality 3
+                # 3D Polar transformation
                 goal_observations = torch.stack(
                     [
                         goal_observations[:, 0],
-                        torch.cos(-goal_observations[:, 1]) * vertical_angle,
-                        torch.sin(-goal_observations[:, 1]) * vertical_angle,
+                        torch.cos(-goal_observations[:, 1])
+                        * vertical_angle_sin,
+                        torch.sin(-goal_observations[:, 1])
+                        * vertical_angle_sin,
                         torch.cos(goal_observations[:, 2]),
                     ],
                     -1,

--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -353,14 +353,32 @@ class PointNavResNetNet(Net):
             goal_observations = observations[
                 IntegratedPointGoalGPSAndCompassSensor.cls_uuid
             ]
-            goal_observations = torch.stack(
-                [
-                    goal_observations[:, 0],
-                    torch.cos(-goal_observations[:, 1]),
-                    torch.sin(-goal_observations[:, 1]),
-                ],
-                -1,
-            )
+            if goal_observations.shape[1] == 2:
+                # Polar Dimensionality 2
+                goal_observations = torch.stack(
+                    [
+                        goal_observations[:, 0],
+                        torch.cos(-goal_observations[:, 1]),
+                        torch.sin(-goal_observations[:, 1]),
+                    ],
+                    -1,
+                )
+            else:
+                assert (
+                    goal_observations.shape[1] == 3
+                ), "Unsupported dimensionality"
+
+                vertical_angle = torch.sin(goal_observations[:, 2])
+                # Polar Dimensionality 3
+                goal_observations = torch.stack(
+                    [
+                        goal_observations[:, 0],
+                        torch.cos(-goal_observations[:, 1]) * vertical_angle,
+                        torch.sin(-goal_observations[:, 1]) * vertical_angle,
+                        torch.cos(goal_observations[:, 2]),
+                    ],
+                    -1,
+                )
 
             x.append(self.tgt_embeding(goal_observations))
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Enables the ResNet baseline to support an integrated pointnav_gps_compass sensor of dimensionality 3. Previously only 2D Integrated PointNav/GPS Compass was supported.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
