### PR TITLE
Renamed references from master to main in docs and  for DDPPO master address

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
             - habitat-sim-{{ checksum "./hsim_sha" }}
       - restore_cache:
           keys:
-            - ccache-{{ arch }}-master
+            - ccache-{{ arch }}-main
           paths:
             - /home/circleci/.ccache
       - run:
@@ -221,7 +221,7 @@ jobs:
           paths:
             - ./habitat-sim
       - save_cache:
-          key: ccache-{{ arch }}-master
+          key: ccache-{{ arch }}-main
           background: true
           paths:
             - /home/circleci/.ccache

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CircleCI](https://circleci.com/gh/facebookresearch/habitat-lab.svg?style=shield)](https://circleci.com/gh/facebookresearch/habitat-lab)
-[![codecov](https://codecov.io/gh/facebookresearch/habitat-lab/branch/master/graph/badge.svg)](https://codecov.io/gh/facebookresearch/habitat-lab)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookresearch/habitat-lab/blob/master/LICENSE)
+[![codecov](https://codecov.io/gh/facebookresearch/habitat-lab/branch/main/graph/badge.svg)](https://codecov.io/gh/facebookresearch/habitat-lab)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookresearch/habitat-lab/blob/main/LICENSE)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/facebookresearch/habitat-lab)](https://github.com/facebookresearch/habitat-lab/releases/latest)
 [![Supports Habitat_Sim](https://img.shields.io/static/v1?label=supports&message=Habitat%20Sim&color=informational&link=https://github.com/facebookresearch/habitat-sim)](https://github.com/facebookresearch/habitat-sim)
 [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)

--- a/docs/pages/habitat-lab-demo.rst
+++ b/docs/pages/habitat-lab-demo.rst
@@ -16,7 +16,7 @@ Habitat Lab Demo
 
 All the boilerplate code in the habitat-sim to set sensor config and agent
 config is abstracted out in the Habitat Lab config system. Default config is at
-:gh:`habitat/config/default.py <facebookresearch/habitat-lab/blob/master/habitat/config/default.py>`.
+:gh:`habitat/config/default.py <facebookresearch/habitat-lab/blob/main/habitat/config/default.py>`.
 You can override defaults by specifying them in a separate file and pass it to
 the :ref:`habitat.config.get_config()` function or defrost the config object,
 override parameters and freeze the config.

--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -131,7 +131,7 @@ Below is a demo of what the example output will look like:
 .. image:: quickstart.png
 
 For more examples refer to
-:gh:`Habitat Lab examples <facebookresearch/habitat-lab/tree/master/examples>`
+:gh:`Habitat Lab examples <facebookresearch/habitat-lab/tree/main/examples>`
 and :gh:`Habitat-Sim examples <facebookresearch/habitat-sim/tree/main/examples>`.
 
 

--- a/examples/tutorials/colabs/Habitat_Lab.ipynb
+++ b/examples/tutorials/colabs/Habitat_Lab.ipynb
@@ -260,7 +260,7 @@
     "# @markdown (double click to see the code)\n",
     "\n",
     "# example tensorboard visualization\n",
-    "# for more details refer to [link](https://github.com/facebookresearch/habitat-lab/tree/master/habitat_baselines#additional-utilities).\n",
+    "# for more details refer to [link](https://github.com/facebookresearch/habitat-lab/tree/main/habitat_baselines#additional-utilities).\n",
     "\n",
     "try:\n",
     "    from IPython import display\n",
@@ -279,11 +279,11 @@
     "\n",
     "All the concepts link to their definitions:\n",
     "\n",
-    "1. [`habitat.sims.habitat_simulator.HabitatSim`](https://github.com/facebookresearch/habitat-lab/blob/master/habitat/sims/habitat_simulator/habitat_simulator.py#L159)\n",
+    "1. [`habitat.sims.habitat_simulator.HabitatSim`](https://github.com/facebookresearch/habitat-lab/blob/main/habitat/sims/habitat_simulator/habitat_simulator.py#L159)\n",
     "Thin wrapper over `habitat_sim` providing seamless integration with experimentation framework.\n",
     "\n",
     "\n",
-    "2. [`habitat.core.env.Env`](https://github.com/facebookresearch/habitat-lab/blob/master/habitat/core/env.py)\n",
+    "2. [`habitat.core.env.Env`](https://github.com/facebookresearch/habitat-lab/blob/main/habitat/core/env.py)\n",
     "Abstraction for the universe of agent, task and simulator. Agents that you train and evaluate operate inside the environment.\n",
     "\n",
     "\n",
@@ -299,7 +299,7 @@
     "Wrapper over information required for the dataset of embodied task, contains definition and interaction with an `episode`.\n",
     "\n",
     "\n",
-    "6. [`habitat.core.embodied_task.Measure`](https://github.com/facebookresearch/habitat-lab/blob/master/habitat/core/embodied_task.py#L82)\n",
+    "6. [`habitat.core.embodied_task.Measure`](https://github.com/facebookresearch/habitat-lab/blob/main/habitat/core/embodied_task.py#L82)\n",
     "Defines the metrics for embodied task, eg: [SPL](https://github.com/facebookresearch/habitat-lab/blob/d0db1b55be57abbacc5563dca2ca14654c545552/habitat/tasks/nav/nav.py#L533).\n",
     "\n",
     "\n",
@@ -536,7 +536,7 @@
    "source": [
     "### Other Examples\n",
     "\n",
-    "[Create a new action space](https://github.com/facebookresearch/habitat-lab/blob/master/examples/new_actions.py)"
+    "[Create a new action space](https://github.com/facebookresearch/habitat-lab/blob/main/examples/new_actions.py)"
    ]
   },
   {

--- a/examples/tutorials/nb_python/Habitat_Lab.py
+++ b/examples/tutorials/nb_python/Habitat_Lab.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
 # @markdown (double click to see the code)
 
 # example tensorboard visualization
-# for more details refer to [link](https://github.com/facebookresearch/habitat-lab/tree/master/habitat_baselines#additional-utilities).
+# for more details refer to [link](https://github.com/facebookresearch/habitat-lab/tree/main/habitat_baselines#additional-utilities).
 
 try:
     from IPython import display
@@ -213,11 +213,11 @@ except ImportError:
 #
 # All the concepts link to their definitions:
 #
-# 1. [`habitat.sims.habitat_simulator.HabitatSim`](https://github.com/facebookresearch/habitat-lab/blob/master/habitat/sims/habitat_simulator/habitat_simulator.py#L159)
+# 1. [`habitat.sims.habitat_simulator.HabitatSim`](https://github.com/facebookresearch/habitat-lab/blob/main/habitat/sims/habitat_simulator/habitat_simulator.py#L159)
 # Thin wrapper over `habitat_sim` providing seamless integration with experimentation framework.
 #
 #
-# 2. [`habitat.core.env.Env`](https://github.com/facebookresearch/habitat-lab/blob/master/habitat/core/env.py)
+# 2. [`habitat.core.env.Env`](https://github.com/facebookresearch/habitat-lab/blob/main/habitat/core/env.py)
 # Abstraction for the universe of agent, task and simulator. Agents that you train and evaluate operate inside the environment.
 #
 #
@@ -233,7 +233,7 @@ except ImportError:
 # Wrapper over information required for the dataset of embodied task, contains definition and interaction with an `episode`.
 #
 #
-# 6. [`habitat.core.embodied_task.Measure`](https://github.com/facebookresearch/habitat-lab/blob/master/habitat/core/embodied_task.py#L82)
+# 6. [`habitat.core.embodied_task.Measure`](https://github.com/facebookresearch/habitat-lab/blob/main/habitat/core/embodied_task.py#L82)
 # Defines the metrics for embodied task, eg: [SPL](https://github.com/facebookresearch/habitat-lab/blob/d0db1b55be57abbacc5563dca2ca14654c545552/habitat/tasks/nav/nav.py#L533).
 #
 #
@@ -403,7 +403,7 @@ class ForwardOnlyAgent(habitat.Agent):
 # %% [markdown]
 # ### Other Examples
 #
-# [Create a new action space](https://github.com/facebookresearch/habitat-lab/blob/master/examples/new_actions.py)
+# [Create a new action space](https://github.com/facebookresearch/habitat-lab/blob/main/examples/new_actions.py)
 
 # %%
 # @title Sim2Real with Habitat { display-mode: "form" }

--- a/habitat_baselines/il/README.md
+++ b/habitat_baselines/il/README.md
@@ -21,7 +21,7 @@ followed by fine-tuning the NAV model.
 ## Pre-requisites:
 
 - Habitat-sim and Habitat-api installation.
-- Download the Matterport 3D **scene dataset** and **task dataset** and place them in the appropriate folders (relevant information in repository's [README](https://github.com/facebookresearch/habitat-api/blob/master/README.md)).
+- Download the Matterport 3D **scene dataset** and **task dataset** and place them in the appropriate folders (relevant information in repository's [README](https://github.com/facebookresearch/habitat-api/blob/main/README.md)).
 
 ---
 

--- a/habitat_baselines/rl/ddppo/ddp_utils.py
+++ b/habitat_baselines/rl/ddppo/ddp_utils.py
@@ -24,7 +24,7 @@ SAVE_STATE.clear()
 DEFAULT_PORT = 8738
 DEFAULT_PORT_RANGE = 127
 # Default address of world rank 0
-DEFAULT_MASTER_ADDR = "127.0.0.1"
+DEFAULT_MAIN_ADDR = "127.0.0.1"
 
 SLURM_JOBID = os.environ.get("SLURM_JOB_ID", None)
 RESUME_STATE_BASE_NAME = ".habitat-resume-state"
@@ -252,15 +252,15 @@ def init_distrib_slurm(
 
     local_rank, world_rank, world_size = get_distrib_size()
 
-    master_port = int(os.environ.get("MASTER_PORT", DEFAULT_PORT))
+    main_port = int(os.environ.get("MAIN_PORT", DEFAULT_PORT))
     if SLURM_JOBID is not None:
-        master_port += int(SLURM_JOBID) % int(
-            os.environ.get("MASTER_PORT_RANGE", DEFAULT_PORT_RANGE)
+        main_port += int(SLURM_JOBID) % int(
+            os.environ.get("MAIN_PORT_RANGE", DEFAULT_PORT_RANGE)
         )
-    master_addr = os.environ.get("MASTER_ADDR", DEFAULT_MASTER_ADDR)
+    main_addr = os.environ.get("MAIN_ADDR", DEFAULT_MAIN_ADDR)
 
     tcp_store = distrib.TCPStore(  # type: ignore
-        master_addr, master_port, world_size, world_rank == 0
+        main_addr, main_port, world_size, world_rank == 0
     )
     distrib.init_process_group(
         backend, store=tcp_store, rank=world_rank, world_size=world_size

--- a/habitat_baselines/rl/ddppo/multi_node_slurm.sh
+++ b/habitat_baselines/rl/ddppo/multi_node_slurm.sh
@@ -15,8 +15,8 @@
 export GLOG_minloglevel=2
 export MAGNUM_LOG=quiet
 
-MASTER_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)
-export MASTER_ADDR
+MAIN_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)
+export MAIN_ADDR
 
 set -x
 srun python -u -m habitat_baselines.run \

--- a/habitat_baselines/slambased/monodepth.py
+++ b/habitat_baselines/slambased/monodepth.py
@@ -11,7 +11,7 @@ Junjie Hu and Mete Ozay and Yan Zhang and Takayuki Okatani
 WACV 2019
 
 ResNet code gently borrowed from
-https://github.com/pytorch/vision/blob/master/torchvision/models/py
+https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py
 """
 
 

--- a/scripts/generate_profile_shell_scripts.py
+++ b/scripts/generate_profile_shell_scripts.py
@@ -212,8 +212,8 @@ fi
 #SBATCH --open-mode=append
 export GLOG_minloglevel=2
 export MAGNUM_LOG=quiet
-MASTER_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)
-export MASTER_ADDR
+MAIN_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)
+export MAIN_ADDR
 set -x
 srun bash capture_profile_slurm_task.sh
 """


### PR DESCRIPTION
## Motivation and Context
To support master => main renaming github wide:  Renamed references from master to main in docs and  for DDPPO master address.

****Warning**: training scripts may stop working you may need to `export MASTER_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)` to `export MAIN_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)`**

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
