### PR TITLE
[PERFORMANCE] Pickle5 ConnectionWrapper for VectorEnv at least (2-5% speed up)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: check-added-large-files
@@ -31,7 +31,7 @@ repos:
         args: [--autofix]
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.6.4
+    rev: 5.7.0
     hooks:
     -   id: isort
         exclude: docs/
@@ -63,7 +63,7 @@ repos:
         - flake8-simplify
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.800
     hooks:
     -   id: mypy
         pass_filenames: false

--- a/habitat/core/vector_env.py
+++ b/habitat/core/vector_env.py
@@ -34,7 +34,7 @@ from habitat.config import Config
 from habitat.core.env import Env, RLEnv
 from habitat.core.logging import logger
 from habitat.core.utils import tile_images
-from habitat.utils import profiling_wrapper
+from habitat.utils import pickle5_multiprocessing, profiling_wrapper
 
 try:
     # Use torch.multiprocessing if we can.
@@ -174,6 +174,8 @@ class VectorEnv:
         ).format(self._valid_start_methods, multiprocessing_start_method)
         self._auto_reset_done = auto_reset_done
         self._mp_ctx = mp.get_context(multiprocessing_start_method)
+        # Patches the MP_CTX for faster serialization
+        self._mp_ctx.reducer = pickle5_multiprocessing.Pickle5Reducer()
         self._workers = []
         (
             self._connection_read_fns,

--- a/habitat/core/vector_env.py
+++ b/habitat/core/vector_env.py
@@ -174,8 +174,11 @@ class VectorEnv:
         ).format(self._valid_start_methods, multiprocessing_start_method)
         self._auto_reset_done = auto_reset_done
         self._mp_ctx = mp.get_context(multiprocessing_start_method)
