### PR TITLE
Improved and fixed interactive play script

### DIFF
--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -79,7 +79,7 @@ def append_text_to_image(image: np.ndarray, text: str):
     font_size = 0.5
     font_thickness = 1
     font = cv2.FONT_HERSHEY_SIMPLEX
-    text_image = np.zeros(image.shape, dtype=np.uint8)
+    text_image = np.zeros_like(image)
 
     y = 0
     for line in text:

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -348,7 +348,8 @@ def play_env(env, args, config):
         all_obs = np.array(all_obs)
         all_obs = np.transpose(all_obs, (0, 2, 1, 3))
         make_video_cv2(all_obs, "interactive_play")
-    pygame.quit()
+    if not args.no_render:
+        pygame.quit()
 
 
 def has_pygame():
@@ -356,10 +357,6 @@ def has_pygame():
 
 
 if __name__ == "__main__":
-    if not has_pygame():
-        raise ImportError(
-            "Need to install PyGame (run `pip install pygame==2.0.1`)"
-        )
     parser = argparse.ArgumentParser()
     parser.add_argument("--no-render", action="store_true", default=False)
     parser.add_argument("--save-obs", action="store_true", default=False)
@@ -367,6 +364,10 @@ if __name__ == "__main__":
     parser.add_argument("--load-actions", type=str, default=None)
     parser.add_argument("--cfg", type=str, default=DEFAULT_CFG)
     args = parser.parse_args()
+    if not has_pygame() and not args.no_render:
+        raise ImportError(
+            "Need to install PyGame (run `pip install pygame==2.0.1`)"
+        )
 
     config = habitat.get_config(args.cfg)
 

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -313,7 +313,6 @@ def play_env(env, args, config):
         use_ob = overlay_frame(use_ob, info)
 
         draw_ob = use_ob[:]
-        # cv2.imshow('viewer', draw_ob[..., ::-1])
 
         if not args.no_render:
             draw_ob = np.transpose(draw_ob, (1, 0, 2))

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -47,6 +47,7 @@ except ImportError:
     pygame = None
 
 DEFAULT_CFG = "configs/tasks/rearrangepick_replica_cad_example.yaml"
+DEFAULT_RENDER_STEPS_LIMIT = 60
 
 
 def make_video_cv2(observations, prefix=""):
@@ -259,9 +260,9 @@ def get_wrapped_prop(venv, prop):
 
 
 def play_env(env, args, config):
-    render_count = None
+    render_steps_limit = None
     if args.no_render:
-        render_count = 60
+        render_steps_limit = DEFAULT_RENDER_STEPS_LIMIT
 
     use_arm_actions = None
     if args.load_actions is not None:
@@ -286,7 +287,7 @@ def play_env(env, args, config):
     all_arm_actions = []
 
     while True:
-        if render_count is not None and i > render_count:
+        if render_steps_limit is not None and i > render_steps_limit:
             break
         step_result, arm_action = get_input_vel_ctlr(
             args.no_render,

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -351,8 +351,12 @@ def play_env(env, args, config):
     pygame.quit()
 
 
+def has_pygame():
+    return pygame is not None
+
+
 if __name__ == "__main__":
-    if pygame is None:
+    if not has_pygame():
         raise ImportError(
             "Need to install PyGame (run `pip install pygame==2.0.1`)"
         )

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -261,7 +261,7 @@ def get_wrapped_prop(venv, prop):
 def play_env(env, args, config):
     render_count = None
     if args.no_render:
-        render_count = 60 * 60
+        render_count = 60
 
     use_arm_actions = None
     if args.load_actions is not None:

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -79,7 +79,7 @@ def append_text_to_image(image: np.ndarray, text: str):
     font_size = 0.5
     font_thickness = 1
     font = cv2.FONT_HERSHEY_SIMPLEX
-    text_image = np.zeros_like(image)
+    text_image = np.zeros_like(image, dtype=np.uint8)
 
     y = 0
     for line in text:
@@ -96,7 +96,7 @@ def append_text_to_image(image: np.ndarray, text: str):
             font_thickness,
             lineType=cv2.LINE_AA,
         )
