### PR TITLE
[BUGFIX] Sets cubemap projection height/width for Fisheye Projection

### DIFF
--- a/habitat_baselines/common/obs_transformers.py
+++ b/habitat_baselines/common/obs_transformers.py
@@ -1033,7 +1033,7 @@ class Cube2Fisheye(ProjectionConverter):
         """
 
         # Cubemap input
-        input_projections = get_cubemap_projections()
+        input_projections = get_cubemap_projections(fish_h, fish_w)
 
         # Fisheye output
         output_projection = FisheyeProjection(


### PR DESCRIPTION
Properly sets the cubemap projection depending the resolution of the fisheye camera.

The Fisheye camera did not work for depth images of any resolution other than 256, this should solve that issue. Would appreciate feedback from @matsuren that I didn't break anything else by accident when doing.

## Motivation and Context
Realized that the fisheye projection could only be used on depth images if the output fisheye size was 256x256. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
