### PR TITLE
Made tensorboard metrics and losses each appear in their own graph

### DIFF
--- a/habitat_baselines/il/trainers/eqa_cnn_pretrain_trainer.py
+++ b/habitat_baselines/il/trainers/eqa_cnn_pretrain_trainer.py
@@ -148,12 +148,10 @@ class EQACNNPretrainTrainer(BaseILTrainer):
                             )
                         )
 
-                        writer.add_scalar("total_loss", loss, t)
-                        writer.add_scalars(
-                            "individual_losses",
-                            {"seg_loss": l1, "ae_loss": l2, "depth_loss": l3},
-                            t,
-                        )
+                        writer.add_scalar("loss/total_loss", loss, t)
+                        writer.add_scalar("loss/seg_loss", l1, t)
+                        writer.add_scalar("loss/ae_loss", l2, t)
+                        writer.add_scalar("loss/depth_loss", l3, t)
 
                     loss.backward()
                     optim.step()
@@ -283,12 +281,12 @@ class EQACNNPretrainTrainer(BaseILTrainer):
         avg_l2 /= len(eval_loader)
         avg_l3 /= len(eval_loader)
 
-        writer.add_scalar("avg val total loss", avg_loss, checkpoint_index)
-        writer.add_scalars(
-            "avg val individual_losses",
-            {"seg_loss": avg_l1, "ae_loss": avg_l2, "depth_loss": avg_l3},
-            checkpoint_index,
+        writer.add_scalar(
+            "avg_val_loss/total_loss", avg_loss, checkpoint_index
         )
+        writer.add_scalar("avg_val_loss/seg_loss", avg_l1, checkpoint_index)
+        writer.add_scalar("avg_val_loss/ae_loss", avg_l2, checkpoint_index)
+        writer.add_scalar("avg_val_loss/depth_loss", avg_l3, checkpoint_index)
 
         logger.info("[ Average loss: {:.3f} ]".format(avg_loss))
         logger.info("[ Average seg loss: {:.3f} ]".format(avg_l1))


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

When using TensorBoard with Habitat Lab, I noticed that all the metrics were in the same "metrics" graph. I think it will be a better user experience if all metrics had their own graph. This should make it easier to compare runs since by selecting a single run in the left menu, all associated metrics will appear (with a single color). See the two screenshots for a comparison 

BEFORE : 
<img width="1786" alt="tb_old" src="https://user-images.githubusercontent.com/28320361/148870184-7e948a1a-509e-4d7d-bcfd-2e1c246706d9.png">
AFTER : 
<img width="1331" alt="tb_new" src="https://user-images.githubusercontent.com/28320361/148870195-f5d9f228-14bc-4d0b-bebf-70e659644537.png">

EDIT : Also added entropy to the losses, I think it is useful for PPO to see the evolution of entropy during training

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

Unit tests and launched a few runs.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- refactoring

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
