### PR TITLE
[ObsTransforms] Add support for semantic sensor observation transforms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,6 @@ repos:
     hooks:
     - id: black
       exclude: ^examples/tutorials/(nb_python|colabs)
-      additional_dependencies: ['click==8.0.4']
 
 -   repo: https://github.com/myint/autoflake
     rev: v1.4

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -203,8 +203,6 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
         # make semantic observation a 3D array
         if isinstance(obs, np.ndarray):
             obs = obs[..., None].astype(np.int32)
-        else:
-            obs = obs.unsqueeze(-1)
         return obs
 
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -200,7 +200,11 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
     ) -> VisualObservation:
         obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)
-        obs = obs[..., None].astype(np.int32)
+        # make semantic observation a 3D array
+        if isinstance(obs, np.ndarray):
+            obs = obs[..., None].astype(np.int32)
+        else:
+            obs = obs.unsqueeze(-1)
         return obs
 
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -196,7 +196,7 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
         )
 
     def get_observation(
-        self, sim_obs: Dict[str, Union[np.ndarray, bool, "Tensor"]]
+        self, sim_obs: Dict[str, Union[np.ndarray, bool, "Tensor", None]]
     ) -> VisualObservation:
         obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -200,13 +200,7 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
     ) -> VisualObservation:
         obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)
-        # make semantic observation a 3D array
-        if isinstance(obs, np.ndarray):
-            obs = np.expand_dims(
-                obs, axis=2
-            ).astype(np.int32)
-        else:
-            obs = obs.unsqueeze(-1)
+        obs = obs[..., None].astype(np.int32)
         return obs
 
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -203,6 +203,8 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
         # make semantic observation a 3D array
         if isinstance(obs, np.ndarray):
             obs = obs[..., None].astype(np.int32)
+        else:
+            obs = obs[..., None]
         return obs
 
 

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -196,7 +196,7 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
         )
 
     def get_observation(
-        self, sim_obs: Dict[str, Union[np.ndarray, bool, "Tensor", None]]
+        self, sim_obs: Dict[str, Union[np.ndarray, bool, "Tensor"]]
     ) -> VisualObservation:
         obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -191,8 +191,8 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
         return spaces.Box(
             low=np.iinfo(np.uint32).min,
             high=np.iinfo(np.uint32).max,
-            shape=(self.config.HEIGHT, self.config.WIDTH),
-            dtype=np.uint32,
+            shape=(self.config.HEIGHT, self.config.WIDTH, 1),
+            dtype=np.int32,
         )
 
     def get_observation(
@@ -200,6 +200,13 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
     ) -> VisualObservation:
         obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)
+        # make semantic observation a 3D array
+        if isinstance(obs, np.ndarray):
+            obs = np.expand_dims(
+                obs, axis=2
+            ).astype(np.int32)
+        else:
+            obs = obs.unsqueeze(-1)
         return obs
 
 

--- a/habitat_baselines/common/obs_transformers.py
+++ b/habitat_baselines/common/obs_transformers.py
@@ -84,6 +84,11 @@ class ResizeShortestEdge(ObservationTransformer):
         self._size: int = size
         self.channels_last: bool = channels_last
         self.trans_keys: Tuple[str, ...] = trans_keys
+        self.interpolation_mode = {
+            "rgb": "area",
+            "depth": "area",
+            "semantic": "nearest-exact",
+        }
 
     def transform_observation_space(
         self,
@@ -113,9 +118,9 @@ class ResizeShortestEdge(ObservationTransformer):
                     )
         return observation_space
 
-    def _transform_obs(self, obs: torch.Tensor) -> torch.Tensor:
+    def _transform_obs(self, obs: torch.Tensor, interpolation_mode: str) -> torch.Tensor:
         return image_resize_shortest_edge(
-            obs, self._size, channels_last=self.channels_last
+            obs, self._size, channels_last=self.channels_last, interpolation_mode=interpolation_mode
         )
 
     @torch.no_grad()
