### PR TITLE
Making ddppo_reach_state work out of the box

### DIFF
--- a/habitat_baselines/config/rearrange/ddppo_reach_state.yaml
+++ b/habitat_baselines/config/rearrange/ddppo_reach_state.yaml
@@ -7,7 +7,7 @@ TENSORBOARD_DIR: "tb"
 VIDEO_DIR: "video_dir"
 TEST_EPISODE_COUNT: -1
 EVAL_CKPT_PATH_DIR: "data/new_checkpoints"
-NUM_ENVIRONMENTS: 1
+NUM_ENVIRONMENTS: 4
 # Visual sensors to include
 SENSORS: ["HEAD_DEPTH_SENSOR"]
 CHECKPOINT_FOLDER: "data/new_checkpoints"
@@ -39,7 +39,7 @@ RL:
     # ppo params
     clip_param: 0.2
     ppo_epoch: 2
-    num_mini_batch: 1
+    num_mini_batch: 2
     value_loss_coef: 0.5
     entropy_coef: 0.01
     lr: 2.5e-4

--- a/habitat_baselines/config/rearrange/ddppo_reach_state.yaml
+++ b/habitat_baselines/config/rearrange/ddppo_reach_state.yaml
@@ -7,7 +7,7 @@ TENSORBOARD_DIR: "tb"
 VIDEO_DIR: "video_dir"
 TEST_EPISODE_COUNT: -1
 EVAL_CKPT_PATH_DIR: "data/new_checkpoints"
-NUM_ENVIRONMENTS: 4
+NUM_ENVIRONMENTS: 1
 # Visual sensors to include
 SENSORS: ["HEAD_DEPTH_SENSOR"]
 CHECKPOINT_FOLDER: "data/new_checkpoints"
@@ -39,7 +39,7 @@ RL:
     # ppo params
     clip_param: 0.2
     ppo_epoch: 2
-    num_mini_batch: 2
+    num_mini_batch: 1
     value_loss_coef: 0.5
     entropy_coef: 0.01
     lr: 2.5e-4


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Running the command

```
habitat_baselines/run.py --exp-config habitat_baselines/config/rearrange/ddppo_reach_state.yaml --run-type train
```
 will raise an error : 
```
RuntimeError: reduce the number of environments as there aren't enough number of scenes.
num_environments: 4	num_scenes: 1
```
Setting the number of environments to 1 as suggested will raise the error 
```
AssertionError: Trainer requires the number of environments (1) to be greater than or equal to the number of trainer mini batches (2).
```
This PR sets both the number of environments and the number of mini batches to 1 allowing training to happen.

**IMPORTANT**
Is there a better solution? Is it possible to have several environments using the same scene to allow for faster training?


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Error no longer happens

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
