### PR TITLE
Fixing typing annotation on gym.Env

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,17 @@ sys.path = [os.path.join(os.path.dirname(__file__), "../")] + sys.path
 
 import habitat  # isort:skip
 
+import gym  # isort:skip
+import typing  # isort:skip
+
+# Override the typing annotation of _np_random of gym.Env since the type provided is
+# "RandomNumberGenerator | None" and the "|" symbol for typing is not valid in Python <3.10
+# Remove when upgrading to Python 3.10
+gym.Env.__annotations__["_np_random"] = typing.Optional[
+    gym.utils.seeding.RandomNumberGenerator
+]
+
+
 # Overrides the __all__ as that one pulls everything into the root module
 # and doesn't expose any submodules
 habitat.__all__ = ["config", "core", "Agent", "Benchmark"]

--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -1045,8 +1045,9 @@ class PPOTrainer(BaseRLTrainer):
                 # episode ended
                 if not not_done_masks[i].item():
                     pbar.update()
-                    episode_stats = {}
-                    episode_stats["reward"] = current_episode_reward[i].item()
+                    episode_stats = {
+                        "reward": current_episode_reward[i].item()
+                    }
                     episode_stats.update(
                         self._extract_scalars_from_info(infos[i])
                     )


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

When building documentation, an error `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` will appear because gym.Env uses type annotations only valid in Python 3.10+ 

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Make sure CI passes all the tests!

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