-        # Patches the MP_CTX for faster serialization
-        self._mp_ctx.reducer = pickle5_multiprocessing.Pickle5Reducer()
+        # This patches multiprocessing to use pickle5 which has nocopy pickling support
+        # Only tested with numpy
+        self._mp_ctx.reducer.ForkingPickler = (  # type: ignore
+            pickle5_multiprocessing.ForkingPickler5
+        )
         self._workers = []
         (
             self._connection_read_fns,

--- a/habitat/utils/pickle5_multiprocessing.py
+++ b/habitat/utils/pickle5_multiprocessing.py
@@ -9,12 +9,21 @@ import sys
 from multiprocessing.connection import Connection
 from multiprocessing.reduction import ForkingPickler as _ForkingPickler
 
+from habitat.core.logging import logger
+
 if sys.version_info[:2] < (3, 8):
     # pickle 5 backport
     try:
         import pickle5 as pickle
     except ImportError:
         import pickle  # type: ignore[no-redef]
+
+        logger.warn(
+            f"""Warning pickle v5 protocol not supported.
+        Falling back to pickle version {pickle.HIGHEST_PROTOCOL}.
+        pip install pickle5 or upgrade to Python 3.8 or greater
+        for faster performance"""
+        )
 
     class ForkingPickler5(pickle.Pickler):
         wrapped = _ForkingPickler

--- a/habitat/utils/pickle5_multiprocessing.py
+++ b/habitat/utils/pickle5_multiprocessing.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import io
 import sys
 from multiprocessing.connection import Connection

--- a/habitat/utils/pickle5_multiprocessing.py
+++ b/habitat/utils/pickle5_multiprocessing.py
@@ -1,0 +1,56 @@
+import io
+import multiprocessing
+import multiprocessing.connection as mpc
+import sys
+from multiprocessing.reduction import AbstractReducer, ForkingPickler
+from typing import Dict
+
+# This patches the multiprocessing connection to serialize / deserialize pickle5
+if sys.version_info[:2] <= (3, 8):
+    # pickle 5 backport
+    import pickle5
+
+    class ForkingPickler5(pickle5.Pickler):
+        _extra_reducers: Dict = dict()
+        wrapped = mpc._ForkingPickler  # type: ignore
+        loads = staticmethod(pickle5.loads)
+
+        @classmethod
+        def register(cls, type, reduce):  # noqa: A002
+            """Register a reduce function for a type."""
+            cls._extra_reducers[type] = reduce
+
+        @classmethod
+        def dumps(cls, obj, protocol=-1):
+            buf = io.BytesIO()
+            cls(buf, protocol).dump(obj)
+            return buf.getbuffer()
+
+        def __init__(self, file, protocol=-1, **kwargs):
+            super().__init__(file, protocol, **kwargs)
+            self.dispatch_table = self.wrapped(
+                file, protocol, **kwargs
+            ).dispatch_table
+            self.dispatch_table.update(self._extra_reducers)
+
+
+else:
+
+    class ForkingPickler5(ForkingPickler):
+        @classmethod
+        def dumps(cls, obj, protocol=-1):
+            return super().dumps(obj, protocol)
+
+
+def dump(obj, file, protocol=-1):
+    ForkingPickler5(file, protocol).dump(obj)
+
+
+class Pickle5Reducer(AbstractReducer):
+    ForkingPickler = ForkingPickler5
+    register = ForkingPickler5.register
+    dump = dump
+
+
+mpc._ForkingPickler = ForkingPickler5  # type: ignore
+multiprocessing.context._default_context.reducer = Pickle5Reducer  # type: ignore

--- a/habitat/utils/pickle5_multiprocessing.py
+++ b/habitat/utils/pickle5_multiprocessing.py
@@ -1,60 +1,66 @@
 import io
-import multiprocessing
-import multiprocessing.connection as mpc
 import sys
-from multiprocessing.reduction import AbstractReducer, ForkingPickler
+from multiprocessing.connection import Connection
+from multiprocessing.reduction import ForkingPickler as _ForkingPickler
 from typing import Dict
 
-# This patches the multiprocessing connection to serialize / deserialize pickle5
-if sys.version_info[:2] <= (3, 8):
+if sys.version_info[:2] < (3, 8):
     # pickle 5 backport
-    import pickle5
-
-    class ForkingPickler5(pickle5.Pickler):
-        _extra_reducers: Dict = dict()
-        wrapped = mpc._ForkingPickler  # type: ignore
-        loads = staticmethod(pickle5.loads)
-
-        @classmethod
-        def register(cls, type, reduce):  # noqa: A002
-            """Register a reduce function for a type."""
-            cls._extra_reducers[type] = reduce
-
-        @classmethod
-        def dumps(cls, obj, protocol=-1):
-            buf = io.BytesIO()
-            cls(buf, protocol).dump(obj)
-            return buf.getbuffer()
-
-        def __init__(self, file, protocol=-1, **kwargs):
-            super().__init__(file, protocol, **kwargs)
-            self.dispatch_table = self.wrapped(
-                file, protocol, **kwargs
-            ).dispatch_table
-            self.dispatch_table.update(self._extra_reducers)
-
-
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle  # type: ignore[no-redef]
 else:
-
-    class ForkingPickler5(ForkingPickler):
-        @classmethod
-        def dumps(cls, obj, protocol=-1):
-            return super().dumps(obj, protocol)
+    import pickle
 
 
-def dump(obj, file, protocol=-1):
-    ForkingPickler5(file, protocol).dump(obj)
+class ForkingPickler5(pickle.Pickler):
+    _extra_reducers: Dict = dict()
+    wrapped = _ForkingPickler
+    loads = staticmethod(pickle.loads)
+
+    @classmethod
+    def register(cls, type, reduce):  # noqa: A002
+        """Register a reduce function for a type."""
+        cls._extra_reducers[type] = reduce
+
+    @classmethod
+    def dumps(cls, obj, protocol=-1):
+        buf = io.BytesIO()
+        cls(buf, protocol).dump(obj)
+        return buf.getbuffer()
+
+    def __init__(self, file, protocol=-1, **kwargs):
+        super().__init__(file, protocol, **kwargs)
+        self.dispatch_table = self.wrapped(
+            file, protocol, **kwargs
+        ).dispatch_table
+        self.dispatch_table.update(self._extra_reducers)
 
 
-class Pickle5Reducer(AbstractReducer):
-    ForkingPickler = ForkingPickler5
-    register = ForkingPickler5.register
-    dump = dump
+class ConnectionWrapper(object):
+    """Proxy class for _multiprocessing.Connection which uses ForkingPickler to
+    serialize objects. Will use the Pickle5 backport if available."""
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, conn: Connection):
+        self.conn: Connection = conn
 
+    def send(self, obj):
+        buf = io.BytesIO()
+        ForkingPickler5(buf, pickle.HIGHEST_PROTOCOL).dump(obj)
+        self.send_bytes(buf.getvalue())
 
