### PR TITLE
[Bugfix] make hx contiguous for new pytorch version

### DIFF
--- a/habitat_baselines/rl/models/rnn_state_encoder.py
+++ b/habitat_baselines/rl/models/rnn_state_encoder.py
@@ -278,7 +278,7 @@ class RNNStateEncoder(nn.Module):
         return hidden_states
 
     def unpack_hidden(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        return hidden_states
+        return hidden_states.contiguous()
 
     def single_forward(
         self, x, hidden_states, masks
@@ -376,7 +376,7 @@ class LSTMStateEncoder(RNNStateEncoder):
         self, hidden_states
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         lstm_states = torch.chunk(hidden_states, 2, 0)
-        return (lstm_states[0], lstm_states[1])
+        return (lstm_states[0].contiguous(), lstm_states[1].contiguous())
 
 
 class GRUStateEncoder(RNNStateEncoder):

--- a/test/test_baseline_training.py
+++ b/test/test_baseline_training.py
@@ -31,7 +31,7 @@ def setup_function(test_trainers):
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_BASELINE_SMALL", 0)) == 0,
-    reason="Full training tests did not run. Need `export FULL_TRAINING_TEST=1",
+    reason="Full training tests did not run. Need `export TEST_BASELINE_SMALL=1",
 )
 @pytest.mark.skipif(
     not baseline_installed, reason="baseline sub-module not installed"
@@ -88,7 +88,7 @@ def test_trainers(config_path, num_updates):
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_BASELINE_LARGE", 0)) == 0,
-    reason="Full training tests did not run. Need `export FULL_TRAINING_TEST=1",
+    reason="Full training tests did not run. Need `export TEST_BASELINE_LARGE=1",
 )
 @pytest.mark.skipif(
     not baseline_installed, reason="baseline sub-module not installed"


### PR DESCRIPTION
## Motivation and Context

On habitat-sim CI, using torch version 1.12 creates a CI issue because torch enforces LSTM inputs to be contiguous. 
This PR makes hx and cx contiguous to resolve the issue.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
