### PR TITLE
[Baselines Performance]Force pytorch to be single threaded

### DIFF
--- a/habitat_baselines/config/default.py
+++ b/habitat_baselines/config/default.py
@@ -44,10 +44,15 @@ _C.LOG_INTERVAL = 10
 _C.LOG_FILE = "train.log"
 _C.FORCE_BLIND_POLICY = False
 _C.VERBOSE = True
-# PyTorch keeps making more CPU things multi-threaded and that
-# always ends up reducing our perf when training is being done on the GPU,
-# so force it to be single threaded.
-_C.FORCE_TORCH_SINGLE_THREADED = True
+# For our use case, the CPU side things are mainly memory copies
+# and nothing of substantive compute. PyTorch has been making
+# more and more memory copies parallel, but that just ends up
+# slowing those down dramatically and reducing our perf.
+# This forces it to be single threaded.  The default
+# value is left as false as it's different than how
+# PyTorch normally behaves, but all configs we provide
+# set it to true and yours likely should too
+_C.FORCE_TORCH_SINGLE_THREADED = False
 # -----------------------------------------------------------------------------
 # EVAL CONFIG
 # -----------------------------------------------------------------------------

--- a/habitat_baselines/config/default.py
+++ b/habitat_baselines/config/default.py
@@ -44,6 +44,10 @@ _C.LOG_INTERVAL = 10
 _C.LOG_FILE = "train.log"
 _C.FORCE_BLIND_POLICY = False
 _C.VERBOSE = True
+# PyTorch keeps making more CPU things multi-threaded and that
+# always ends up reducing our perf when training is being done on the GPU,
+# so force it to be single threaded.
+_C.FORCE_TORCH_SINGLE_THREADED = True
 # -----------------------------------------------------------------------------
 # EVAL CONFIG
 # -----------------------------------------------------------------------------

--- a/habitat_baselines/config/eqa/il_eqa_cnn_pretrain.yaml
+++ b/habitat_baselines/config/eqa/il_eqa_cnn_pretrain.yaml
@@ -18,6 +18,9 @@ LOG_METRICS: True
 LOG_INTERVAL: 50
 EVAL_SAVE_RESULTS: True
 EVAL_SAVE_RESULTS_INTERVAL: 50
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 IL:
   EQACNNPretrain:

--- a/habitat_baselines/config/eqa/il_pacman_nav.yaml
+++ b/habitat_baselines/config/eqa/il_pacman_nav.yaml
@@ -23,6 +23,9 @@ LOG_INTERVAL: 10
 CHECKPOINT_INTERVAL: 1
 EVAL_SAVE_RESULTS: True
 EVAL_SAVE_RESULTS_INTERVAL: 10
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 IL:
   NAV:

--- a/habitat_baselines/config/eqa/il_vqa.yaml
+++ b/habitat_baselines/config/eqa/il_vqa.yaml
@@ -23,6 +23,10 @@ LOG_INTERVAL: 100
 EVAL_SAVE_RESULTS: True
 EVAL_SAVE_RESULTS_INTERVAL: 10
 
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
+
 IL:
   VQA:
     # vqa params

--- a/habitat_baselines/config/imagenav/ddppo_imagenav_example.yaml
+++ b/habitat_baselines/config/imagenav/ddppo_imagenav_example.yaml
@@ -15,6 +15,9 @@ NUM_UPDATES: -1
 TOTAL_NUM_STEPS: 1e6
 LOG_INTERVAL: 10
 NUM_CHECKPOINTS: 10
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 
 RL:

--- a/habitat_baselines/config/imagenav/ddppo_imagenav_gibson.yaml
+++ b/habitat_baselines/config/imagenav/ddppo_imagenav_gibson.yaml
@@ -16,6 +16,9 @@ NUM_UPDATES: -1
 TOTAL_NUM_STEPS: 1e9
 LOG_INTERVAL: 100
 NUM_CHECKPOINTS: 100
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   SUCCESS_REWARD: 2.5

--- a/habitat_baselines/config/imagenav/ppo_imagenav_example.yaml
+++ b/habitat_baselines/config/imagenav/ppo_imagenav_example.yaml
@@ -15,6 +15,9 @@ NUM_UPDATES: -1
 TOTAL_NUM_STEPS: 1e6
 LOG_INTERVAL: 10
 NUM_CHECKPOINTS: 10
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   PPO:

--- a/habitat_baselines/config/objectnav/ddppo_objectnav.yaml
+++ b/habitat_baselines/config/objectnav/ddppo_objectnav.yaml
@@ -15,6 +15,9 @@ SENSORS: ["DEPTH_SENSOR", "RGB_SENSOR"]
 NUM_UPDATES: 270000
 LOG_INTERVAL: 10
 NUM_CHECKPOINTS: 100
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 EVAL:
   SPLIT: "val"