-mpc._ForkingPickler = ForkingPickler5  # type: ignore
-multiprocessing.context._default_context.reducer.ForkingPickler = ForkingPickler5  # type: ignore
-multiprocessing.context._default_context.reducer.dump = dump  # type: ignore
+    def recv(self):
+        self._check_closed()
+        self._check_readable()
+        buf = self.recv_bytes()
+        return pickle.loads(buf)
+
+    def __getattr__(self, name):
+        if "conn" in self.__dict__:
+            return getattr(self.conn, name)
+        raise AttributeError(
+            "'{}' object has no attribute '{}'".format(
+                type(self).__name__, "conn"
+            )
+        )

--- a/habitat/utils/pickle5_multiprocessing.py
+++ b/habitat/utils/pickle5_multiprocessing.py
@@ -51,6 +51,10 @@ class Pickle5Reducer(AbstractReducer):
     register = ForkingPickler5.register
     dump = dump
 
+    def __init__(self, *args):
+        super().__init__(*args)
+
 
 mpc._ForkingPickler = ForkingPickler5  # type: ignore
-multiprocessing.context._default_context.reducer = Pickle5Reducer  # type: ignore
+multiprocessing.context._default_context.reducer.ForkingPickler = ForkingPickler5  # type: ignore
+multiprocessing.context._default_context.reducer.dump = dump  # type: ignore

--- a/habitat/utils/pickle5_multiprocessing.py
+++ b/habitat/utils/pickle5_multiprocessing.py
@@ -2,7 +2,6 @@ import io
 import sys
 from multiprocessing.connection import Connection
 from multiprocessing.reduction import ForkingPickler as _ForkingPickler
-from typing import Dict
 
 if sys.version_info[:2] < (3, 8):
     # pickle 5 backport
@@ -15,27 +14,20 @@ else:
 
 
 class ForkingPickler5(pickle.Pickler):
-    _extra_reducers: Dict = dict()
     wrapped = _ForkingPickler
     loads = staticmethod(pickle.loads)
 
     @classmethod
-    def register(cls, type, reduce):  # noqa: A002
-        """Register a reduce function for a type."""
-        cls._extra_reducers[type] = reduce
-
-    @classmethod
-    def dumps(cls, obj, protocol=-1):
+    def dumps(cls, obj, protocol: int = -1):
         buf = io.BytesIO()
         cls(buf, protocol).dump(obj)
         return buf.getbuffer()
 
-    def __init__(self, file, protocol=-1, **kwargs):
+    def __init__(self, file, protocol: int = -1, **kwargs):
         super().__init__(file, protocol, **kwargs)
         self.dispatch_table = self.wrapped(
             file, protocol, **kwargs
         ).dispatch_table
-        self.dispatch_table.update(self._extra_reducers)
 
 
 class ConnectionWrapper(object):
@@ -46,8 +38,10 @@ class ConnectionWrapper(object):
         self.conn: Connection = conn
 
     def send(self, obj):
+        self._check_closed()
+        self._check_writable()
         buf = io.BytesIO()
-        ForkingPickler5(buf, pickle.HIGHEST_PROTOCOL).dump(obj)
+        ForkingPickler5(buf, -1).dump(obj)
         self.send_bytes(buf.getvalue())
 
     def recv(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ yacs>=0.1.5
 numpy-quaternion>=2019.3.18.14.33.20
 attrs>=19.1.0
 opencv-python>=3.3.0
+pickle5; python_version < '3.8'
 # visualization optional dependencies
 imageio>=2.2.0
 imageio-ffmpeg>=0.2.0


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* [PEP 574](https://www.python.org/dev/peps/pep-0574/) introduced a zero-copy pickling method that makes the pickling of Numpy arrays significantly faster. However, this feature is only supported on the latest Pickle protocol (5) which is not used by the default for multiprocessing (or even torch.multiprocessing, although it is often used in wrappers like Queues). 

I ported and slightly modified the torch Connection wrapper code to habitat-lab and improved it by adding a pickle5 backport. The backport port brings this functionality back to Python<3.8 After using this PR, it should remove a copy from NumPy arrays.

Furthermore, this should not affect the pickling of any other parts of the code stack or any other multiprocessing code.

This speed up is likely to be a lot more on higher resolution outputs from habitat-sim as well as the sensor numbers increase.

This change should be fully backwards compatible and speed things up across the board without any code changes for the end user.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local testing shows at least 2-5% speed up in VectorEnv evaluation.  The entire test suite appears now takes 10 seconds less (despite only a fraction of the tests actually using VectorEnv.) I have tested this in Python 3.8 as well as Python 3.6.

As an aside, we should use add tests for pytest-benchmarking on common habitat-lab components like VectorEnv.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes
- Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] All new and existing tests passed.
