### PR TITLE
pointnav_generator bug fix

### DIFF
--- a/habitat/datasets/pointnav/pointnav_generator.py
+++ b/habitat/datasets/pointnav/pointnav_generator.py
@@ -153,6 +153,8 @@ def generate_pointnav_episode(
                 far_dist=furthest_dist_limit,
                 geodesic_to_euclid_ratio=geodesic_to_euclid_min_ratio,
             )
+            if is_compatible:
+                break
         if is_compatible:
             angle = np.random.uniform(0, 2 * np.pi)
             source_rotation = [0, np.sin(angle / 2), 0, np.cos(angle / 2)]

--- a/habitat_baselines/slambased/install_deps.sh
+++ b/habitat_baselines/slambased/install_deps.sh
@@ -56,7 +56,7 @@ cd "${MAINDIR}" || exit
 cd ORB_SLAM2-PythonBindings/src || exit
 ln -s "${MAINDIR}"/eigen3_installed/include/eigen3/Eigen Eigen
 cd "${MAINDIR}"/ORB_SLAM2-PythonBindings || exit
-#mkdir build
+mkdir build
 cd build || exit
 CONDA_DIR="$(dirname $(dirname $(which conda)))"
 CONDA_DIR=\"${CONDA_DIR}/envs/HandcraftedAgents/lib/python3.6/site-packages/\"

--- a/habitat_baselines/slambased/install_deps.sh
+++ b/habitat_baselines/slambased/install_deps.sh
@@ -17,9 +17,9 @@ conda install ffmpeg -c conda-forge -y
 cd "${MAINDIR}" || exit
 mkdir eigen3
 cd eigen3 || exit
-wget http://bitbucket.org/eigen/eigen/get/3.3.5.tar.gz
-tar -xzf 3.3.5.tar.gz
-cd eigen-eigen-b3f3d4950030 || exit
+wget https://gitlab.com/libeigen/eigen/-/archive/3.3.5/eigen-3.3.5.tar.gz
+tar -xzf eigen-3.3.5.tar.gz
+cd eigen-3.3.5 || exit
 mkdir build
 cd build || exit
 cmake .. -DCMAKE_INSTALL_PREFIX="${MAINDIR}"/eigen3_installed/
@@ -56,10 +56,11 @@ cd "${MAINDIR}" || exit
 cd ORB_SLAM2-PythonBindings/src || exit
 ln -s "${MAINDIR}"/eigen3_installed/include/eigen3/Eigen Eigen
 cd "${MAINDIR}"/ORB_SLAM2-PythonBindings || exit
-mkdir build
+#mkdir build
 cd build || exit
-CONDA_DIR="$(dirname $(dirname \"$(which conda)\"))"
-sed -i "s,lib/python3.5/dist-packages,${CONDA_DIR}/envs/HandcraftedAgents/lib/python3.6/site-packages/,g" ../CMakeLists.txt
+CONDA_DIR="$(dirname $(dirname $(which conda)))"
+CONDA_DIR=\"${CONDA_DIR}/envs/HandcraftedAgents/lib/python3.6/site-packages/\"
+sed -i "s,lib/python3.5/dist-packages,${CONDA_DIR},g" ../CMakeLists.txt
 cmake .. -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))")/libpython3.6m.so -DPYTHON_EXECUTABLE:FILEPATH=$(which python) -DCMAKE_LIBRARY_PATH="${MAINDIR}"/ORBSLAM2_installed/lib -DCMAKE_INCLUDE_PATH="${MAINDIR}"/ORBSLAM2_installed/include;"${MAINDIR}"/eigen3_installed/include/eigen3 -DCMAKE_INSTALL_PREFIX="${MAINDIR}"/pyorbslam2_installed
 make
 make install


### PR DESCRIPTION
## Motivation and Context
In pointnav_generator.py it looks like previously the loop wouldn't break if a compatible source_position was found, so this adds a break condition.
<!--- Why is this change required? What problem does it solve? -->
If this wasn't added then the pointnav generator would effectively only consider the last point sampled for compatibility.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
N/A

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
