### PR TITLE
Fix backwards compatability for Hab1 tasks and Hab2 gym-style tasks

### DIFF
--- a/habitat_baselines/rl/ddppo/policy/running_mean_and_var.py
+++ b/habitat_baselines/rl/ddppo/policy/running_mean_and_var.py
@@ -13,6 +13,7 @@ from torch import nn as nn
 class RunningMeanAndVar(nn.Module):
     def __init__(self, n_channels: int) -> None:
         super().__init__()
+        assert n_channels > 0
         self.register_buffer("_mean", torch.zeros(1, n_channels, 1, 1))
         self.register_buffer("_var", torch.zeros(1, n_channels, 1, 1))
         self.register_buffer("_count", torch.zeros(()))


### PR DESCRIPTION
## Motivation and Context

We weren't handling backwards compatibility correctly when GYM.OBS_KEYS is none. This fixes that really opaque CI error about `RuntimeError: output with shape [1, 0, 1, 1] doesn't match the broadcast shape [1, 0, 1, 0]`

## How Has This Been Tested

The CI

## Types of changes


Bug fix (non-breaking change which fixes an issue)
