### PR TITLE
Migrate ci resource type in advance of deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 gpu: &gpu
   machine:
     image: ubuntu-1604-cuda-10.1:201909-23
-  resource_class: gpu.small
+  resource_class: gpu.nvidia.small.multi
   environment:
     FPS_THRESHOLD: 900
 


### PR DESCRIPTION
## Motivation and Context

CircleCI is deprecating legacy resource types (e.g. gpu.small) by 2022. We should migrate to the new resource types.

## How Has This Been Tested

CI jobs running with new resource type.