-    return image + text_image
+    return np.clip(image + text_image, 0, 255)
 
 
 def overlay_frame(frame, info):

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -164,22 +164,21 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
         generated image of a single frame.
     """
     egocentric_view_l: List[np.ndarray] = []
-    if "rgb" in observation:
-        rgb = observation["rgb"]
-        if not isinstance(rgb, np.ndarray):
-            rgb = rgb.cpu().numpy()
+    for k in observation:
+        if "rgb" in k:
+            rgb = observation[k]
+            if not isinstance(rgb, np.ndarray):
+                rgb = rgb.cpu().numpy()
 
-        egocentric_view_l.append(rgb)
+            egocentric_view_l.append(rgb)
+        elif "depth" in k:
+            depth_map = observation[k].squeeze() * 255.0
+            if not isinstance(depth_map, np.ndarray):
+                depth_map = depth_map.cpu().numpy()
 
-    # draw depth map if observation has depth info
-    if "depth" in observation:
-        depth_map = observation["depth"].squeeze() * 255.0
-        if not isinstance(depth_map, np.ndarray):
-            depth_map = depth_map.cpu().numpy()
-
-        depth_map = depth_map.astype(np.uint8)
-        depth_map = np.stack([depth_map for _ in range(3)], axis=2)
-        egocentric_view_l.append(depth_map)
+            depth_map = depth_map.astype(np.uint8)
+            depth_map = np.stack([depth_map for _ in range(3)], axis=2)
+            egocentric_view_l.append(depth_map)
 
     # add image goal if observation has image_goal info
     if "imagegoal" in observation:
@@ -192,7 +191,43 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
     assert (
         len(egocentric_view_l) > 0
     ), "Expected at least one visual sensor enabled."
-    egocentric_view = np.concatenate(egocentric_view_l, axis=1)
+
+    shapes = [x.shape for x in egocentric_view_l]
+
+    if len(set(shapes)) != 1:
+        egocentric_view_l = sorted(
+            egocentric_view_l, key=lambda x: x.shape[0], reverse=True
+        )
+        img_cols = [[egocentric_view_l[0]]]
+        max_height = egocentric_view_l[0].shape[0]
+        cur_y = 0.0
+        col = []
+        for i in range(len(egocentric_view_l) - 1):
+            im = egocentric_view_l[i + 1]
+            if cur_y + im.shape[0] <= max_height:
+                col.append(im)
+                cur_y += im.shape[0]
+            else:
+                img_cols.append(col)
+                col = [im]
+                cur_y = 0.0
+        img_cols.append(col)
+        col_widths = [
+            max([col_ele.shape[1] for col_ele in col]) for col in img_cols
+        ]
+        total_width = sum(col_widths)
+        final_im = np.zeros(
+            (max_height, total_width, 3), dtype=egocentric_view_l[0].dtype
+        )
+        cur_x = 0
+        for i in range(len(img_cols)):
+            next_x = cur_x + col_widths[i]
+            total_col_im = np.concatenate(img_cols[i], axis=0)
+            final_im[: total_col_im.shape[0], cur_x:next_x] = total_col_im
+            cur_x = next_x
+        egocentric_view = final_im
+    else:
+        egocentric_view = np.concatenate(egocentric_view_l, axis=1)
 
     # draw collision
     if "collisions" in info and info["collisions"]["is_collision"]:

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -204,8 +204,7 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
         cur_y = 0.0
         # Arrange the images in columns with the largest image to the left.
         col = []
-        for i in range(len(egocentric_view_l) - 1):
-            im = egocentric_view_l[i + 1]
+        for im in egocentric_view_l[1:]:
             if cur_y + im.shape[0] <= max_height:
                 col.append(im)
                 cur_y += im.shape[0]

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -214,7 +214,7 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
                 cur_y = 0.0
         img_cols.append(col)
         col_widths = [
-            max([col_ele.shape[1] for col_ele in col]) for col in img_cols
+            max(col_ele.shape[1] for col_ele in col) for col in img_cols
         ]
         # Get the total width of all the columns put together.
         total_width = sum(col_widths)

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -195,12 +195,14 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
     shapes = [x.shape for x in egocentric_view_l]
 
     if len(set(shapes)) != 1:
+        # Get the images in descending order of vertical height.
         egocentric_view_l = sorted(
             egocentric_view_l, key=lambda x: x.shape[0], reverse=True
         )
         img_cols = [[egocentric_view_l[0]]]
         max_height = egocentric_view_l[0].shape[0]
         cur_y = 0.0
+        # Arrange the images in columns with the largest image to the left.
         col = []
         for i in range(len(egocentric_view_l) - 1):
             im = egocentric_view_l[i + 1]
@@ -215,7 +217,10 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
         col_widths = [
             max([col_ele.shape[1] for col_ele in col]) for col in img_cols
         ]
+        # Get the total width of all the columns put together.
         total_width = sum(col_widths)
+
+        # Tile the images, pasting the columns side by side.
         final_im = np.zeros(
             (max_height, total_width, 3), dtype=egocentric_view_l[0].dtype
         )

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -152,6 +152,45 @@ def draw_collision(view: np.ndarray, alpha: float = 0.4) -> np.ndarray:
     return view
 
 
+def tile_images(render_obs_images: List[np.ndarray]) -> np.ndarray:
+    """Tiles multiple images of non-equal size to a single image. Images are
+    tiled into columns making the returned image wider than tall.
+    """
+    # Get the images in descending order of vertical height.
+    render_obs_images = sorted(
+        render_obs_images, key=lambda x: x.shape[0], reverse=True
+    )
+    img_cols = [[render_obs_images[0]]]
+    max_height = render_obs_images[0].shape[0]
+    cur_y = 0.0
+    # Arrange the images in columns with the largest image to the left.
+    col = []
+    for im in render_obs_images[1:]:
+        if cur_y + im.shape[0] <= max_height:
+            col.append(im)
+            cur_y += im.shape[0]
+        else:
+            img_cols.append(col)
+            col = [im]
+            cur_y = 0.0
+    img_cols.append(col)
+    col_widths = [max(col_ele.shape[1] for col_ele in col) for col in img_cols]
+    # Get the total width of all the columns put together.
+    total_width = sum(col_widths)
+
+    # Tile the images, pasting the columns side by side.
+    final_im = np.zeros(
+        (max_height, total_width, 3), dtype=render_obs_images[0].dtype
+    )
+    cur_x = 0
+    for i in range(len(img_cols)):
+        next_x = cur_x + col_widths[i]
+        total_col_im = np.concatenate(img_cols[i], axis=0)
+        final_im[: total_col_im.shape[0], cur_x:next_x] = total_col_im
+        cur_x = next_x
+    return final_im
+
+
 def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
     r"""Generate image of single frame from observation and info
     returned from a single environment step().
