### PR TITLE
Fixed automatic data download outside of git repo

### DIFF
--- a/habitat/datasets/rearrange/rearrange_dataset.py
+++ b/habitat/datasets/rearrange/rearrange_dataset.py
@@ -49,7 +49,9 @@ class RearrangeDatasetV0(PointNavDatasetV1):
             print(
                 "Rearrange task assets are not downloaded locally, downloading and extracting now..."
             )
-            data_downloader.main(["--uids", "rearrange_task_assets"])
+            data_downloader.main(
+                ["--uids", "rearrange_task_assets", "--data-path", "data/"]
+            )
             print("Downloaded and extracted the data.")
         check_and_gen_physics_config()
 


### PR DESCRIPTION
## Motivation and Context
Data downloader works without explicit data-path only inside of git repo. To support usage with PyPi package setting data-path.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
CI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
