### PR TITLE
Add error if unexpected keys are found on Habitat_Sim configs

### DIFF
--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -74,7 +74,7 @@ def overwrite_config(
                     f"""{low_attr} is not found on habitat_sim but is found on habitat_lab config.
                     It's also not in the list of keys to ignore: {ignore_keys}
                     Did you make a typo in the config?
-                    If not the version of Habitat Sim may not be compatible with Habitat Lab version: {config_from}: {config_from}
+                    If not the version of Habitat Sim may not be compatible with Habitat Lab version: {config_from}
                     """
                 )
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Union,
     cast,
 )
@@ -44,15 +45,17 @@ from habitat.core.spaces import Space
 RGBSENSOR_DIMENSION = 3
 
 
-def overwrite_config(config_from: Config, config_to: Any) -> None:
+def overwrite_config(
+    config_from: Config, config_to: Any, ignore_keys: Optional[Set[str]] = None
+) -> None:
     r"""Takes Habitat Lab config and Habitat-Sim config structures. Overwrites
     Habitat-Sim config with Habitat Lab values, where a field name is present
     in lowercase. Mostly used to avoid :ref:`sim_cfg.field = hapi_cfg.FIELD`
     code.
-
     Args:
         config_from: Habitat Lab config node.
         config_to: Habitat-Sim config structure.
+        ignore_keys: Optional set of keys to ignore in config_to
     """
 
     def if_config_to_lower(config):
@@ -62,8 +65,19 @@ def overwrite_config(config_from: Config, config_to: Any) -> None:
             return config
 
     for attr, value in config_from.items():
-        if hasattr(config_to, attr.lower()):
-            setattr(config_to, attr.lower(), if_config_to_lower(value))
+        low_attr = attr.lower()
+        if ignore_keys is None or low_attr not in ignore_keys:
+            if hasattr(config_to, low_attr):
+                setattr(config_to, low_attr, if_config_to_lower(value))
+            else:
+                # TODO consider new type of Error for this?
+                raise RuntimeError(
+                    f"""{low_attr} is not found on habitat_sim but is found on habitat_lab config.
+                    It's also not in the list of keys to ignore: {ignore_keys}
+                    Did you make a typo in the YAML config?
+                    If not the version of habitat_sim may not be supported: {config_from}
+                    """
+                )
 
 
 @registry.register_sensor
@@ -225,18 +239,39 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         overwrite_config(
             config_from=self.habitat_config.HABITAT_SIM_V0,
             config_to=sim_config,
+            ignore_keys={"gpu_gpu"},
         )
         sim_config.scene_id = self.habitat_config.SCENE
         agent_config = habitat_sim.AgentConfiguration()
         overwrite_config(
-            config_from=self._get_agent_config(), config_to=agent_config
+            config_from=self._get_agent_config(),
+            config_to=agent_config,
+            ignore_keys={
+                "is_set_start_state",
+                "sensors",
+                "start_position",
+                "start_rotation",
+            },
         )
 
         sensor_specifications = []
         for sensor in _sensor_suite.sensors.values():
             sim_sensor_cfg = habitat_sim.SensorSpec()
+            # TODO Handle configs for custom VisualSensors that might need
+            # their own ignore_keys. Maybe with special key / checking
+            # SensorType
             overwrite_config(
-                config_from=sensor.config, config_to=sim_sensor_cfg
+                config_from=sensor.config,
+                config_to=sim_sensor_cfg,
+                ignore_keys={
+                    "height",
+                    "hfov",
+                    "max_depth",
+                    "min_depth",
+                    "normalize_depth",
+                    "type",
+                    "width",
+                },
             )
             sim_sensor_cfg.uuid = sensor.uuid
             sim_sensor_cfg.resolution = list(

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -71,11 +71,11 @@ def overwrite_config(
                 setattr(config_to, low_attr, if_config_to_lower(value))
             else:
                 # TODO consider new type of Error for this?
-                raise RuntimeError(
+                raise NameError(
                     f"""{low_attr} is not found on habitat_sim but is found on habitat_lab config.
                     It's also not in the list of keys to ignore: {ignore_keys}
-                    Did you make a typo in the YAML config?
-                    If not the version of habitat_sim may not be supported: {config_from}
+                    Did you make a typo in the config?
+                    If not the version of Habitat Sim may not be compatible with Habitat Lab version: {config_from}: {config_from}
                     """
                 )
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -70,7 +70,6 @@ def overwrite_config(
             if hasattr(config_to, low_attr):
                 setattr(config_to, low_attr, if_config_to_lower(value))
             else:
-                # TODO consider new type of Error for this?
                 raise NameError(
                     f"""{low_attr} is not found on habitat_sim but is found on habitat_lab config.
                     It's also not in the list of keys to ignore: {ignore_keys}

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -238,6 +238,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         overwrite_config(
             config_from=self.habitat_config.HABITAT_SIM_V0,
             config_to=sim_config,
+            # Ignore key as it gets propogated to sensor below
             ignore_keys={"gpu_gpu"},
         )
         sim_config.scene_id = self.habitat_config.SCENE
@@ -245,8 +246,10 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         overwrite_config(
             config_from=self._get_agent_config(),
             config_to=agent_config,
+            # These keys are only used by Hab-Lab
             ignore_keys={
                 "is_set_start_state",
+                # This is the Sensor Config. Unpacked below
                 "sensors",
                 "start_position",
                 "start_rotation",
@@ -262,6 +265,8 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
             overwrite_config(
                 config_from=sensor.config,
                 config_to=sim_sensor_cfg,
+                # These keys are only used by Hab-Lab
+                # or translated into the sensor config manually
                 ignore_keys={
                     "height",
                     "hfov",


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* This breaks out a change from the orthocamera PR that errors Habitat_Sim when an unexpected config is encountered. This also will help ensure proper version / API compatibility between Habitat_Sim and Habitat_Lab.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
* Locally with pytest 
## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

This may break some old custom sensors that exist as third parties. We can make it less strict if needed or add a way to extend the ignore_keys more easily (perhaps through the config itself).