### PR TITLE
Removing python_lint since pre-commit does more and has specified linter versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,32 +7,6 @@ gpu: &gpu
     FPS_THRESHOLD: 900
 
 jobs:
-  python_lint:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run:
-          name: setup
-          command: |
-              sudo pip install black flake8 flake8-builtins flake8-bugbear flake8-comprehensions flake8-return flake8-simplify "isort[pyproject]" numpy --progress-bar off
-              sudo pip install -r requirements.txt --progress-bar off
-      - run:
-          name: run black
-          command: |
-              black --exclude '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)|examples/tutorials/(colabs|nb_python)' habitat/. habitat_baselines/. examples/. test/. setup.py --diff
-              black --exclude '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)|examples/tutorials/(colabs|nb_python)' habitat/. habitat_baselines/. examples/. test/. setup.py --check
-      - run:
-          name: run isort
-          command: |
-              isort --version
-              isort habitat/. habitat_baselines/. examples/. test/. setup.py --diff
-              isort habitat/. habitat_baselines/. examples/. test/. setup.py --check-only
-      - run:
-          name: run flake8
-          command: |
-              flake8 --version
-              flake8 habitat/. habitat_baselines/. examples/. tests/. setup.py
   pre-commit:
     docker:
       - image: circleci/python:3.6
@@ -277,5 +251,4 @@ workflows:
   install_and_test:
     jobs:
       - pre-commit
-      - python_lint
       - install_and_test_ubuntu


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The python_lint test does not have fixed versions. When a new version of a linter like flake8 has a new version, the new linter will find issues that were not previously there. This is a bad user experience for contributors. Since pre-commit already performs linter checks and has fixed versions, I propose to remove python_lint test from circleci. pre-commit will still catch linting errors. 

For context, see https://cvmlp.slack.com/archives/CFN5TAUSD/p1641836958004800

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
N/A

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
