### PR TITLE
final_space in resnet_policy must always be at least 1

### DIFF
--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -140,8 +140,8 @@ class ResNetEncoder(nn.Module):
             input_channels = self._n_input_depth + self._n_input_rgb
             self.backbone = make_backbone(input_channels, baseplanes, ngroups)
 
-            final_spatial = int(
-                spatial_size * self.backbone.final_spatial_compress
+            final_spatial = max(
+                1, int(spatial_size * self.backbone.final_spatial_compress)
             )
             after_compression_flat_size = 2048
             num_compression_channels = int(


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

When running the command 

```
habitat_baselines/run.py --exp-config habitat_baselines/config/rearrange/ddppo_reach_state.yaml --run-type train NUM_ENVIRONMENTS 1
```
I get the following error
```
Traceback (most recent call last):
  File "habitat_baselines/run.py", line 81, in <module>
    main()
  File "habitat_baselines/run.py", line 40, in main
    run_exp(**vars(args))
  File "habitat_baselines/run.py", line 77, in run_exp
    execute_exp(config, run_type)
  File "habitat_baselines/run.py", line 60, in execute_exp
    trainer.train()
  File "/opt/homebrew/Cellar/python37/3.7.5_3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 74, in inner
    return func(*args, **kwds)
  File "/Users/vincentpierre/Documents/habitat-lab/habitat_baselines/rl/ppo/ppo_trainer.py", line 724, in train
    self._init_train()
  File "/Users/vincentpierre/Documents/habitat-lab/habitat_baselines/rl/ppo/ppo_trainer.py", line 282, in _init_train
    self._setup_actor_critic_agent(ppo_cfg)
  File "/Users/vincentpierre/Documents/habitat-lab/habitat_baselines/rl/ppo/ppo_trainer.py", line 140, in _setup_actor_critic_agent
    self.config, observation_space, self.policy_action_space
  File "/Users/vincentpierre/Documents/habitat-lab/habitat_baselines/rl/ddppo/policy/resnet_policy.py", line 102, in from_config
    fuse_keys=config.RL.get("GYM_OBS_KEYS", None),
  File "/Users/vincentpierre/Documents/habitat-lab/habitat_baselines/rl/ddppo/policy/resnet_policy.py", line 79, in __init__
    fuse_keys=fuse_keys,
  File "/Users/vincentpierre/Documents/habitat-lab/habitat_baselines/rl/ddppo/policy/resnet_policy.py", line 341, in __init__
    normalize_visual_inputs=normalize_visual_inputs,
  File "/Users/vincentpierre/Documents/habitat-lab/habitat_baselines/rl/ddppo/policy/resnet_policy.py", line 148, in __init__
    round(after_compression_flat_size / (final_spatial ** 2))
ZeroDivisionError: division by zero
```

It seems that `final_space` can be 0. Which raises this error.
The task `reach_state.yaml` actually has a [HEAD_DEPTH_SENSOR](https://github.com/facebookresearch/habitat-lab/blob/hab_suite_dev/configs/tasks/rearrange/reach_state.yaml#L71) :
```
    HEAD_DEPTH_SENSOR:
        WIDTH: 32
        HEIGHT: 32
        MIN_DEPTH: 0.0
        MAX_DEPTH: 10.0
        NORMALIZE_DEPTH: True
```
I assume that because the size of the input is only 32 x 32, the final_space reaches 0.

`spacial_size` = 32 // 2 = 16
`self.backbone.final_spatial_compress` = 0.03125 
`final_space` = round (16 * 0.03125) = round(0.5) = 0


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
made the change and fixed the error. I am not familiar with the code base, so I am not sure if using a `max` here is appropriate.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