@@ -125,7 +130,7 @@ class ResizeShortestEdge(ObservationTransformer):
         if self._size is not None:
             observations.update(
                 {
-                    sensor: self._transform_obs(observations[sensor])
+                    sensor: self._transform_obs(observations[sensor], self.interpolation_mode[sensor])
                     for sensor in self.trans_keys
                     if sensor in observations
                 }

--- a/habitat_baselines/common/obs_transformers.py
+++ b/habitat_baselines/common/obs_transformers.py
@@ -75,6 +75,7 @@ class ResizeShortestEdge(ObservationTransformer):
         size: int,
         channels_last: bool = True,
         trans_keys: Tuple[str, ...] = ("rgb", "depth", "semantic"),
+        semantic_key: str = "semantic",
     ):
         """Args:
         size: The size you want to resize the shortest edge to
@@ -84,11 +85,7 @@ class ResizeShortestEdge(ObservationTransformer):
         self._size: int = size
         self.channels_last: bool = channels_last
         self.trans_keys: Tuple[str, ...] = trans_keys
-        self.interpolation_mode = {
-            "rgb": "area",
-            "depth": "area",
-            "semantic": "nearest-exact",
-        }
+        self.semantic_key = semantic_key
 
     def transform_observation_space(
         self,
@@ -118,9 +115,14 @@ class ResizeShortestEdge(ObservationTransformer):
                     )
         return observation_space
 
-    def _transform_obs(self, obs: torch.Tensor, interpolation_mode: str) -> torch.Tensor:
+    def _transform_obs(
+        self, obs: torch.Tensor, interpolation_mode: str
+    ) -> torch.Tensor:
         return image_resize_shortest_edge(
-            obs, self._size, channels_last=self.channels_last, interpolation_mode=interpolation_mode
+            obs,
+            self._size,
+            channels_last=self.channels_last,
+            interpolation_mode=interpolation_mode,
         )
 
     @torch.no_grad()
@@ -128,13 +130,14 @@ class ResizeShortestEdge(ObservationTransformer):
         self, observations: Dict[str, torch.Tensor]
     ) -> Dict[str, torch.Tensor]:
         if self._size is not None:
-            observations.update(
-                {
-                    sensor: self._transform_obs(observations[sensor], self.interpolation_mode[sensor])
-                    for sensor in self.trans_keys
-                    if sensor in observations
-                }
-            )
+            for sensor in self.trans_keys:
+                if sensor in observations:
+                    interpolation_mode = "area"
+                    if self.semantic_key in sensor:
+                        interpolation_mode = "nearest"
+                    observations[sensor] = self._transform_obs(
+                        observations[sensor], interpolation_mode
+                    )
         return observations
 
     @classmethod

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -440,7 +440,10 @@ def tensor_to_bgr_images(
 
 
 def image_resize_shortest_edge(
-    img: Tensor, size: int, channels_last: bool = False, interpolation_mode="area"
+    img: Tensor,
+    size: int,
+    channels_last: bool = False,
+    interpolation_mode="area",
 ) -> torch.Tensor:
     """Resizes an img so that the shortest side is length of size while
         preserving aspect ratio.

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -440,7 +440,7 @@ def tensor_to_bgr_images(
 
 
 def image_resize_shortest_edge(
-    img: Tensor, size: int, channels_last: bool = False
+    img: Tensor, size: int, channels_last: bool = False, interpolation_mode="area"
 ) -> torch.Tensor:
     """Resizes an img so that the shortest side is length of size while
         preserving aspect ratio.
@@ -472,7 +472,7 @@ def image_resize_shortest_edge(
     h = int(h * scale)
     w = int(w * scale)
     img = torch.nn.functional.interpolate(
-        img.float(), size=(h, w), mode="area"
+        img.float(), size=(h, w), mode=interpolation_mode
     ).to(dtype=img.dtype)
     if channels_last:
         if len(img.shape) == 4:


### PR DESCRIPTION
## Motivation and Context

Add support for semantic sensor in observation transformer to support ObjectNav DD-PPO training with semantic sensor.

## How Has This Been Tested

Locally by using DD-PPO training for ObjectNav

## Types of changes

- [x] Changes semantic observation dimensions to (H,W, 1) in `HabitatSimSemanticSensor` sensor
- [x] Add support for semantic sensor in `ResizeShortestEdge` observation transforms
- [x] Handle interpolation for semantic observation in `image_resize_shortest_edge` util method

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
