### PR TITLE
Hab suite dev fix pick

### DIFF
--- a/configs/tasks/rearrange/pick.yaml
+++ b/configs/tasks/rearrange/pick.yaml
@@ -72,8 +72,8 @@ TASK:
         TYPE: "RearrangePickReward"
         DIST_REWARD: 20.0
         SUCC_REWARD: 10.0
-        PICK_REWARD: 5.0
-        DROP_PEN: 20.0
+        PICK_REWARD: 20.0
+        DROP_PEN: 5.0
         WRONG_PICK_PEN: 5.0
         USE_DIFF: True
         DROP_OBJ_SHOULD_END: True

--- a/configs/tasks/rearrange/pick.yaml
+++ b/configs/tasks/rearrange/pick.yaml
@@ -1,5 +1,5 @@
 ENVIRONMENT:
-    MAX_EPISODE_STEPS: 100
+    MAX_EPISODE_STEPS: 200
 DATASET:
     TYPE: RearrangeDataset-v0
     SPLIT: train
@@ -72,18 +72,18 @@ TASK:
         TYPE: "RearrangePickReward"
         DIST_REWARD: 20.0
         SUCC_REWARD: 10.0
-        PICK_REWARD: 20.0
-        DROP_PEN: 5.0
+        PICK_REWARD: 5.0
+        DROP_PEN: 20.0
         WRONG_PICK_PEN: 5.0
         USE_DIFF: True
-        DROP_OBJ_SHOULD_END: False
-        WRONG_PICK_SHOULD_END: False
+        DROP_OBJ_SHOULD_END: True
+        WRONG_PICK_SHOULD_END: True
 
         # General Rearrange Reward config
         CONSTRAINT_VIOLATE_PEN: 10.0
-        FORCE_PEN: 0.0
-        MAX_FORCE_PEN: 0.0
-        FORCE_END_PEN: 0.0
+        FORCE_PEN: 0.001
+        MAX_FORCE_PEN: 1.0
+        FORCE_END_PEN: 10.0
 
 
     PICK_SUCCESS:
@@ -104,7 +104,7 @@ TASK:
         ARM_ACTION:
             TYPE: "ArmAction"
             ARM_CONTROLLER: "ArmRelPosAction"
-            GRIP_CONTROLLER: "SuctionGraspAction"
+            GRIP_CONTROLLER: "MagicGraspAction"
             ARM_JOINT_DIMENSIONALITY: 7
             GRASP_THRESH_DIST: 0.15
             DISABLE_GRIP: False

--- a/configs/tasks/rearrange/pick.yaml
+++ b/configs/tasks/rearrange/pick.yaml
@@ -1,5 +1,5 @@
 ENVIRONMENT:
-    MAX_EPISODE_STEPS: 200
+    MAX_EPISODE_STEPS: 100
 DATASET:
     TYPE: RearrangeDataset-v0
     SPLIT: train
@@ -15,7 +15,7 @@ TASK:
     # In radians
     BASE_ANGLE_NOISE: 0.15
     BASE_NOISE: 0.05
-    CONSTRAINT_VIOLATION_ENDS_EPISODE: True
+    CONSTRAINT_VIOLATION_ENDS_EPISODE: False
     FORCE_REGENERATE: False
 
     # Measurements for composite tasks.
@@ -57,7 +57,7 @@ TASK:
         MIN_FORCE: 20.0
     EXCESSIVE_FORCE_SHOULD_END:
         TYPE: "ForceTerminate"
-        MAX_ACCUM_FORCE: 5000.0
+        MAX_ACCUM_FORCE: 0.0
     ROBOT_COLLS:
         TYPE: "RobotCollisions"
     OBJECT_TO_GOAL_DISTANCE:
@@ -76,14 +76,14 @@ TASK:
         DROP_PEN: 5.0
         WRONG_PICK_PEN: 5.0
         USE_DIFF: True
