### PR TITLE
[gala_kinematic] Masking the loss for the first observation

### DIFF
--- a/habitat_baselines/config/rearrange/gala_kinematic_ddppo.yaml
+++ b/habitat_baselines/config/rearrange/gala_kinematic_ddppo.yaml
@@ -1,5 +1,5 @@
-TENSORBOARD_DIR: "data/ckpt/gala_kinematic_ddppo"
-CHECKPOINT_FOLDER: "data/ckpt/gala_kinematic_ddppo"
+TENSORBOARD_DIR: "/checkpoint/eundersander/gala_kinematic/tb/gala_kinematic_ddppo"
+CHECKPOINT_FOLDER: "/checkpoint/eundersander/gala_kinematic/ckpt/gala_kinematic_ddppo"
 VIDEO_DIR: "../videos"
 REWARD_SCALE: 0.01
 NUM_CHECKPOINTS: 0

--- a/habitat_baselines/config/rearrange/gala_kinematic_ddppo.yaml
+++ b/habitat_baselines/config/rearrange/gala_kinematic_ddppo.yaml
@@ -1,5 +1,5 @@
-TENSORBOARD_DIR: "/checkpoint/eundersander/gala_kinematic/tb/gala_kinematic_ddppo"
-CHECKPOINT_FOLDER: "/checkpoint/eundersander/gala_kinematic/ckpt/gala_kinematic_ddppo"
+TENSORBOARD_DIR: "data/ckpt/gala_kinematic_ddppo"
+CHECKPOINT_FOLDER: "data/ckpt/gala_kinematic_ddppo"
 VIDEO_DIR: "../videos"
 REWARD_SCALE: 0.01
 NUM_CHECKPOINTS: 0

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -86,6 +86,10 @@ class CustomNormal(torch.distributions.normal.Normal):
         ret = super().log_prob(actions).sum(-1).unsqueeze(-1)
         return ret
 
+    def entropy(self) -> Tensor:
+        ret = super().entropy().sum(-1).unsqueeze(-1)
+        return ret
+
 
 class GaussianNet(nn.Module):
     def __init__(


### PR DESCRIPTION
## Motivation and Context
Masking the losses using the mask in the rollout.
This mask corresponds to the first observation after a reset which needs to be discarded

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
