### PR TITLE
Fix failing gym 2.0 test

### DIFF
--- a/test/test_habitat_task.py
+++ b/test/test_habitat_task.py
@@ -13,8 +13,10 @@ import habitat
 from habitat.utils.test_utils import sample_non_stop_action
 
 CFG_TEST = "configs/test/habitat_all_sensors_test.yaml"
-TELEPORT_POSITION = np.array([-3.2890449, 0.15067159, 11.124366])
-TELEPORT_ROTATION = np.array([0.92035, 0, -0.39109465, 0])
+TELEPORT_POSITION = np.array(
+    [-3.2890449, 0.15067159, 11.124366], dtype=np.float32
+)
+TELEPORT_ROTATION = np.array([0.92035, 0, -0.39109465, 0], dtype=np.float32)
 
 
 def test_task_actions():


### PR DESCRIPTION
## Motivation and Context

Gym 2.0 makes `contains` much stricter so now types need to be castable and it doesn't like casting from float64 to float32.

## How Has This Been Tested

Via the test.


