### PR TITLE
Adapt to m.css updates in the sim repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
               curl -s https://aihabitat.org/docs/habitat-sim/objects.inv > ../habitat-sim/build/docs-public/habitat-sim/objects.inv
 
               cd docs
-              conda install -y -c conda-forge doxygen==1.8.16
+              conda install -y -c conda-forge doxygen
               conda install -y  jinja2 pygments docutils
               mkdir -p ../build/docs
               ./build-public.sh


### PR DESCRIPTION
## Motivation and Context

Final counterpart to corresponding sim and website PRs. The m.css submodule is updated in an already-merged PR the sim repository and thus it should no longer be needed to rely on an ancient Doxygen here either.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
