### PR TITLE
[bugfix] - Apply AO instance uniform scale to Receptacles

### DIFF
--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -1045,8 +1045,7 @@ class PPOTrainer(BaseRLTrainer):
                 # episode ended
                 if not not_done_masks[i].item():
                     pbar.update()
-                    episode_stats = dict()
-                    episode_stats["reward"] = current_episode_reward[i].item()
+                    episode_stats = {"reward" : current_episode_reward[i].item()}
                     episode_stats.update(
                         self._extract_scalars_from_info(infos[i])
                     )

--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -1045,7 +1045,7 @@ class PPOTrainer(BaseRLTrainer):
                 # episode ended
                 if not not_done_masks[i].item():
                     pbar.update()
-                    episode_stats = {}
+                    episode_stats = dict()
                     episode_stats["reward"] = current_episode_reward[i].item()
                     episode_stats.update(
                         self._extract_scalars_from_info(infos[i])


### PR DESCRIPTION
## Motivation and Context

AO's have optional uniform scaling applied to instances upon load. This scale should be propagated to any Receptacles defined for the AO. 

## How Has This Been Tested

Locally in viewer.py

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
