### PR TITLE
Flattening some of the rearrange sensors observations

### DIFF
--- a/habitat/tasks/rearrange/rearrange_sensors.py
+++ b/habitat/tasks/rearrange/rearrange_sensors.py
@@ -64,8 +64,7 @@ class AbsObjectGoalPositionSensor(MultiObjSensor):
         idxs, _ = self._sim.get_targets()
         scene_pos = self._sim.get_scene_pos()
         pos = scene_pos[idxs]
-
-        return pos
+        return np.hstack(pos)
 
 
 @registry.register_sensor
@@ -135,7 +134,7 @@ class AbsTargetStartSensor(MultiObjSensor):
 
     def get_observation(self, observations, episode, *args, **kwargs):
         pos = self._sim.get_target_objs_start()
-        return pos
+        return np.hstack(pos)
 
 
 @registry.register_sensor
@@ -153,7 +152,7 @@ class GoalSensor(MultiObjSensor):
         _, pos = self._sim.get_targets()
         for i in range(pos.shape[0]):
             pos[i] = T_inv.transform_point(pos[i])
-        return pos
+        return np.hstack(pos)
 
 
 @registry.register_sensor
@@ -162,7 +161,7 @@ class AbsGoalSensor(MultiObjSensor):
 
     def get_observation(self, *args, observations, episode, **kwargs):
         _, pos = self._sim.get_targets()
-        return pos
+        return np.hstack(pos)
 
 
 @registry.register_sensor

--- a/habitat/tasks/rearrange/rearrange_sensors.py
+++ b/habitat/tasks/rearrange/rearrange_sensors.py
@@ -64,7 +64,7 @@ class AbsObjectGoalPositionSensor(MultiObjSensor):
         idxs, _ = self._sim.get_targets()
         scene_pos = self._sim.get_scene_pos()
         pos = scene_pos[idxs]
-        return np.hstack(pos)
+        return [coordinate for position in pos for coordinate in position]
 
 
 @registry.register_sensor
@@ -134,7 +134,7 @@ class AbsTargetStartSensor(MultiObjSensor):
 
     def get_observation(self, observations, episode, *args, **kwargs):
         pos = self._sim.get_target_objs_start()
-        return np.hstack(pos)
+        return [coordinate for position in pos for coordinate in position]
 
 
 @registry.register_sensor
@@ -152,7 +152,7 @@ class GoalSensor(MultiObjSensor):
         _, pos = self._sim.get_targets()
         for i in range(pos.shape[0]):
             pos[i] = T_inv.transform_point(pos[i])
-        return np.hstack(pos)
+        return [coordinate for position in pos for coordinate in position]
 
 
 @registry.register_sensor
@@ -161,7 +161,7 @@ class AbsGoalSensor(MultiObjSensor):
 
     def get_observation(self, *args, observations, episode, **kwargs):
         _, pos = self._sim.get_targets()
-        return np.hstack(pos)
+        return [coordinate for position in pos for coordinate in position]
 
 
 @registry.register_sensor


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The sensors inheriting from `MultiObjSensor` need to provide 1D observations of shape `(n_targets * 3,)`. Currently, some sensors return a list of list of floats which is a 2D observation. To fix this, we use `np.hstack` to flatten the observation to 1D before returning it.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Tried running a configuration with one of the sensors. Unit tests. No new unit tests added.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
