### PR TITLE
Enhance the display of the top down map for whatever floor the agent is currently on

### DIFF
--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -731,26 +731,34 @@ class TopDownMap(Measure):
     def _draw_goals_view_points(self, episode):
         if self._config.DRAW_VIEW_POINTS:
             for goal in episode.goals:
-                try:
-                    if goal.view_points is not None:
-                        for view_point in goal.view_points:
-                            self._draw_point(
-                                view_point.agent_state.position,
-                                maps.MAP_VIEW_POINT_INDICATOR,
-                            )
-                except AttributeError:
-                    pass
+                if goal.position[1] > \
+                    self._sim.get_agent(0).state.position[1] and \
+                    goal.position[1] < \
+                    self._sim.get_agent(0).state.position[1] + 2:
+                    try:
+                        if goal.view_points is not None:
+                            for view_point in goal.view_points:
+                                self._draw_point(
+                                    view_point.agent_state.position,
+                                    maps.MAP_VIEW_POINT_INDICATOR,
+                                )
+                    except AttributeError:
+                        pass
 
     def _draw_goals_positions(self, episode):
         if self._config.DRAW_GOAL_POSITIONS:
 
             for goal in episode.goals:
-                try:
-                    self._draw_point(
-                        goal.position, maps.MAP_TARGET_POINT_INDICATOR
-                    )
-                except AttributeError:
-                    pass
+                if goal.position[1] > \
+                    self._sim.get_agent(0).state.position[1] and \
+                    goal.position[1] < \
+                    self._sim.get_agent(0).state.position[1] + 2:
+                    try:
+                        self._draw_point(
+                            goal.position, maps.MAP_TARGET_POINT_INDICATOR
+                        )
+                    except AttributeError:
+                        pass
 
     def _draw_goals_aabb(self, episode):
         if self._config.DRAW_GOAL_AABBS:
@@ -778,6 +786,8 @@ class TopDownMap(Measure):
                             (x_len, -z_len),
                             (-x_len, -z_len),
                         ]
+                        if center[1] > self._sim.get_agent(0).state.position[1]
+                           and center[1] < self._sim.get_agent(0).state.position[1] + 2
                     ]
 
                     map_corners = [

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -824,7 +824,9 @@ class TopDownMap(Measure):
                 self.line_thickness,
             )
 
-    def _is_on_same_floor(self, height, ref_floor_height=None, ceiling_height=2.0):
+    def _is_on_same_floor(
+        self, height, ref_floor_height=None, ceiling_height=2.0
+    ):
         same_floor = False
         if ref_floor_height is None:
             ref_floor_height = self._sim.get_agent(0).state.position[1]

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -832,7 +832,6 @@ class TopDownMap(Measure):
             same_floor = True
         return same_floor
 
-
     def reset_metric(self, episode, *args: Any, **kwargs: Any):
         self._step_count = 0
         self._metric = None

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -829,10 +829,7 @@ class TopDownMap(Measure):
     ):
         if ref_floor_height is None:
             ref_floor_height = self._sim.get_agent(0).state.position[1]
-        if ref_floor_height < height < ref_floor_height + ceiling_height:
-            return True
-        else:
-            return False
+        return ref_floor_height < height < ref_floor_height + ceiling_height
 
     def reset_metric(self, episode, *args: Any, **kwargs: Any):
         self._step_count = 0

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -827,12 +827,12 @@ class TopDownMap(Measure):
     def _is_on_same_floor(
         self, height, ref_floor_height=None, ceiling_height=2.0
     ):
-        same_floor = False
         if ref_floor_height is None:
             ref_floor_height = self._sim.get_agent(0).state.position[1]
         if ref_floor_height < height < ref_floor_height + ceiling_height:
-            same_floor = True
-        return same_floor
+            return True
+        else:
+            return False
 
     def reset_metric(self, episode, *args: Any, **kwargs: Any):
         self._step_count = 0

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -44,6 +44,7 @@ except ImportError:
     pass
 cv2 = try_cv2_import()
 
+
 MAP_THICKNESS_SCALAR: int = 128
 
 
@@ -519,8 +520,7 @@ class Success(Measure):
         task.measurements.check_measure_dependencies(
             self.uuid, [DistanceToGoal.cls_uuid]
         )