-        DROP_OBJ_SHOULD_END: True
-        WRONG_PICK_SHOULD_END: True
+        DROP_OBJ_SHOULD_END: False
+        WRONG_PICK_SHOULD_END: False
 
         # General Rearrange Reward config
         CONSTRAINT_VIOLATE_PEN: 10.0
-        FORCE_PEN: 0.001
-        MAX_FORCE_PEN: 1.0
-        FORCE_END_PEN: 10.0
+        FORCE_PEN: 0.0
+        MAX_FORCE_PEN: 0.0
+        FORCE_END_PEN: 0.0
 
 
     PICK_SUCCESS:
@@ -104,7 +104,7 @@ TASK:
         ARM_ACTION:
             TYPE: "ArmAction"
             ARM_CONTROLLER: "ArmRelPosAction"
-            GRIP_CONTROLLER: "MagicGraspAction"
+            GRIP_CONTROLLER: "SuctionGraspAction"
             ARM_JOINT_DIMENSIONALITY: 7
             GRASP_THRESH_DIST: 0.15
             DISABLE_GRIP: False
@@ -151,6 +151,8 @@ SIMULATOR:
     ROBOT_URDF: ./data/robots/hab_fetch/robots/hab_fetch.urdf
     ROBOT_TYPE: "FetchRobot"
     FORWARD_STEP_SIZE: 0.25
+    AUTO_SLEEP: False
+    CONCUR_RENDER: False
 
     # Grasping
     HOLD_THRESH: 0.09

--- a/configs/tasks/rearrange/pick.yaml
+++ b/configs/tasks/rearrange/pick.yaml
@@ -15,7 +15,7 @@ TASK:
     # In radians
     BASE_ANGLE_NOISE: 0.15
     BASE_NOISE: 0.05
-    CONSTRAINT_VIOLATION_ENDS_EPISODE: False
+    CONSTRAINT_VIOLATION_ENDS_EPISODE: True
     FORCE_REGENERATE: False
 
     # Measurements for composite tasks.
@@ -57,7 +57,7 @@ TASK:
         MIN_FORCE: 20.0
     EXCESSIVE_FORCE_SHOULD_END:
         TYPE: "ForceTerminate"
-        MAX_ACCUM_FORCE: 0.0
+        MAX_ACCUM_FORCE: 5000.0
     ROBOT_COLLS:
         TYPE: "RobotCollisions"
     OBJECT_TO_GOAL_DISTANCE:
@@ -151,8 +151,6 @@ SIMULATOR:
     ROBOT_URDF: ./data/robots/hab_fetch/robots/hab_fetch.urdf
     ROBOT_TYPE: "FetchRobot"
     FORWARD_STEP_SIZE: 0.25
-    AUTO_SLEEP: False
-    CONCUR_RENDER: False
 
     # Grasping
     HOLD_THRESH: 0.09

--- a/habitat/tasks/rearrange/grip_actions.py
+++ b/habitat/tasks/rearrange/grip_actions.py
@@ -50,6 +50,7 @@ class MagicGraspAction(GripSimulatorTaskAction):
                 self._sim.grasp_mgr.snap_to_obj(
                     self._sim.scene_obj_ids[closest_obj_idx]
                 )
+                return
 
         # Get markers we are close to.
         markers = self._sim.get_all_markers()

--- a/habitat/tasks/rearrange/grip_actions.py
+++ b/habitat/tasks/rearrange/grip_actions.py
@@ -59,7 +59,7 @@ class MagicGraspAction(GripSimulatorTaskAction):
             pos = np.array([markers[k].get_current_position() for k in names])
 
             closest_idx = np.argmin(
-                np.linalg.norm(scene_obj_pos - ee_pos, ord=2, axis=-1)
+                np.linalg.norm(pos - ee_pos, ord=2, axis=-1)
             )
 
             to_target = np.linalg.norm(ee_pos - pos[closest_idx], ord=2)

--- a/habitat/tasks/rearrange/sub_tasks/pick_sensors.py
+++ b/habitat/tasks/rearrange/sub_tasks/pick_sensors.py
@@ -111,7 +111,11 @@ class RearrangePickReward(RearrangeReward):
                 if self._config.WRONG_PICK_SHOULD_END:
                     self._task.should_end = True
                 self._metric = reward
