### PR TITLE
ForcePenalty can only be positive

### DIFF
--- a/habitat/tasks/rearrange/rearrange_sensors.py
+++ b/habitat/tasks/rearrange/rearrange_sensors.py
@@ -679,8 +679,11 @@ class RearrangeReward(Measure):
         force_metric = self._task.measurements.measures[RobotForce.cls_uuid]
         # Penalize the force that was added to the accumulated force at the
         # last time step.
-        reward -= min(
-            self._config.FORCE_PEN * force_metric.add_force,
-            self._config.MAX_FORCE_PEN,
+        reward -= max(
+            0,
+            min(
+                self._config.FORCE_PEN * force_metric.add_force,
+                self._config.MAX_FORCE_PEN,
+            ),
         )
         return reward


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

when trying to train DDPPO with the command 
```
 habitat_baselines/run.py --exp-config habitat_baselines/config/rearrange/ddppo_pick.yaml --run-type train
 ```
The force of the robot becomes very high and the agent sometimes receives rewards a lot larger than what should be possible (maximum reward should be <100 but is over 10,000 at times). My hypothesis is that the robot is able to exploit the force penalty (obtaining a negative penalty (reward) for decreasing the amount of force used).

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
I launched a training session and the reward remained under 100 consistently.
The Agent still does not train, more work is needed.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