-        self.update_metric(episode=episode, task=task, *args,
-                           **kwargs)  # type: ignore
+        self.update_metric(episode=episode, task=task, *args, **kwargs)  # type: ignore
 
     def update_metric(
         self, episode, task: EmbodiedTask, *args: Any, **kwargs: Any
@@ -597,8 +597,8 @@ class SPL(Measure):
         self._metric = ep_success * (
             self._start_end_episode_distance
             / max(
-            self._start_end_episode_distance, self._agent_episode_distance
-        )
+                self._start_end_episode_distance, self._agent_episode_distance
+            )
         )
 
 
@@ -623,8 +623,7 @@ class SoftSPL(SPL):
         self._start_end_episode_distance = task.measurements.measures[
             DistanceToGoal.cls_uuid
         ].get_metric()
-        self.update_metric(episode=episode, task=task, *args,
-                           **kwargs)  # type: ignore
+        self.update_metric(episode=episode, task=task, *args, **kwargs)  # type: ignore
 
     def update_metric(self, episode, task, *args: Any, **kwargs: Any):
         current_position = self._sim.get_agent_state().position
@@ -645,8 +644,8 @@ class SoftSPL(SPL):
         self._metric = ep_soft_success * (
             self._start_end_episode_distance
             / max(
-            self._start_end_episode_distance, self._agent_episode_distance
-        )
+                self._start_end_episode_distance, self._agent_episode_distance
+            )
         )
 
 
@@ -725,8 +724,8 @@ class TopDownMap(Measure):
             sim=self._sim,
         )
         self._top_down_map[
-        t_x - self.point_padding: t_x + self.point_padding + 1,
-        t_y - self.point_padding: t_y + self.point_padding + 1,
+            t_x - self.point_padding : t_x + self.point_padding + 1,
+            t_y - self.point_padding : t_y + self.point_padding + 1,
         ] = point_type
 
     def _draw_goals_view_points(self, episode):
@@ -833,6 +832,7 @@ class TopDownMap(Measure):
             same_floor = True
         return same_floor
 
+
     def reset_metric(self, episode, *args: Any, **kwargs: Any):
         self._step_count = 0
         self._metric = None
@@ -922,7 +922,7 @@ class TopDownMap(Measure):
                 self.get_polar_angle(),
                 fov=self._config.FOG_OF_WAR.FOV,
                 max_line_len=self._config.FOG_OF_WAR.VISIBILITY_DIST
-                             / maps.calculate_meters_per_pixel(
+                / maps.calculate_meters_per_pixel(
                     self._map_resolution, sim=self._sim
                 ),
             )

--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -824,11 +824,11 @@ class TopDownMap(Measure):
                 self.line_thickness,
             )
 
-    def _is_on_same_floor(self, pt, ref_floor_pt=None, ceiling_height=2.0):
+    def _is_on_same_floor(self, height, ref_floor_height=None, ceiling_height=2.0):
         same_floor = False
-        if ref_floor_pt is None:
-            ref_floor_pt = self._sim.get_agent(0).state.position[1]
-        if ref_floor_pt < pt < ref_floor_pt + ceiling_height:
+        if ref_floor_height is None:
+            ref_floor_height = self._sim.get_agent(0).state.position[1]
+        if ref_floor_height < height < ref_floor_height + ceiling_height:
             same_floor = True
         return same_floor
 


### PR DESCRIPTION
## Motivation and Context
Hi there, when I use the habitat simulator for object navigation tasks, I notice that the top-down map provided by the simulator is quite confusing. **Goal bboxes and their view points from other floors are wrongly marked** in the top-down map of the current layer, which is misleading.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
For example, the original top-down map for finding a `cushion` in `1pXnuDYAj8r` is like this:
![00146](https://user-images.githubusercontent.com/24936522/106623417-8d587980-65af-11eb-81a6-d33567755600.jpg)

However, most of the highlighted goals are actually not on this layer. After adding the height condition in `nav.py`, we can finally get the correct map.
![00021](https://user-images.githubusercontent.com/24936522/106623623-c5f85300-65af-11eb-8b2b-dcac34b20b42.jpg)


<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
