### PR TITLE
Remove tensorflow dependency

### DIFF
--- a/habitat_baselines/rl/requirements.txt
+++ b/habitat_baselines/rl/requirements.txt
@@ -1,5 +1,3 @@
 moviepy>=1.0.1
 torch>=1.3.1
-# full tensorflow required for tensorboard video support
-tensorflow==1.13.1
-tb-nightly
+tensorboard

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ if __name__ == "__main__":
             "pytest-mock",
             "pytest",
             "pybullet==3.0.4",
+            "mock",
         ],
         include_package_data=True,
         cmdclass={"install": InstallCommand, "develop": DevelopCommand},


### PR DESCRIPTION
## Motivation and Context

Remove TensorFlow dependency. The comment in requirements of "full tensorflow required for tensorboard video support" is no longer true. Also switching tb-nightly to tensorboard as the nightly features we needed at the time have long since been moved to the mainline.

## How Has This Been Tested

Locally.

## Types of changes


- Docs change / refactoring / dependency upgrade
