### PR TITLE
Making resnet work for non-square visual inputs

### DIFF
--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -150,10 +150,12 @@ class ResNetEncoder(nn.Module):
             final_spatial_w = int(
                 np.ceil(spatial_size_w * self.backbone.final_spatial_compress)
             )
-
             after_compression_flat_size = 2048
             num_compression_channels = int(
-                round(after_compression_flat_size / (final_spatial_h * final_spatial_w))
+                round(
+                    after_compression_flat_size
+                    / (final_spatial_h * final_spatial_w)
+                )
             )
             self.compression = nn.Sequential(
                 nn.Conv2d(

--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -153,7 +153,7 @@ class ResNetEncoder(nn.Module):
 
             after_compression_flat_size = 2048
             num_compression_channels = int(
-                round(after_compression_flat_size / (final_spatial_h ** 2))
+                round(after_compression_flat_size / (final_spatial_h * final_spatial_w))
             )
             self.compression = nn.Sequential(
                 nn.Conv2d(

--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -134,18 +134,26 @@ class ResNetEncoder(nn.Module):
             self.running_mean_and_var = nn.Sequential()
 
         if not self.is_blind:
-            # We assume that all image observations have same height and width
             all_keys = self.rgb_keys + self.depth_keys
-            spatial_size = observation_space.spaces[all_keys[0]].shape[0] // 2
+            spatial_size_h = (
+                observation_space.spaces[all_keys[0]].shape[0] // 2
+            )
+            spatial_size_w = (
+                observation_space.spaces[all_keys[0]].shape[1] // 2
+            )
             input_channels = self._n_input_depth + self._n_input_rgb
             self.backbone = make_backbone(input_channels, baseplanes, ngroups)
 
-            final_spatial = max(
-                1, int(spatial_size * self.backbone.final_spatial_compress)
+            final_spatial_h = int(
+                np.ceil(spatial_size_h * self.backbone.final_spatial_compress)
             )
+            final_spatial_w = int(
+                np.ceil(spatial_size_w * self.backbone.final_spatial_compress)
+            )
+
             after_compression_flat_size = 2048
             num_compression_channels = int(
-                round(after_compression_flat_size / (final_spatial ** 2))
+                round(after_compression_flat_size / (final_spatial_h ** 2))
             )
             self.compression = nn.Sequential(
                 nn.Conv2d(
@@ -161,8 +169,8 @@ class ResNetEncoder(nn.Module):
 
             self.output_shape = (
                 num_compression_channels,
-                final_spatial,
-                final_spatial,
+                final_spatial_h,
+                final_spatial_w,
             )
 
     @property

--- a/test/test_baseline_resnet.py
+++ b/test/test_baseline_resnet.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+try:
+    import torch
+    import torch.distributed
+    from gym import spaces
+
+    from habitat_baselines.rl.ddppo.policy.resnet import resnet18, resnet50
+    from habitat_baselines.rl.ddppo.policy.resnet_policy import ResNetEncoder
+
+    baseline_installed = True
+except ImportError:
+    baseline_installed = False
+
+
+def _npobs_dict_to_tensorobs_dict(npobs_dict):
+    result = {}
+    for k, v in npobs_dict.items():
+        result[k] = torch.as_tensor(v).unsqueeze(0)
+    return result
+
+
+@pytest.mark.skipif(
+    not baseline_installed, reason="baseline sub-module not installed"
+)
+@pytest.mark.parametrize(
+    "observation_space",
+    [
+        spaces.Dict(
+            {
+                "rgb_1": spaces.Box(low=0, high=1, shape=(62, 30, 3)),
+                "rgb_2": spaces.Box(low=0, high=1, shape=(62, 30, 2)),
+            },
+        ),
+        spaces.Dict(
+            {
+                "rgb_1": spaces.Box(low=0, high=1, shape=(63, 84, 1)),
+                "depth_1": spaces.Box(low=0, high=1, shape=(63, 84, 2)),
+            },
+        ),
+        spaces.Dict(
+            {
+                "rgb_1": spaces.Box(low=0, high=1, shape=(64, 128, 3)),
+            },
+        ),
+        spaces.Dict(
+            {
+                "rgb_1": spaces.Box(low=0, high=1, shape=(65, 30, 3)),
+                "rgb_2": spaces.Box(low=0, high=1, shape=(65, 30, 1)),
+                "depth_1": spaces.Box(low=0, high=1, shape=(65, 30, 2)),
+            },
+        ),
+        spaces.Dict(
+            {
+                "rgb_1": spaces.Box(low=0, high=1, shape=(66, 64, 3)),
+                "depth_2": spaces.Box(low=0, high=1, shape=(66, 64, 2)),
+            },
+        ),
+    ],
+)
+@pytest.mark.parametrize("backbone", [resnet18, resnet50])
+def test_resnetencoder_initialization(observation_space, backbone):
+    encoder = ResNetEncoder(observation_space, make_backbone=backbone)
+    obs = observation_space.sample()
+    t_obs = _npobs_dict_to_tensorobs_dict(obs)
+    out = encoder.forward(t_obs)
+    assert out.shape == (1, *encoder.output_shape)


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

I was testing some tasks where the width and height of the image were not the same (it is the case in the default config for instance).
I believe this change makes the output_shape non-square which is more general.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