@@ -163,22 +202,22 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
     Returns:
         generated image of a single frame.
     """
-    egocentric_view_l: List[np.ndarray] = []
-    for k in observation:
-        if "rgb" in k:
-            rgb = observation[k]
+    render_obs_images: List[np.ndarray] = []
+    for sensor_name in observation:
+        if "rgb" in sensor_name:
+            rgb = observation[sensor_name]
             if not isinstance(rgb, np.ndarray):
                 rgb = rgb.cpu().numpy()
 
-            egocentric_view_l.append(rgb)
-        elif "depth" in k:
-            depth_map = observation[k].squeeze() * 255.0
+            render_obs_images.append(rgb)
+        elif "depth" in sensor_name:
+            depth_map = observation[sensor_name].squeeze() * 255.0
             if not isinstance(depth_map, np.ndarray):
                 depth_map = depth_map.cpu().numpy()
 
             depth_map = depth_map.astype(np.uint8)
             depth_map = np.stack([depth_map for _ in range(3)], axis=2)
-            egocentric_view_l.append(depth_map)
+            render_obs_images.append(depth_map)
 
     # add image goal if observation has image_goal info
     if "imagegoal" in observation:
@@ -186,65 +225,31 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
         if not isinstance(rgb, np.ndarray):
             rgb = rgb.cpu().numpy()
 
-        egocentric_view_l.append(rgb)
+        render_obs_images.append(rgb)
 
     assert (
-        len(egocentric_view_l) > 0
+        len(render_obs_images) > 0
     ), "Expected at least one visual sensor enabled."
 
-    shapes = [x.shape for x in egocentric_view_l]
+    shapes_are_equal = np.all(
+        [x.shape for x in render_obs_images] == render_obs_images[0].shape
+    )
 
-    if len(set(shapes)) != 1:
-        # Get the images in descending order of vertical height.
-        egocentric_view_l = sorted(
-            egocentric_view_l, key=lambda x: x.shape[0], reverse=True
-        )
-        img_cols = [[egocentric_view_l[0]]]
-        max_height = egocentric_view_l[0].shape[0]
-        cur_y = 0.0
-        # Arrange the images in columns with the largest image to the left.
-        col = []
-        for im in egocentric_view_l[1:]:
-            if cur_y + im.shape[0] <= max_height:
-                col.append(im)
-                cur_y += im.shape[0]
-            else:
-                img_cols.append(col)
-                col = [im]
-                cur_y = 0.0
-        img_cols.append(col)
-        col_widths = [
-            max(col_ele.shape[1] for col_ele in col) for col in img_cols
-        ]
-        # Get the total width of all the columns put together.
-        total_width = sum(col_widths)
-
-        # Tile the images, pasting the columns side by side.
-        final_im = np.zeros(
-            (max_height, total_width, 3), dtype=egocentric_view_l[0].dtype
-        )
-        cur_x = 0
-        for i in range(len(img_cols)):
-            next_x = cur_x + col_widths[i]
-            total_col_im = np.concatenate(img_cols[i], axis=0)
-            final_im[: total_col_im.shape[0], cur_x:next_x] = total_col_im
-            cur_x = next_x
-        egocentric_view = final_im
+    if not shapes_are_equal:
+        render_frame = tile_images(render_obs_images)
     else:
-        egocentric_view = np.concatenate(egocentric_view_l, axis=1)
+        render_frame = np.concatenate(render_obs_images, axis=1)
 
     # draw collision
     if "collisions" in info and info["collisions"]["is_collision"]:
-        egocentric_view = draw_collision(egocentric_view)
-
-    frame = egocentric_view
+        render_frame = draw_collision(render_frame)
 
     if "top_down_map" in info:
         top_down_map = maps.colorize_draw_agent_and_fit_to_height(
-            info["top_down_map"], egocentric_view.shape[0]
+            info["top_down_map"], render_frame.shape[0]
         )
-        frame = np.concatenate((egocentric_view, top_down_map), axis=1)
-    return frame
+        render_frame = np.concatenate((render_frame, top_down_map), axis=1)
+    return render_frame
 
 
 def append_text_to_image(image: np.ndarray, text: str):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -6,8 +6,6 @@ from os import path as osp
 
 import pytest
 
-from examples.interactive_play import has_pygame
-
 
 def run_main(*args):
     # patch sys.args
@@ -58,10 +56,6 @@ def run_main_subproc(args):
             "--no-make-video",
         ),
         ("examples/tutorials/nb_python/Habitat_Lab.py",),
-        (
-            "examples/interactive_play.py",
-            "--no-render",
-        ),
     ],
 )
 def test_example_modules(args):
@@ -78,6 +72,4 @@ def test_example_modules(args):
     ],
 )
 def test_rearrange_example_modules(args):
-    if not has_pygame():
-        return
     run_main_subproc(args)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -6,6 +6,8 @@ from os import path as osp
 
 import pytest
 
+from examples.interactive_play import has_pygame
+
 
 def run_main(*args):
     # patch sys.args
@@ -76,4 +78,6 @@ def test_example_modules(args):
     ],
 )
 def test_rearrange_example_modules(args):
+    if not has_pygame():
+        return
     run_main_subproc(args)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -56,7 +56,24 @@ def run_main_subproc(args):
             "--no-make-video",
         ),
         ("examples/tutorials/nb_python/Habitat_Lab.py",),
+        (
+            "examples/interactive_play.py",
+            "--no-render",
+        ),
     ],
 )
 def test_example_modules(args):
+    run_main_subproc(args)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        (
+            "examples/interactive_play.py",
+            "--no-render",
+        ),
+    ],
+)
+def test_rearrange_example_modules(args):
     run_main_subproc(args)

--- a/test/test_visual_utils.py
+++ b/test/test_visual_utils.py
@@ -31,3 +31,29 @@ def test_observations_to_image():
         1000,
         3,
     ), "Resulted image resolution doesn't match."
+
+
+def test_different_dim_observations_to_image():
+    observations = {
+        "1_rgb": np.random.rand(512, 512, 3),
+        "2_rgb": np.random.rand(418, 418, 3),
+        "1_depth": np.random.rand(128, 128, 1),
+        "2_depth": np.random.rand(128, 128, 1),
+    }
+    info = {
+        "collisions": {"is_collision": True},
+        "top_down_map": {
+            "map": np.random.randint(low=0, high=255, size=(300, 300)),
+            "fog_of_war_mask": np.random.randint(
+                low=0, high=1, size=(300, 300)
+            ),
+            "agent_map_coord": (10, 10),
+            "agent_angle": np.random.random(),
+        },
+    }
+    image = observations_to_image(observations, info)
+    assert image.shape == (
+        512,
+        1570,
+        3,
+    ), "Resulted image resolution doesn't match."


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The rendered image and text was flipped the wrong direction. Other sensor images were not being rendered to the screen, now all sensors are automatically rendered. Refactored `observations_to_image` to allow variable sized sensor images. The different image sizes are now tiled side by side. 

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

- Via the interactive play script: `python examples/interactive_play.py --cfg configs/tasks/rearrangepick_replica_cad_example_ik.yaml`
- Added a new test `test_different_dim_observations_to_image` for new changes to `observations_to_image` utility function.
- New test `test_rearrange_example_modules` to make sure the interactive_play script runs. 

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Example of interactive play output:

https://user-images.githubusercontent.com/877440/126211420-e2802555-8d2a-47c1-8ebd-4b6c67aa8bcd.mov

