### PR TITLE
[Baselines] Use Numpy for CPU Batching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov
-                pip install pytest-sugar
+                pip install pytest-sugar pillow<=7.2.0
               fi
       - run:
           name: Install pytorch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov
-                pip install pytest-sugar pillow<=7.2.0
+                pip install pytest-sugar "pillow<=7.2.0"
               fi
       - run:
           name: Install pytorch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
                 conda create -y -n habitat python=3.6
                 . activate habitat
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov
-                pip install pytest-sugar "pillow<=7.2.0"
+                pip install pytest-sugar
               fi
       - run:
           name: Install pytorch

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -204,10 +204,10 @@ def batch_obs(
         if cache is not None:
             # If we were using a numpy array to do indexing and copying,
             # convert back to torch tensor
-            # We know that batch_t[sensor] is either an np.ndarray
+            # We know that batch_t[sensor_name] is either an np.ndarray
             # or a torch.Tensor, so this is faster than torch.as_tensor
-            if isinstance(batch_t[sensor], np.ndarray):
-                batch_t[sensor] = torch.from_numpy(batch_t[sensor])
+            if isinstance(batch_t[sensor_name], np.ndarray):
+                batch_t[sensor_name] = torch.from_numpy(batch_t[sensor_name])
 
             batch_t[sensor_name] = batch_t[sensor_name].to(
                 device, non_blocking=True

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -93,7 +93,7 @@ class ObservationBatchingCache:
     r"""Helper for batching observations that maintains a cpu-side tensor
     that is the right size and is pinned to cuda memory
     """
-    _pool: Dict[Any, torch.Tensor] = attr.Factory(dict)
+    _pool: Dict[Any, Union[torch.Tensor, np.ndarray]] = attr.Factory(dict)
 
     def get(
         self,
@@ -101,7 +101,7 @@ class ObservationBatchingCache:
         sensor_name: str,
         sensor: torch.Tensor,
         device: Optional[torch.device] = None,
-    ) -> torch.Tensor:
+    ) -> Union[torch.Tensor, np.ndarray]:
         r"""Returns a tensor of the right size to batch num_obs observations together
 
         If sensor is a cpu-side tensor and device is a cuda device the batched tensor will
@@ -127,7 +127,9 @@ class ObservationBatchingCache:
             and device.type == "cuda"
             and cache.device.type == "cpu"
         ):
-            cache = cache.pin_memory()
+            # Pytorch indexing is really slow,
+            # so convert to numpy
+            cache = cache.pin_memory().numpy()
 
         self._pool[key] = cache
         return cache
@@ -171,21 +173,36 @@ def batch_obs(
 
     for sensor_name in sensor_names:
         for i, obs in enumerate(observations):
-            sensor = torch.as_tensor(obs[sensor_name])
+            sensor = obs[sensor_name]
             if cache is None:
-                batch[sensor_name].append(sensor)
+                batch[sensor_name].append(torch.as_tensor(sensor))
             else:
                 if sensor_name not in batch_t:
                     batch_t[sensor_name] = cache.get(
-                        len(observations), sensor_name, sensor, device
+                        len(observations),
+                        sensor_name,
+                        torch.as_tensor(sensor),
+                        device,
                     )
 
-                batch_t[sensor_name][i].copy_(sensor)
+                if isinstance(sensor, np.ndarray):
+                    batch_t[sensor_name][i] = sensor
+                elif torch.is_tensor(sensor):
+                    batch_t[sensor_name][i].copy_(sensor, non_blocking=True)
+                # If the sensor wasn't a tensor, then it's some CPU side data
+                # so use a numpy array
+                else:
+                    batch_t[sensor_name][i] = np.asarray(sensor)
 
         # With the batching cache, we use pinned mem
         # so we can start the move to the GPU async
         # and continue stacking other things with it
         if cache is not None:
+            # If we were using a numpy array to do indexing and copying,
+            # convert back to torch tensor
+            if isinstance(batch_t[sensor], np.ndarray):
+                batch_t[sensor] = torch.from_numpy(batch_t[sensor])
+
             batch_t[sensor_name] = batch_t[sensor_name].to(
                 device, non_blocking=True
             )


### PR DESCRIPTION
## Motivation and Context

Pytorch indexing is slow because it needs to track things for autograd even in no_grad mode, thereby making numpy faster for indexing and batching of obs.

## How Has This Been Tested

With a little test script.  This is about 2x faster sensors with normal Depth and GPS+Compass and becomes more beneficial as more little sensors are added.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade

