### PR TITLE
Adding tb folder to .gitignore to avoid pushing Tensorboard artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ data
 
 # vim
 *.swp
+
+# Tensorboard files
+tb/


### PR DESCRIPTION
## Motivation and Context

When running the training command `python -u habitat_baselines/run.py` with habitat-baselines, TensorBoard will create and store artifacts in the `tb` folder by default. This change adds the `tb` folder to `.gitignore`

## How Has This Been Tested

made sure that files in `tb` were ignored by git

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
