### PR TITLE
Add support for writing episode gfx-replay files during eval

### DIFF
--- a/habitat/config/default.py
+++ b/habitat/config/default.py
@@ -792,6 +792,7 @@ _C.SIMULATOR.HABITAT_SIM_V0.PHYSICS_CONFIG_FILE = (
 )
 # Possibly unstable optimization for extra performance with concurrent rendering
 _C.SIMULATOR.HABITAT_SIM_V0.LEAVE_CONTEXT_WITH_BACKGROUND_RENDERER = False
+_C.SIMULATOR.HABITAT_SIM_V0.ENABLE_GFX_REPLAY_SAVE = False
 # -----------------------------------------------------------------------------
 # PYROBOT
 # -----------------------------------------------------------------------------

--- a/habitat/core/embodied_task.py
+++ b/habitat/core/embodied_task.py
@@ -389,3 +389,6 @@ class EmbodiedTask:
 
     def seed(self, seed: int) -> None:
         return
+
+    def get_metrics_at_episode_end(self):
+        return {}

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -209,7 +209,12 @@ class Env:
         return time.time() - self._episode_start_time
 
     def get_metrics(self) -> Metrics:
-        return self._task.measurements.get_metrics()
+        metrics = self._task.measurements.get_metrics()
+
+        if self._episode_over:
+            metrics.update(self._task.get_metrics_at_episode_end())
+
+        return metrics
 
     def _past_limit(self) -> bool:
         return (

--- a/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat/tasks/rearrange/rearrange_task.py
@@ -54,6 +54,7 @@ class RearrangeTask(NavigationTask):
         self._targ_idx: int = 0
         self._episode_id: str = ""
         self._cur_episode_step = 0
+        self._gfx_replay_keyframes_string = None
 
     @property
     def targ_idx(self):
@@ -88,6 +89,7 @@ class RearrangeTask(NavigationTask):
         self.should_end = False
         self._done = False
         self._cur_episode_step = 0
+        self._gfx_replay_keyframes_string = None
 
         self._sim.set_robot_base_to_random_point()
 
@@ -203,3 +205,24 @@ class RearrangeTask(NavigationTask):
                 f"-----Episode {self._episode_id} requested to end after {self._cur_episode_step} steps.-----"
             )
             rearrange_logger.debug("-" * 40)
+
+    def get_metrics_at_episode_end(self):
+
+        metrics: Dict[str, Any] = {}
+
+        # Add a gfx-replay list of keyframes for the episode. This is a JSON string that
+        # should be saved to a file; the file can be read by visualization tools
+        # (e.g. import into Blender for screenshots and videos).
+        if (
+            self._episode_id
+            and self._sim.sim_config.sim_cfg.enable_gfx_replay_save
+        ):
+            if not self._gfx_replay_keyframes_string:
+                self._gfx_replay_keyframes_string = (
+                    self._sim.gfx_replay_manager.write_saved_keyframes_to_string()
+                )
+            metrics[
+                "gfx_replay_keyframes_string"
+            ] = self._gfx_replay_keyframes_string
+
+        return metrics

--- a/habitat_baselines/config/default.py
+++ b/habitat_baselines/config/default.py
@@ -30,6 +30,7 @@ _C.VIDEO_OPTION = ["disk", "tensorboard"]
 _C.TENSORBOARD_DIR = "tb"
 _C.WRITER_TYPE = "tb"
 _C.VIDEO_DIR = "video_dir"
+_C.GFX_REPLAY_DIR = ""
 _C.VIDEO_FPS = 10
 _C.VIDEO_RENDER_TOP_DOWN = True
 _C.VIDEO_RENDER_ALL_INFO = False

--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -1110,6 +1110,24 @@ class PPOTrainer(BaseRLTrainer):
 
                         rgb_frames[i] = []
 
+                    # A gfx-replay list of keyframes for the episode. This is a JSON string that
+                    # should be saved to a file; the file can be read by visualization tools
+                    # (e.g. import into Blender for screenshots and videos).
+                    gfx_replay_uuid = "gfx_replay_keyframes_string"
+                    if (
+                        self.config.GFX_REPLAY_DIR
+                        and gfx_replay_uuid in infos[i]
+                    ):
+                        gfx_replay_keyframes_string = infos[i][gfx_replay_uuid]
+                        filepath = (
+                            self.config.GFX_REPLAY_DIR
+                            + "/episode{}.replay.json".format(
+                                current_episodes[i].episode_id
+                            )
+                        )
+                        with open(filepath, "w") as text_file:
+                            text_file.write(gfx_replay_keyframes_string)
+
                 # episode continues
                 elif len(self.config.VIDEO_OPTION) > 0:
                     # TODO move normalization / channel changing out of the policy and undo it here


### PR DESCRIPTION
## Motivation and Context

Similar to how we generate a video per episode, we also now generate a gfx-replay JSON file per episode. Coming soon, these files can be imported into Blender for high-quality visualization (see https://github.com/facebookresearch/habitat-sim/pull/1759).

This feature requires some Hab-sim gfx-replay fixes, which are here: https://github.com/facebookresearch/habitat-sim/pull/1758

## How Has This Been Tested

Local testing with Hab 2.0 rearrange eval.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