--- a/habitat_baselines/config/pointnav/ddppo_pointnav.yaml
+++ b/habitat_baselines/config/pointnav/ddppo_pointnav.yaml
@@ -16,6 +16,9 @@ NUM_UPDATES: -1
 TOTAL_NUM_STEPS: 2.5e9
 LOG_INTERVAL: 10
 NUM_CHECKPOINTS: 100
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   SUCCESS_REWARD: 2.5

--- a/habitat_baselines/config/pointnav/ppo_pointnav.yaml
+++ b/habitat_baselines/config/pointnav/ppo_pointnav.yaml
@@ -21,6 +21,9 @@ CHECKPOINT_FOLDER: "data/new_checkpoints"
 TOTAL_NUM_STEPS: 75e6
 LOG_INTERVAL: 25
 NUM_CHECKPOINTS: 100
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   PPO:

--- a/habitat_baselines/config/pointnav/ppo_pointnav_example.yaml
+++ b/habitat_baselines/config/pointnav/ppo_pointnav_example.yaml
@@ -19,6 +19,9 @@ NUM_UPDATES: -1
 TOTAL_NUM_STEPS: 1e6
 LOG_INTERVAL: 10
 NUM_CHECKPOINTS: 50
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   PPO:

--- a/habitat_baselines/config/pointnav/ppo_pointnav_habitat_iccv19.yaml
+++ b/habitat_baselines/config/pointnav/ppo_pointnav_habitat_iccv19.yaml
@@ -24,6 +24,9 @@ CHECKPOINT_FOLDER: "data/new_checkpoints"
 TOTAL_NUM_STEPS: 75e6
 LOG_INTERVAL: 25
 NUM_CHECKPOINTS: 100
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   SUCCESS_REWARD: 10.0

--- a/habitat_baselines/config/test/ddppo_imagenav_test.yaml
+++ b/habitat_baselines/config/test/ddppo_imagenav_test.yaml
@@ -14,6 +14,9 @@ NUM_UPDATES: 2
 LOG_INTERVAL: 100
 NUM_CHECKPOINTS: 2
 TEST_EPISODE_COUNT: 2
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 
 RL:

--- a/habitat_baselines/config/test/ddppo_pointnav_test.yaml
+++ b/habitat_baselines/config/test/ddppo_pointnav_test.yaml
@@ -12,6 +12,9 @@ NUM_UPDATES: 2
 NUM_CHECKPOINTS: 2
 LOG_INTERVAL: 100
 TEST_EPISODE_COUNT: 2
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   SUCCESS_REWARD: 2.5

--- a/habitat_baselines/config/test/ppo_imagenav_test.yaml
+++ b/habitat_baselines/config/test/ppo_imagenav_test.yaml
@@ -12,6 +12,9 @@ NUM_UPDATES: 2
 LOG_INTERVAL: 100
 NUM_CHECKPOINTS: 2
 TEST_EPISODE_COUNT: 2
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   PPO:

--- a/habitat_baselines/config/test/ppo_pointnav_test.yaml
+++ b/habitat_baselines/config/test/ppo_pointnav_test.yaml
@@ -13,6 +13,9 @@ NUM_UPDATES: 2
 LOG_INTERVAL: 100
 NUM_CHECKPOINTS: 2
 TEST_EPISODE_COUNT: 2
+# Force PyTorch to be single threaded as
+# this improves performance considerably
+FORCE_TORCH_SINGLE_THREADED: True
 
 RL:
   PPO:

--- a/habitat_baselines/run.py
+++ b/habitat_baselines/run.py
@@ -49,6 +49,8 @@ def execute_exp(config: Config, run_type: str) -> None:
     random.seed(config.TASK_CONFIG.SEED)
     np.random.seed(config.TASK_CONFIG.SEED)
     torch.manual_seed(config.TASK_CONFIG.SEED)
+    if config.FORCE_TORCH_SINGLE_THREADED and torch.cuda.is_available():
+        torch.set_num_threads(1)
 
     trainer_init = baseline_registry.get_trainer(config.TRAINER_NAME)
     assert trainer_init is not None, f"{config.TRAINER_NAME} is not supported"

--- a/habitat_baselines/slambased/monodepth.py
+++ b/habitat_baselines/slambased/monodepth.py
@@ -637,7 +637,7 @@ class MonoDepthEstimator:
         )
         self.model = torch.nn.DataParallel(self.model).cuda()
         cpt = torch.load(checkpoint)
-        if "state_dict" in cpt.keys():
+        if "state_dict" in cpt:
             cpt = cpt["state_dict"]
         self.model.load_state_dict(cpt)
         self.model.eval()


### PR DESCRIPTION
## Motivation and Context

PyTorch keeps making more CPU things multi-threaded and that always ends up reducing our perf when training is being done on the GPU, so force it to be single threaded.

## How Has This Been Tested

Torch is single threaded!

## Types of changes

- New feature (non-breaking change which adds functionality)
