### PR TITLE
Fixing robot spawning for pick task           

### DIFF
--- a/habitat/tasks/rearrange/sub_tasks/pick_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/pick_task.py
@@ -63,6 +63,12 @@ class RearrangePickTaskV1(RearrangeTask):
         state = sim.capture_state()
         start_pos = orig_start_pos
 
+        # Spawn 30 cm away from the target
+        rel_targ = targ_pos - start_pos
+        rel_targ[1] = 0
+        rel_targ /= np.linalg.norm(rel_targ)
+        start_pos -= rel_targ * 0.3
+
         forward = np.array([1.0, 0, 0])
         dist_thresh = 0.1
         did_collide = False
@@ -76,7 +82,6 @@ class RearrangePickTaskV1(RearrangeTask):
             start_pos = orig_start_pos + np.random.normal(
                 0, self._config.BASE_NOISE, size=(3,)
             )
-
             rel_targ = targ_pos - start_pos
             angle_to_obj = get_angle(forward[[0, 2]], rel_targ[[0, 2]])
             if np.cross(forward[[0, 2]], rel_targ[[0, 2]]) > 0:
@@ -173,7 +178,7 @@ class RearrangePickTaskV1(RearrangeTask):
                     start_pos = (
                         receptacle_ao.translation
                         + receptacle_ao.rotation.transform_vector(
-                            np.array([0.5, 0, 0])
+                            np.array([0.1, 0, 0])
                         )
                     )
                     start_pos = np.array(start_pos)


### PR DESCRIPTION
Modifying the robots spawning so it spawns a little further away from the receptable (30 com) so that the robot arm does not spawn into the fridge

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