+                self._task.prev_picked = cur_picked
+                self._prev_picked = self._sim.grasp_mgr.snap_idx is not None
+                self.cur_dist = -1
                 return
+
 
         if self._config.USE_DIFF:
             if self.cur_dist < 0:
@@ -132,6 +136,9 @@ class RearrangePickReward(RearrangeReward):
             if self._config.DROP_OBJ_SHOULD_END:
                 self._task.should_end = True
             self._metric = reward
+            self._task.prev_picked = cur_picked
+            self._prev_picked = self._sim.grasp_mgr.snap_idx is not None
+            self.cur_dist = -1
             return
 
         self._task.prev_picked = cur_picked

--- a/habitat/tasks/rearrange/sub_tasks/pick_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/pick_task.py
@@ -124,8 +124,8 @@ class RearrangePickTaskV1(RearrangeTask):
     def _should_prevent_grip(self, action_args):
         return (
             self._sim.grasp_mgr.is_grasped
-            and action_args.get("grip_ac", None) is not None
-            and action_args["grip_ac"] <= 0
+            and action_args.get("grip_action", None) is not None
+            and action_args["grip_action"] <= 0
         )
 
     def step(self, action, episode):
@@ -133,7 +133,7 @@ class RearrangePickTaskV1(RearrangeTask):
 
         if self._should_prevent_grip(action_args):
             # No releasing the object once it is held.
-            action_args["grip_ac"] = None
+            action_args["grip_action"] = None
         obs = super().step(action=action, episode=episode)
 
         return obs

--- a/habitat_baselines/config/rearrange/ddppo_pick.yaml
+++ b/habitat_baselines/config/rearrange/ddppo_pick.yaml
@@ -9,7 +9,7 @@ TENSORBOARD_DIR: "tb"
 VIDEO_DIR: "video_dir"
 TEST_EPISODE_COUNT: -1
 EVAL_CKPT_PATH_DIR: "data/new_checkpoints"
-NUM_ENVIRONMENTS: 4
+NUM_ENVIRONMENTS: 32
 WRITER_TYPE: 'tb'
 # Visual sensors to include
 SENSORS: ["HEAD_DEPTH_SENSOR"]
@@ -29,6 +29,8 @@ RL:
   POLICY:
       name: "PointNavResNetPolicy"
       action_distribution_type: "gaussian"
+      ACTION_DIST:
+         use_log_std: True
 
   REWARD_MEASURE: "rearrangepick_reward"
   SUCCESS_MEASURE: "rearrangepick_success"
@@ -42,7 +44,7 @@ RL:
     ppo_epoch: 2
     num_mini_batch: 2
     value_loss_coef: 0.5
-    entropy_coef: 0.01
+    entropy_coef: 0.0001
     lr: 2.5e-4
     eps: 1e-5
     max_grad_norm: 0.2

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -638,7 +638,7 @@ def action_array_to_dict(
     action_args = {}
     action_offset = 0
     for action_name, action_length in action_name_to_lengths.items():
-        action_values = action[action_offset:action_length]
+        action_values = action[action_offset : action_offset + action_length]
         if clip:
             action_values = np.clip(
                 action_values.detach().cpu().numpy(), -1.0, 1.0


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The ddppo_pick.yaml task does not train properly currently on hab_suite_dev. This change makes the environment trainable.
The biggest changes include : 
 - Changes to the code of the sensors to handle episodes that do not end when the wrong object is picked or when an object is dropped
 - Make the episode not end with excessive force (The forces can quickly become very large and I suspect it makes exploration too hard)
 - Changes to the entropy coefficient and initialization of the Gaussian Distribution.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
The top curve is with the changes, and the bottom one without.

<img width="722" alt="Screen Shot 2022-01-18 at 08 40 05" src="https://user-images.githubusercontent.com/28320361/149980181-cc4ddd61-fba2-4f4e-b920-c6da50178e40.png">

