### PR TITLE
[ci-bugfix] - remove opencv conda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,6 @@ jobs:
               then
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
                 . activate habitat;
-                conda install -c  conda-forge opencv=4.5.5 -y
                 conda install -y pytorch torchvision cudatoolkit=10.0 -c pytorch
               fi
               touch ~/miniconda/pytorch_installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,7 @@ jobs:
               . activate habitat; cd habitat-lab
               python setup.py develop --all
               export PYTHONPATH=.:$PYTHONPATH
+              conda install -c  conda-forge opencv=4.5.5 -y
               python setup.py test --addopts "--cov-report=xml --cov=./"
 
               bash <(curl -s https://codecov.io/bash) -f coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,6 @@ jobs:
               . activate habitat; cd habitat-lab
               python setup.py develop --all
               export PYTHONPATH=.:$PYTHONPATH
-              conda install -c  conda-forge opencv=4.5.5 -y
               python setup.py test --addopts "--cov-report=xml --cov=./"
 
               bash <(curl -s https://codecov.io/bash) -f coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
               then
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
                 . activate habitat;
-                conda install -c  conda-forge opencv=4.5.5.64 -y
+                conda install -c  conda-forge opencv=4.5.5 -y
                 conda install -y pytorch torchvision cudatoolkit=10.0 -c pytorch
               fi
               touch ~/miniconda/pytorch_installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
               then
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
                 . activate habitat;
-                conda install -c  conda-forge opencv -y
+                conda install -c  conda-forge opencv=4.5.5.64 -y
                 conda install -y pytorch torchvision cudatoolkit=10.0 -c pytorch
               fi
               touch ~/miniconda/pytorch_installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.16.1
 yacs>=0.1.8
 numpy-quaternion>=2019.3.18.14.33.20
 attrs>=19.1.0
-opencv-python==4.5.5.64
+opencv-python>=3.3.0
 pickle5; python_version < '3.8'
 # visualization optional dependencies
 imageio>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.16.1
 yacs>=0.1.8
 numpy-quaternion>=2019.3.18.14.33.20
 attrs>=19.1.0
-opencv-python>=3.3.0
+opencv-python==4.5.5.64
 pickle5; python_version < '3.8'
 # visualization optional dependencies
 imageio>=2.2.0


### PR DESCRIPTION
## Motivation and Context

installing both conda opencv and pip opencv-python was redundant and causing package conflicts on CI. Removing the conda install in favor of the pip install defined in requirements.txt.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
