### PR TITLE
Variable Experience Rollout [Part 1]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,9 @@ jobs:
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
                 conda create -y -n habitat python=3.7
                 . activate habitat
+                pip install -U pip
                 conda install -q -y -c conda-forge ninja ccache numpy pytest pytest-mock pytest-cov psutil
-                pip install pytest-sugar
+                pip install pytest-sugar cython
               fi
       - run:
           name: Install pytorch
@@ -250,6 +251,7 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-lab
               python setup.py develop --all
+              find . -name ci-requirements.txt | xargs -I {} pip install -r {}
               export PYTHONPATH=.:$PYTHONPATH
               python setup.py test --addopts "--cov-report=xml --cov-report term  --cov=./"
 

--- a/.gitignore
+++ b/.gitignore
@@ -89,10 +89,10 @@ data
 *.swp
 
 # habitat_baselines outputs
-/videos/
-/train_dir/
-/tb/
+/videos
+/train_dir
+/tb
 
 # outputs from other libraries
-/sandbox/
-/plots/outputs/
+/sandbox
+/plots/outputs

--- a/habitat_baselines/__init__.py
+++ b/habitat_baselines/__init__.py
@@ -12,6 +12,7 @@ from habitat_baselines.il.trainers.eqa_cnn_pretrain_trainer import (
 from habitat_baselines.il.trainers.pacman_trainer import PACMANTrainer
 from habitat_baselines.il.trainers.vqa_trainer import VQATrainer
 from habitat_baselines.rl.ppo.ppo_trainer import PPOTrainer, RolloutStorage
+from habitat_baselines.rl.ver.ver_trainer import VERTrainer
 
 __all__ = [
     "BaseTrainer",
@@ -22,4 +23,5 @@ __all__ = [
     "EQACNNPretrainTrainer",
     "PACMANTrainer",
     "VQATrainer",
+    "VERTrainer",
 ]

--- a/habitat_baselines/common/windowed_running_mean.py
+++ b/habitat_baselines/common/windowed_running_mean.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import numbers
+from typing import Optional, Sequence, Union
+
+import attr
+import numpy as np
+
+
+@attr.s(auto_attribs=True, slots=True, repr=False)
+class WindowedRunningMean:
+    r"""Efficient implementation of a windowed running mean. Supports an infinite window"""
+    window_size: Union[int, float]
+    _sum: float = attr.ib(0.0, init=False)
+    _count: int = attr.ib(0, init=False)
+    _ptr: int = attr.ib(0, init=False)
+    _buffer: Optional[np.ndarray] = attr.ib(None, init=False)
+
+    def __attrs_post_init__(self):
+        if not self.infinite_window:
+            self.window_size = int(self.window_size)
+            self._buffer = np.zeros((self.window_size,), dtype=np.float64)
+
+    def add(self, v_i: Union[numbers.Real, float, int]) -> None:
+        v = float(v_i)
+        self._sum += v
+        if self.infinite_window:
+            self._count += 1
+        else:
+            assert isinstance(self.window_size, int)
+            if self._count == self.window_size:
+                self._sum -= float(self._buffer[self._ptr])
+            else:
+                self._count += 1
+
+            self._buffer[self._ptr] = v
+            self._ptr = (self._ptr + 1) % self.window_size
+
+    def add_many(self, vs: Sequence[Union[numbers.Real, float, int]]):
+        for v in vs:
+            self.add(v)
+
+    @property
+    def mean(self) -> float:
+        return self.sum / max(self.count, 1)
+
+    @property
+    def sum(self) -> float:
+        return self._sum
+
+    @property
+    def infinite_window(self) -> bool:
+        return math.isinf(self.window_size) or self.window_size <= 0
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+    def __iadd__(self, v):
+        self.add(v)
+        return self
+
+    def __float__(self):
+        return float(self.mean)
+
+    def __repr__(self):
+        return "WindowedRunningMean(window_size={}, mean={})".format(
+            self.window_size, self.mean
+        )

--- a/habitat_baselines/config/default.py
+++ b/habitat_baselines/config/default.py
@@ -121,6 +121,7 @@ _C.RL.POLICY.ACTION_DIST.min_log_std = -5
 _C.RL.POLICY.ACTION_DIST.max_log_std = 2
 # For continuous action distributions (including gaussian):
 _C.RL.POLICY.ACTION_DIST.action_activation = "tanh"  # ['tanh', '']
+_C.RL.POLICY.ACTION_DIST.scheduled_std = False
 # -----------------------------------------------------------------------------
 # OBS_TRANSFORMS CONFIG
 # -----------------------------------------------------------------------------
@@ -195,6 +196,18 @@ _C.RL.PPO.use_clipped_value_loss = True
 # policy inference time during rollout generation
 # Not that this does not change the memory requirements
 _C.RL.PPO.use_double_buffered_sampler = False
+# VER
+_C.RL.VER = CN()
+_C.RL.VER.variable_experience = True
+_C.RL.VER.num_inference_workers = 2
+_C.RL.VER.overlap_rollouts_and_learn = False
+## AUX
+# _C.RL.auxiliary_losses = CN()
+# _C.RL.auxiliary_losses.enabled = []
+# _C.RL.auxiliary_losses.cpca = CN()
+# _C.RL.auxiliary_losses.cpca.k = 20
+# _C.RL.auxiliary_losses.cpca.time_subsample = 6
+# _C.RL.auxiliary_losses.cpca.future_subsample = 2
 # -----------------------------------------------------------------------------
 # DECENTRALIZED DISTRIBUTED PROXIMAL POLICY OPTIMIZATION (DD-PPO)
 # -----------------------------------------------------------------------------

--- a/habitat_baselines/rl/ddppo/multi_node_slurm.sh
+++ b/habitat_baselines/rl/ddppo/multi_node_slurm.sh
@@ -15,7 +15,7 @@
 export GLOG_minloglevel=2
 export MAGNUM_LOG=quiet
 
-MAIN_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)
+MAIN_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
 export MAIN_ADDR
 
 set -x

--- a/habitat_baselines/rl/ver/README.md
+++ b/habitat_baselines/rl/ver/README.md
@@ -1,0 +1,34 @@
+Variable Experience Rollout (VER)
+=================================
+
+
+Implementation of variable experience rollout (VER). VER applies the sampling techniques for async to sync and collects a variable amount of experience for each environments rollout to mitigate the straggler effect.
+
+
+The system has 5 components. 3 of these are the key components for learning:
+
+* Environment workers receive actions to simulate. They write the output of their environment into shared memory.
+* Inference workers receive batches of environment steps and perform inference. They write the next action to take into shared memory. They then write the batch of experience for learning into GPU shared memory.
+* The Learner takes batches of experience and updates the policy.
+
+How these pieces are connected together is best seen via this diagram:
+
+![VER System Diagram](/habitat_baselines/rl/ver/images/ver-system.svg)
+
+The Shared CPU Memory block is implemented via the `transfer_buffers` and the Shared GPU Memory block is implemented via the `rollouts`.
+
+There are two components that serve auxiliary functions:
+
+* The Report worker is responsible for tracking the progress of training. It writes metrics to tensorboard (or wandb). This lives in a separate process for maximum training speed.
+* The Preemption decider decides when to preempt stragglers when combining VER and DD-PPO
+
+## Citing
+
+If you use VER or the model-weights in your research, please cite the following [paper](https://tbd):
+
+    @inproceedings{wijmans2022ver,
+      title = {{VER}: {S}caling On-Policy RL Leads to the Emergence of Navigation in Embodied Rearrangement},
+      author =  {Erik Wijmans and Irfan Essa and Dhruv Batra},
+      booktitle = {arXiv},
+      year =    {2022}
+    }

--- a/habitat_baselines/rl/ver/__init__.py
+++ b/habitat_baselines/rl/ver/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/habitat_baselines/rl/ver/ci-requirements.txt
+++ b/habitat_baselines/rl/ver/ci-requirements.txt
@@ -1,0 +1,2 @@
+faster_fifo==1.4.2
+threadpoolctl==3.1.0

--- a/habitat_baselines/rl/ver/environment_worker.py
+++ b/habitat_baselines/rl/ver/environment_worker.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import os
+import random
+from multiprocessing.context import BaseContext
+from typing import Any, Callable, Iterable, List, Optional, Sequence, TypeVar
+
+import attr
+import numpy as np
+
+from habitat import Config, RLEnv, logger, make_dataset
+from habitat.utils.gym_definitions import make_gym_from_config
+from habitat_baselines.common.tensor_dict import NDArrayDict, TensorDict
+from habitat_baselines.rl.ver.queue import BatchedQueue
+from habitat_baselines.rl.ver.task_enums import (
+    EnvironmentWorkerTasks,
+    ReportWorkerTasks,
+)
+from habitat_baselines.rl.ver.timing import Timing
+from habitat_baselines.rl.ver.worker_common import (
+    ProcessBase,
+    WorkerBase,
+    WorkerQueues,
+)
+from habitat_baselines.utils.common import (
+    inference_mode,
+    is_continuous_action_space,
+)
+
+MIN_SCENES_PER_ENV = 16
+
+T = TypeVar("T")
+
+
+def infinite_shuffling_iterator(
+    inp_seq: Sequence[T], prng: Optional[random.Random] = None
+) -> Iterable[T]:
+    inp = list(inp_seq)
+    i = len(inp)
+    while True:
+        if i == len(inp):
+            if prng is not None:
+                prng.shuffle(inp)
+            else:
+                random.shuffle(inp)
+            i = 0
+
+        yield inp[i]
+        i += 1
+
+
+@attr.s(slots=True, init=False, auto_attribs=True)
+class DefaultActionPlugin:
+    policy_action_space: Any
+    is_continuous: bool
+
+    def __init__(self, policy_action_space: Any) -> None:
+        self.policy_action_space = policy_action_space
+        self.is_continuous = is_continuous_action_space(policy_action_space)
+
+    def __call__(self, action: np.ndarray) -> np.ndarray:
+        if self.is_continuous:
+            return np.clip(
+                action,
+                self.policy_action_space.low,
+                self.policy_action_space.high,
+            )
+        else:
+            return action.item()
+
+
+@attr.s(auto_attribs=True)
+class EnvironmentWorkerProcess(ProcessBase):
+    env_idx: int
+    env_config: Any
+    auto_reset_done: bool
+    queues: WorkerQueues
+    action_plugin: Callable[[np.ndarray], np.ndarray] = attr.ib(init=False)
+    env: RLEnv = attr.ib(default=None)
+    total_reward: float = 0.0
+    episode_length: int = 0
+    timer: Timing = attr.Factory(Timing)
+    _episode_id: int = 0
+    _step_id: int = 0
+    _torch_transfer_buffers: TensorDict = attr.ib(init=False)
+    send_transfer_buffers: NDArrayDict = attr.ib(init=False)
+    actions: np.ndarray = attr.ib(init=False)
+
+    def __attrs_post_init__(self):
+        self.build_dispatch_table(EnvironmentWorkerTasks)
+
+    def wait(self):
+        self.response_queue.put("REQ")
+
+    def close(self):
+        if self.env is not None:
+            self.env.close()
+
+        self.env = None
+
+    def start(self):
+        assert self.env is None
+        self.env = make_gym_from_config(self.env_config)
+
+        self.response_queue.put(
+            dict(
+                env_idx=self.env_idx,
+                obs_space=self.env.observation_space,
+                act_space=self.env.action_space,
+            )
+        )
+
+        logger.info(f"EnvironmentWorker-{self.env_idx} initialized")
+
+    def reset(self):
+        self._last_obs = self.env.reset()
+
+    def start_experience_collection(self):
+        assert self.env is not None
+
+        full_env_result = dict(
+            observations=self._last_obs,
+            episode_ids=self._episode_id,
+            step_ids=self._step_id,
+        )
+        self.send_transfer_buffers.slice_keys(full_env_result.keys())[
+            self.env_idx
+        ] = full_env_result
+        self.queues.inference.put(self.env_idx)
+
+    def _step_env(self, action):
+        with self.timer.avg_time("step env"):
+            obs, reward, done, info = self.env.step(action)
+            self._step_id += 1
+
+            if not math.isfinite(reward):
+                reward = -1.0
+
+        with self.timer.avg_time("reset env"):
+            if done:
+                self._episode_id += 1
+                self._step_id = 0
+                if self.auto_reset_done:
+                    obs = self.env.reset()
+
+        return obs, reward, done, info
+
+    def step(self):
+        with self.timer.avg_time("process actions"):
+            action = self.action_plugin(self.actions[self.env_idx])
+
+        self._last_obs, reward, done, info = self._step_env(action)
+
+        with self.timer.avg_time("enqueue env"):
+            self.send_transfer_buffers[self.env_idx] = dict(
+                observations=self._last_obs,
+                rewards=reward,
+                masks=not done,
+                episode_ids=self._episode_id,
+                step_ids=self._step_id,
+            )
+
+        self.queues.inference.put(self.env_idx)
+
+        self.total_reward += reward
+        self.episode_length += 1
+
+        if done:
+            self.queues.report.put_many(
+                [
+                    (
+                        ReportWorkerTasks.episode_end,
+                        dict(
+                            env_idx=self.env_idx,
+                            length=self.episode_length,
+                            reward=self.total_reward,
+                            info=info,
+                        ),
+                    ),
+                    (ReportWorkerTasks.env_timing, self.timer),
+                ]
+            )
+            self.timer = Timing()
+            self.total_reward = 0.0
+            self.episode_length = 0
+
+    @property
+    def task_queue(self) -> BatchedQueue:
+        return self.queues.environments[self.env_idx]
+
+    def set_transfer_buffers(self, torch_transfer_buffers: TensorDict):
+        self._torch_transfer_buffers = torch_transfer_buffers
+        self._torch_transfer_buffers["environment_ids"][
+            self.env_idx
+        ] = self.env_idx
+        acts = self._torch_transfer_buffers["actions"].numpy()
+        assert isinstance(acts, np.ndarray)
+        self.actions = acts
+        self.send_transfer_buffers = self._torch_transfer_buffers.slice_keys(
+            "observations",
+            "rewards",
+            "masks",
+            "episode_ids",
+            "step_ids",
+        ).numpy()
+
+    def set_action_plugin(self, action_plugin):
+        self.action_plugin = action_plugin
+
+    @inference_mode()
+    def run(self):
+        os.nice(10)
+
+        super().run()
+
+        self.close()
+
+
+class EnvironmentWorker(WorkerBase):
+    def __init__(
+        self,
+        mp_ctx: BaseContext,
+        env_idx: int,
+        env_config,
+        auto_reset_done,
+        queues: WorkerQueues,
+    ):
+        super().__init__(
+            mp_ctx,
+            EnvironmentWorkerProcess,
+            env_idx,
+            env_config,
+            auto_reset_done,
+            queues,
+        )
+        self.env_worker_queue = queues.environments[env_idx]
+
+    def start(self):
+        self.env_worker_queue.put((EnvironmentWorkerTasks.start, None))
+
+    def get_init_report(self):
+        return self.response_queue.get()
+
+    def reset(self):
+        self.env_worker_queue.put((EnvironmentWorkerTasks.reset, None))
+
+    def set_transfer_buffers(self, buffers: TensorDict):
+        self.env_worker_queue.put(
+            (EnvironmentWorkerTasks.set_transfer_buffers, buffers)
+        )
+
+    def set_action_plugin(self, action_plugin):
+        self.env_worker_queue.put(
+            (EnvironmentWorkerTasks.set_action_plugin, action_plugin)
+        )
+
+    def start_experience_collection(self):
+        self.env_worker_queue.put(
+            (EnvironmentWorkerTasks.start_experience_collection, None)
+        )
+
+    def wait_start(self):
+        self.env_worker_queue.put((EnvironmentWorkerTasks.wait, None))
+
+    def wait_sync(self):
+        assert (
+            self.response_queue.get() == "REQ"
+        ), "Got the wrong response from the actor worker. Something unexpected was placed in the response queue"
+
+    def wait(self):
+        self.wait_start()
+        self.wait_sync()
+
+
+def _construct_environment_workers_impl(
+    configs,
+    auto_reset_done,
+    mp_ctx: BaseContext,
+    queues: WorkerQueues,
+):
+    num_environments = len(configs)
+    workers = []
+    for i in range(num_environments):
+        w = EnvironmentWorker(
+            mp_ctx,
+            i,
+            configs[i],
+            auto_reset_done,
+            queues,
+        )
+        workers.append(w)
+
+    return workers
+
+
+def _make_proc_config(config, rank, scenes=None, scene_splits=None):
+    proc_config = config.clone()
+    proc_config.defrost()
+
+    task_config = proc_config.TASK_CONFIG
+    task_config.SEED = task_config.SEED + rank
+    if scenes is not None and len(scenes) > 0:
+        task_config.DATASET.CONTENT_SCENES = scene_splits[rank]
+
+    task_config.SIMULATOR.HABITAT_SIM_V0.GPU_DEVICE_ID = (
+        config.SIMULATOR_GPU_ID
+    )
+
+    task_config.SIMULATOR.AGENT_0.SENSORS = config.SENSORS
+
+    proc_config.freeze()
+    return proc_config
+
+
+def _create_worker_configs(config: Config):
+    num_environments = config.NUM_ENVIRONMENTS
+
+    dataset = make_dataset(config.TASK_CONFIG.DATASET.TYPE)
+    scenes = config.TASK_CONFIG.DATASET.CONTENT_SCENES
+    if "*" in config.TASK_CONFIG.DATASET.CONTENT_SCENES:
+        scenes = dataset.get_scenes_to_load(config.TASK_CONFIG.DATASET)
+
+    # We use a minimum number of scenes per environment to reduce bias
+    scenes_per_env = max(
+        int(math.ceil(len(scenes) / num_environments)), MIN_SCENES_PER_ENV
+    )
+    scene_splits: List[List[str]] = [[] for _ in range(num_environments)]
+    for idx, scene in enumerate(infinite_shuffling_iterator(scenes)):
+        scene_splits[idx % len(scene_splits)].append(scene)
+        if len(scene_splits[-1]) == scenes_per_env:
+            break
+
+    assert len(set().union(*(set(scenes) for scenes in scene_splits))) == len(
+        scenes
+    )
+
+    args = [
+        _make_proc_config(config, rank, scenes, scene_splits)
+        for rank in range(num_environments)
+    ]
+
+    return args
+
+
+def construct_environment_workers(
+    config: Config,
+    mp_ctx: BaseContext,
+    worker_queues: WorkerQueues,
+) -> List[EnvironmentWorker]:
+    configs = _create_worker_configs(config)
+
+    return _construct_environment_workers_impl(
+        configs,
+        True,
+        mp_ctx,
+        worker_queues,
+    )
+
+
+def build_action_plugin_from_policy_action_space(policy_action_space):
+    return DefaultActionPlugin(policy_action_space)

--- a/habitat_baselines/rl/ver/images/ver-system.svg
+++ b/habitat_baselines/rl/ver/images/ver-system.svg
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="355 271 736 225" width="736" height="225">
+  <defs>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -3 7 6" markerWidth="7" markerHeight="6" color="#323232">
+      <g>
+        <path d="M 4.8 0 L 0 -1.8 L 0 1.8 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -3 7 6" markerWidth="7" markerHeight="6" color="#333">
+      <g>
+        <path d="M 4.8 0 L 0 -1.8 L 0 1.8 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_3" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -3 7 6" markerWidth="7" markerHeight="6" color="black">
+      <g>
+        <path d="M 4.8 0 L 0 -1.8 L 0 1.8 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="Canvas_1" stroke-opacity="1" fill="none" fill-opacity="1" stroke-dasharray="none" stroke="none">
+    <title>Canvas 1</title>
+    <rect fill="white" x="355" y="271" width="736" height="225"/>
+    <g id="Canvas_1_Layer_1">
+      <title>Layer 1</title>
+      <g id="Graphic_4">
+        <path d="M 374 273 L 525 273 C 527.20914 273 529 274.79086 529 277 L 529 320 C 529 322.20914 527.20914 324 525 324 L 374 324 C 371.79086 324 370 322.20914 370 320 L 370 277 C 370 274.79086 371.79086 273 374 273 Z" fill="#a1b0b1"/>
+        <path d="M 374 273 L 525 273 C 527.20914 273 529 274.79086 529 277 L 529 320 C 529 322.20914 527.20914 324 525 324 L 374 324 C 371.79086 324 370 322.20914 370 320 L 370 277 C 370 274.79086 371.79086 273 374 273 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      </g>
+      <g id="Graphic_5">
+        <path d="M 384 283 L 535 283 C 537.20914 283 539 284.79086 539 287 L 539 330 C 539 332.20914 537.20914 334 535 334 L 384 334 C 381.79086 334 380 332.20914 380 330 L 380 287 C 380 284.79086 381.79086 283 384 283 Z" fill="#a1b0b1"/>
+        <path d="M 384 283 L 535 283 C 537.20914 283 539 284.79086 539 287 L 539 330 C 539 332.20914 537.20914 334 535 334 L 384 334 C 381.79086 334 380 332.20914 380 330 L 380 287 C 380 284.79086 381.79086 283 384 283 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      </g>
+      <g id="Graphic_2">
+        <path d="M 394 293 L 545 293 C 547.20914 293 549 294.79086 549 297 L 549 340 C 549 342.20914 547.20914 344 545 344 L 394 344 C 391.79086 344 390 342.20914 390 340 L 390 297 C 390 294.79086 391.79086 293 394 293 Z" fill="#a1b0b1"/>
+        <path d="M 394 293 L 545 293 C 547.20914 293 549 294.79086 549 297 L 549 340 C 549 342.20914 547.20914 344 545 344 L 394 344 C 391.79086 344 390 342.20914 390 340 L 390 297 C 390 294.79086 391.79086 293 394 293 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      </g>
+      <g id="Graphic_45">
+        <path d="M 924 351 L 1075 351 C 1077.2091 351 1079 352.79086 1079 355 L 1079 398 C 1079 400.20914 1077.2091 402 1075 402 L 924 402 C 921.7909 402 920 400.20914 920 398 L 920 355 C 920 352.79086 921.7909 351 924 351 Z" fill="#b87dd0"/>
+        <path d="M 924 351 L 1075 351 C 1077.2091 351 1079 352.79086 1079 355 L 1079 398 C 1079 400.20914 1077.2091 402 1075 402 L 924 402 C 921.7909 402 920 400.20914 920 398 L 920 355 C 920 352.79086 921.7909 351 924 351 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+      </g>
+      <g id="Graphic_44">
+        <path d="M 934 361 L 1085 361 C 1087.2091 361 1089 362.79086 1089 365 L 1089 408 C 1089 410.20914 1087.2091 412 1085 412 L 934 412 C 931.7909 412 930 410.20914 930 408 L 930 365 C 930 362.79086 931.7909 361 934 361 Z" fill="#b87dd0"/>
+        <path d="M 934 361 L 1085 361 C 1087.2091 361 1089 362.79086 1089 365 L 1089 408 C 1089 410.20914 1087.2091 412 1085 412 L 934 412 C 931.7909 412 930 410.20914 930 408 L 930 365 C 930 362.79086 931.7909 361 934 361 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+        <text transform="translate(935 377)" fill="#333">
+          <tspan font-family="Roboto" font-size="16" fill="#333" x="15.058594" y="15">Inference Worker</tspan>
+        </text>
+      </g>
+      <g id="Graphic_8">
+        <path d="M 666.0781 302.68622 L 817.0781 302.68622 C 819.2873 302.68622 821.0781 304.47708 821.0781 306.6862 L 821.0781 349.6862 C 821.0781 351.89536 819.2873 353.6862 817.0781 353.6862 L 666.0781 353.6862 C 663.869 353.6862 662.0781 351.89536 662.0781 349.6862 L 662.0781 306.6862 C 662.0781 304.47708 663.869 302.68622 666.0781 302.68622 Z" fill="#79b1d4"/>
+        <path d="M 666.0781 302.68622 L 817.0781 302.68622 C 819.2873 302.68622 821.0781 304.47708 821.0781 306.6862 L 821.0781 349.6862 C 821.0781 351.89536 819.2873 353.6862 817.0781 353.6862 L 666.0781 353.6862 C 663.869 353.6862 662.0781 351.89536 662.0781 349.6862 L 662.0781 306.6862 C 662.0781 304.47708 663.869 302.68622 666.0781 302.68622 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+        <text transform="translate(667.0781 318.6862)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="1.4335938" y="15">Shared CPU Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_9">
+        <path d="M 666.0781 418.5 L 817.0781 418.5 C 819.2873 418.5 821.0781 420.29086 821.0781 422.5 L 821.0781 465.5 C 821.0781 467.70914 819.2873 469.5 817.0781 469.5 L 666.0781 469.5 C 663.869 469.5 662.0781 467.70914 662.0781 465.5 L 662.0781 422.5 C 662.0781 420.29086 663.869 418.5 666.0781 418.5 Z" fill="#71c996"/>
+        <path d="M 666.0781 418.5 L 817.0781 418.5 C 819.2873 418.5 821.0781 420.29086 821.0781 422.5 L 821.0781 465.5 C 821.0781 467.70914 819.2873 469.5 817.0781 469.5 L 666.0781 469.5 C 663.869 469.5 662.0781 467.70914 662.0781 465.5 L 662.0781 422.5 C 662.0781 420.29086 663.869 418.5 666.0781 418.5 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+        <text transform="translate(667.0781 434.5)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="1.1601562" y="15">Shared GPU Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_13">
+        <text transform="translate(581.8711 291.448)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">EnvStep</tspan>
+        </text>
+      </g>
+      <g id="Graphic_17">
+        <text transform="translate(592.8789 345.3138)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">Action</tspan>
+        </text>
+      </g>
+      <g id="Graphic_24">
+        <text transform="translate(879 314.4102)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">Batch(EnvStep)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_25">
+        <text transform="translate(743.3047 361.8431)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">Batch(Actions)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_29">
+        <text transform="translate(884 434.5)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">Batch(EnvStep)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_30">
+        <text transform="translate(743.9023 394.5)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">Policy Weights</tspan>
+        </text>
+      </g>
+      <g id="Line_31">
+        <line x1="568.4392" y1="434.5162" x2="637.0392" y2="434.5162" marker-end="url(#FilledArrow_Marker)" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_32">
+        <line x1="647.9392" y1="452.96417" x2="579.3392" y2="452.96417" marker-end="url(#FilledArrow_Marker)" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Graphic_33">
+        <text transform="translate(360.5963 344.8658)" fill="#333">
+          <tspan font-family="Roboto" font-size="16" fill="#333" x="0" y="15">N</tspan>
+        </text>
+      </g>
+      <g id="Line_35">
+        <line x1="360" y1="325" x2="400" y2="359.6289" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Graphic_36">
+        <text transform="translate(564 399.3138)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">Policy Weights</tspan>
+        </text>
+      </g>
+      <g id="Graphic_37">
+        <text transform="translate(572.197 471.65356)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="0" y="15">Mini-batch</tspan>
+        </text>
+      </g>
+      <g id="Line_42">
+        <line x1="570.78906" y1="318.96222" x2="639.3891" y2="318.96222" marker-end="url(#FilledArrow_Marker)" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_41">
+        <line x1="650.2891" y1="337.4102" x2="581.68906" y2="337.4102" marker-end="url(#FilledArrow_Marker)" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+    </g>
+    <g id="Canvas_1_Layer_2">
+      <title>Layer 2</title>
+      <g id="Graphic_3">
+        <path d="M 404 303 L 555 303 C 557.20914 303 559 304.79086 559 307 L 559 350 C 559 352.20914 557.20914 354 555 354 L 404 354 C 401.79086 354 400 352.20914 400 350 L 400 307 C 400 304.79086 401.79086 303 404 303 Z" fill="#a1b0b1"/>
+        <path d="M 404 303 L 555 303 C 557.20914 303 559 304.79086 559 307 L 559 350 C 559 352.20914 557.20914 354 555 354 L 404 354 C 401.79086 354 400 352.20914 400 350 L 400 307 C 400 304.79086 401.79086 303 404 303 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+        <text transform="translate(405 319)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="3.40625" y="15">Environment Worker</tspan>
+        </text>
+      </g>
+      <g id="Graphic_10">
+        <path d="M 404 418.5 L 555 418.5 C 557.20914 418.5 559 420.29086 559 422.5 L 559 465.5 C 559 467.70914 557.20914 469.5 555 469.5 L 404 469.5 C 401.79086 469.5 400 467.70914 400 465.5 L 400 422.5 C 400 420.29086 401.79086 418.5 404 418.5 Z" fill="#de7265"/>
+        <path d="M 404 418.5 L 555 418.5 C 557.20914 418.5 559 420.29086 559 422.5 L 559 465.5 C 559 467.70914 557.20914 469.5 555 469.5 L 404 469.5 C 401.79086 469.5 400 467.70914 400 465.5 L 400 422.5 C 400 420.29086 401.79086 418.5 404 418.5 Z" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+        <text transform="translate(405 434.5)" fill="#323232">
+          <tspan font-family="Roboto" font-size="16" fill="#323232" x="17.324219" y="15">Learning Worker</tspan>
+        </text>
+      </g>
+    </g>
+    <g id="Canvas_1_Layer_3">
+      <title>Layer 3</title>
+      <g id="Line_51">
+        <path d="M 828.5469 321.5 L 868.5469 321.5 L 868.5469 360.6289 L 899.6312 360.6289" marker-end="url(#FilledArrow_Marker_2)" stroke="#333" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_52">
+        <path d="M 910.0469 374.3138 L 858.125 374.3138 L 858.125 335.18488 L 838.4469 335.18488" marker-end="url(#FilledArrow_Marker_2)" stroke="#333" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_54">
+        <path d="M 828.5469 436.5162 L 861.0781 436.5162 L 861.0781 397.38727 L 899.6312 397.38727" marker-end="url(#FilledArrow_Marker_2)" stroke="#333" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_53">
+        <path d="M 910.0469 411.3138 L 871.7952 411.3138 L 871.7952 450.4427 L 841.4469 450.4427" marker-end="url(#FilledArrow_Marker_3)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/habitat_baselines/rl/ver/inference_worker.py
+++ b/habitat_baselines/rl/ver/inference_worker.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import queue
+import time
+from multiprocessing import SimpleQueue
+from multiprocessing.context import BaseContext
+from typing import List, Tuple
+
+import attr
+import numpy as np
+import torch
+
+from habitat import Config, logger
+from habitat_baselines.common.baseline_registry import baseline_registry
+from habitat_baselines.common.obs_transformers import (
+    apply_obs_transforms_batch,
+    get_active_obs_transforms,
+)
+from habitat_baselines.common.tensor_dict import (
+    NDArrayDict,
+    TensorDict,
+    iterate_dicts_recursively,
+)
+from habitat_baselines.common.windowed_running_mean import WindowedRunningMean
+from habitat_baselines.rl.ppo.policy import NetPolicy
+from habitat_baselines.rl.ver.task_enums import (
+    EnvironmentWorkerTasks,
+    InferenceWorkerTasks,
+    PreemptionDeciderTasks,
+    ReportWorkerTasks,
+)
+from habitat_baselines.rl.ver.timing import Timing
+from habitat_baselines.rl.ver.ver_rollout_storage import VERRolloutStorage
+from habitat_baselines.rl.ver.worker_common import (
+    InferenceWorkerSync,
+    ProcessBase,
+    RolloutEarlyEnds,
+    WorkerBase,
+    WorkerQueues,
+)
+from habitat_baselines.utils.common import batch_obs, inference_mode
+
+
+@attr.s(auto_attribs=True)
+class InferenceWorkerProcess(ProcessBase):
+    setup_queue: SimpleQueue
+    inference_worker_idx: int
+    num_inference_workers: int
+    config: Config
+    queues: WorkerQueues
+    iw_sync: InferenceWorkerSync
+    _torch_transfer_buffers: TensorDict
+    policy_name: str
+    policy_args: Tuple
+    device: torch.device
+    rollout_ends: RolloutEarlyEnds
+    actor_critic_tensors: List[torch.Tensor] = attr.ib(None, init=False)
+    rollouts: VERRolloutStorage = attr.ib(None, init=False)
+    replay_reqs: List = attr.ib(factory=list, init=False)
+    new_reqs: List = attr.ib(factory=list, init=False)
+    _avg_step_time: WindowedRunningMean = attr.ib(
+        factory=lambda: WindowedRunningMean(128), init=False
+    )
+    timer: Timing = attr.Factory(Timing)
+    _n_replay_steps: int = 0
+    actor_critic: NetPolicy = attr.ib(init=False)
+    transfer_buffers: NDArrayDict = attr.ib(default=None, init=False)
+    incoming_transfer_buffers: NDArrayDict = attr.ib(default=None, init=False)
+
+    def __attrs_post_init__(self):
+        if self.device.type == "cuda":
+            torch.cuda.set_device(self.device)
+        self._overlapped = self.config.RL.VER.overlap_rollouts_and_learn
+        with inference_mode():
+            self.actor_critic = baseline_registry.get_policy(
+                self.policy_name
+            ).from_config(*self.policy_args)
+            self.actor_critic.eval()
+            # self.actor_critic.aux_losses.clear()
+            self.actor_critic.to(device=self.device)
+
+        self.transfer_buffers = self._torch_transfer_buffers.numpy()
+        self.incoming_transfer_buffers = self.transfer_buffers.slice_keys(
+            set(self.transfer_buffers.keys()) - {"actions"}
+        )
+        self.last_step_time = time.perf_counter()
+        self.min_reqs = int(
+            max(
+                len(self.queues.environments)
+                / self.num_inference_workers
+                / 1.5,
+                1,
+            )
+        )
+        self.max_reqs = int(
+            max(
+                len(self.queues.environments)
+                / self.num_inference_workers
+                * 1.5,
+                1,
+            )
+        )
+        assert self.max_reqs >= self.min_reqs
+
+        self.min_wait_time = 0.01
+        self.obs_transforms = get_active_obs_transforms(self.config)
+        self._variable_experience = self.config.RL.VER.variable_experience
+
+        torch.backends.cudnn.enabled = True
+        torch.backends.cudnn.benchmark = False
+        logger.info(f"InferenceWorker-{self.inference_worker_idx} initialized")
+
+    def set_actor_critic_tensors(self, actor_critic_tensors):
+        with inference_mode():
+            self.actor_critic_tensors = actor_critic_tensors
+            if not self._overlapped:
+                # If learning and experience collection aren't overlapped,
+                # we can share the weights between all the inference workers and
+                # the learner.
+                for i, t in enumerate(self.actor_critic.all_policy_tensors()):
+                    t.set_(self.actor_critic_tensors[i])
+            else:
+                # Otherwise each inference worker needs its own copy.
+                self._update_actor_critic()
+
+    def set_rollouts(self, rollouts: VERRolloutStorage):
+        self.rollouts = rollouts
+        self._current_policy_version = int(
+            self.rollouts.cpu_current_policy_version
+        )
+
+    def _update_actor_critic(self):
+        for src, dst in zip(
+            self.actor_critic_tensors, self.actor_critic.all_policy_tensors()
+        ):
+            dst.copy_(src)
+
+    def _update_storage_no_ver(
+        self, prev_step: TensorDict, current_step: TensorDict, current_steps
+    ):
+        for offset, step_content in (
+            (-1, prev_step),
+            (0, current_step),
+        ):
+            step_plus_off = current_steps + offset
+
+            for src, dst in iterate_dicts_recursively(
+                step_content,
+                self.rollouts.buffers.slice_keys(step_content.keys()),
+            ):
+                ##
+                # NB: This loop is faster than something fancy with index_copy_
+                # or gather_!  I think that's because copy_ is much faster and
+                # async
+                for i, env_idx in enumerate(self.new_reqs):
+                    step_idx = step_plus_off[env_idx].item()
+                    if 0 <= step_idx <= self.rollouts.num_steps:
+                        dst[step_idx, env_idx].copy_(src[i])
+
+    def _update_storage_ver(
+        self, prev_step: TensorDict, current_step: TensorDict, my_slice
+    ):
+        for src, dst in iterate_dicts_recursively(
+            prev_step, self.rollouts.buffers.slice_keys(prev_step.keys())
+        ):
+            ##
+            # NB: This loop is faster than something fancy with index_copy_
+            # or gather_!  I think that's because copy_ is much faster and
+            # async
+            for i, env_idx in enumerate(self.new_reqs):
+                dst_idx = self._prev_inds[env_idx].item()
+                if dst_idx >= 0:
+                    dst[dst_idx].copy_(src[i])
+
+        assert torch.all(self.rollouts.buffers["is_stale"][my_slice])
+
+        self.rollouts.buffers.slice_keys(current_step.keys())[
+            my_slice
+        ] = current_step
+
+    def _sync_device(self):
+        if self.num_inference_workers > 1 and self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+
+    @contextlib.contextmanager
+    def lock_and_sync(self):
+        if self.num_inference_workers == 1:
+            yield
+            return
+
+        try:
+            with self.iw_sync.lock:
+                yield
+
+                self._sync_device()
+        finally:
+            pass
+
+    def step(self) -> Tuple[bool, List[Tuple[int, int]]]:
+        steps_finished: List[Tuple[int, int]] = []
+        if len(self.new_reqs) == 0:
+            return False, steps_finished
+
+        if (
+            self._current_policy_version
+            != self.rollouts.cpu_current_policy_version
+        ):
+            self._current_policy_version = int(
+                self.rollouts.cpu_current_policy_version
+            )
+            if self._overlapped:
+                self._update_actor_critic()
+
+        current_steps = self.rollouts.current_steps.copy()
+        final_batch = False
+
+        if self._variable_experience:
+            self.new_reqs.sort(
+                key=lambda a: (
+                    self.rollouts.actor_steps_collected[a],
+                    a,
+                )
+            )
+            with self.lock_and_sync():
+                ptr = self.rollouts.ptr.item()
+                num_to_process = int(
+                    min(
+                        int(
+                            self.rollouts.num_steps_to_collect
+                            - self.rollouts.num_steps_collected
+                        ),
+                        len(self.new_reqs),
+                    )
+                )
+                next_ptr = ptr + num_to_process
+                assert next_ptr <= self.rollouts.buffer_size
+                self.rollouts.ptr[:] = next_ptr
+                self.rollouts.num_steps_collected += (
+                    num_to_process - self._n_replay_steps
+                )
+
+                if (
+                    self.rollouts.num_steps_collected
+                ) == self.rollouts.num_steps_to_collect:
+                    final_batch = True
+                    self.rollouts.rollout_done[:] = True
+
+            my_slice = slice(ptr, next_ptr)
+            self.replay_reqs += self.new_reqs[num_to_process:]
+            self.new_reqs = self.new_reqs[:num_to_process]
+        else:
+            for r in self.new_reqs:
+                if current_steps[r] > self.rollouts.num_steps:
+                    raise RuntimeError(
+                        f"Got a step from actor {r} after collecting {current_steps[r]} steps. This shouldn't be possible."
+                    )
+
+            if len(self.new_reqs) > 0:
+                with self.lock_and_sync():
+                    self.rollouts.num_steps_collected += (
+                        len(self.new_reqs) - self._n_replay_steps
+                    )
+
+                    if (
+                        self.rollouts.num_steps_collected
+                        == self.rollouts.num_steps_to_collect
+                    ):
+                        final_batch = True
+                        self.rollouts.rollout_done[:] = True
+
+        if len(self.new_reqs) == 0:
+            return False, steps_finished
+
+        if self._n_replay_steps > 0 and len(self.replay_reqs) > 0:
+            raise RuntimeError(
+                f"Added to replay reqs before reqs from the last rollout were replayed. {self.replay_reqs}"
+            )
+
+        with self.timer.avg_time("batch obs"):
+            to_batch = [
+                self.incoming_transfer_buffers[env_idx]
+                for env_idx in self.new_reqs
+            ]
+
+            to_batch = batch_obs(to_batch, device=self.device)
+            obs = to_batch.pop("observations")
+
+            environment_ids = to_batch["environment_ids"].view(-1)
+
+        with self.timer.avg_time("step policy"):
+            obs = apply_obs_transforms_batch(obs, self.obs_transforms)
+            recurrent_hidden_states = self.rollouts.next_hidden_states[
+                environment_ids
+            ]
+            prev_actions = self.rollouts.next_prev_actions[environment_ids]
+
+            (
+                values,
+                actions,
+                actions_log_probs,
+                next_recurrent_hidden_states,
+            ) = self.actor_critic.act(
+                obs,
+                recurrent_hidden_states,
+                prev_actions,
+                to_batch["masks"],
+            )
+
+            if not final_batch:
+                self.rollouts.next_hidden_states.index_copy_(
+                    0, environment_ids, next_recurrent_hidden_states
+                )
+                self.rollouts.next_prev_actions.index_copy_(
+                    0, environment_ids, actions
+                )
+
+            if self._variable_experience:
+                self._prev_inds = self.rollouts.prev_inds.copy()
+
+                self.rollouts.prev_inds[self.new_reqs] = np.arange(
+                    my_slice.start,
+                    my_slice.stop,
+                    dtype=np.int64,
+                )
+
+            cpu_actions = actions.to(device="cpu")
+            self.transfer_buffers["actions"][
+                self.new_reqs
+            ] = cpu_actions.numpy()
+
+            self._sync_device()
+
+            for env_idx in self.new_reqs:
+                steps_finished.append(
+                    (
+                        int(self.rollouts.current_steps[env_idx]),
+                        int(env_idx),
+                    )
+                )
+                self.rollouts.actor_steps_collected[env_idx] += 1
+                self.rollouts.current_steps[env_idx] += 1
+
+                if self._variable_experience:
+                    final_step = final_batch
+                else:
+                    final_step = self.rollouts.current_steps[env_idx] == (
+                        self.rollouts.num_steps + 1
+                    )
+
+                if not final_step:
+                    self.queues.environments[env_idx].put(
+                        (EnvironmentWorkerTasks.step, None)
+                    )
+                else:
+                    # We 'replay' the steps in the final
+                    # batch of experience collected by the policy
+                    # worker. This allows us to use the inference worker
+                    # to compute the V-est for bootstrapping the returns
+                    self.replay_reqs.append(env_idx)
+
+        with self.timer.avg_time("update storage"):
+            current_step = TensorDict.from_tree(
+                dict(
+                    masks=to_batch["masks"],
+                    observations=obs,
+                    actions=actions,
+                    action_log_probs=actions_log_probs,
+                    recurrent_hidden_states=recurrent_hidden_states,
+                    prev_actions=prev_actions,
+                    policy_version=self.rollouts.current_policy_version.expand(
+                        len(self.new_reqs), 1
+                    ),
+                    episode_ids=to_batch["episode_ids"],
+                    environment_ids=to_batch["environment_ids"],
+                    step_ids=to_batch["step_ids"],
+                    value_preds=values,
+                    returns=torch.full(
+                        (),
+                        float("nan"),
+                        device=self.device,
+                    ).expand(len(self.new_reqs), 1),
+                )
+            )
+
+            prev_step = TensorDict.from_tree(dict(rewards=to_batch["rewards"]))
+
+            if self._variable_experience:
+                self._update_storage_ver(prev_step, current_step, my_slice)
+            else:
+                self._update_storage_no_ver(
+                    prev_step, current_step, current_steps
+                )
+
+        self.new_reqs = []
+
+        return True, steps_finished
+
+    def finish_rollout(self):
+        with self.timer.add_time("rollout"), self.timer.avg_time(
+            "finish rollout"
+        ):
+            self._sync_device()
+
+            # First barrier wait makes sure we don't put outstanding or replay reqs into the
+            # queue before everyone is done
+            self.iw_sync.all_workers.wait()
+            self.queues.inference.put_many(self.replay_reqs + self.new_reqs)
+            self.replay_reqs = []
+            self.new_reqs = []
+
+            # Second wait makes sure we don't read from the queue before
+            # everyone has put their outstanding or replay reqs into the queue
+            self.iw_sync.all_workers.wait()
+
+            self.iw_sync.should_start_next.clear()
+
+            # Give the replay steps to the last inference worker as this
+            # one is guaranteed to not be the main process (when there's more than 1)
+            if self.inference_worker_idx == (
+                self.config.RL.VER.num_inference_workers - 1
+            ):
+                while not self.queues.inference.empty():
+                    self.new_reqs += self.queues.inference.get_many()
+
+                self._n_replay_steps = len(self.new_reqs)
+                self.rollouts.will_replay_step[self.new_reqs] = True
+
+                self.iw_sync.rollout_done.set()
+
+        self.queues.report.put((ReportWorkerTasks.policy_timing, self.timer))
+        self.timer = Timing()
+
+    def _get_more_reqs(self) -> List[int]:
+        if len(self.new_reqs) >= self.max_reqs:
+            return []
+
+        try:
+            with self.timer.add_time("wait"):
+                return self.queues.inference.get_many(
+                    timeout=0.005,
+                    max_messages_to_get=self.max_reqs - len(self.new_reqs),
+                )
+        except queue.Empty:
+            return []
+
+    def try_one_step(self):
+        with self.timer.add_time("rollout"):
+            stepped = False
+
+            self.new_reqs += self._get_more_reqs()
+
+            should_try_step = len(self.new_reqs) > 0 and (
+                len(self.new_reqs) >= self.min_reqs
+                or (time.perf_counter() - self.last_step_time)
+                > self.min_wait_time
+            )
+
+            if should_try_step:
+                t_step_start = time.perf_counter()
+                stepped, steps_finished = self.step()
+                t_step_end = time.perf_counter()
+
+                if stepped:
+                    self.queues.preemption_decider.put(
+                        (
+                            PreemptionDeciderTasks.policy_step,
+                            dict(
+                                worker_idx=self.inference_worker_idx,
+                                steps_finished=steps_finished,
+                                t_stamp=t_step_end,
+                            ),
+                        )
+                    )
+                    self._avg_step_time.add(t_step_end - t_step_start)
+                    self.last_step_time = t_step_end
+
+                    self.min_wait_time = self._avg_step_time.mean / 2
+                    self._n_replay_steps = 0
+
+            return stepped
+
+    @inference_mode()
+    def run(self):
+        assert self.done_event is not None
+        self.actor_critic.eval()
+
+        task = None
+        while task != InferenceWorkerTasks.start:
+            task, data = self.setup_queue.get()
+            if task == InferenceWorkerTasks.set_actor_critic_tensors:
+                self.set_actor_critic_tensors(data)
+            elif task == InferenceWorkerTasks.set_rollouts:
+                self.set_rollouts(data)
+            elif task == InferenceWorkerTasks.start:
+                break
+            else:
+                raise RuntimeError(f"IW Unknown task: {task}")
+
+        while not self.done_event.is_set():
+            if not self.iw_sync.should_start_next.is_set():
+                self.iw_sync.should_start_next.wait(timeout=1.0)
+            else:
+                self.try_one_step()
+
+                self.update_should_end_early()
+
+                if self.rollouts.rollout_done:
+                    self.finish_rollout()
+
+    def update_should_end_early(self) -> None:
+        if not self._variable_experience:
+            return
+
+        use_time = True
+        if use_time:
+            if self.rollout_ends.time.value < 0.0:
+                return
+
+            end_early = self.rollout_ends.time.value <= time.perf_counter()
+
+            if end_early:
+                with self.iw_sync.lock:
+                    self.rollouts.rollout_done[:] = True
+        else:
+            if self.rollout_ends.steps.value < 0.0:
+                return
+            with self.iw_sync.lock:
+                self.rollouts.rollout_done[:] = bool(
+                    self.rollouts.rollout_done
+                ) or (
+                    self.rollout_ends.steps.value
+                    <= self.rollouts.num_steps_collected
+                )
+
+
+class InferenceWorker(WorkerBase):
+    def __init__(self, mp_ctx: BaseContext, *args, **kwargs):
+        self.setup_queue = mp_ctx.SimpleQueue()
+        super().__init__(
+            mp_ctx, InferenceWorkerProcess, self.setup_queue, *args, **kwargs
+        )
+
+    def set_actor_critic_tensors(self, actor_critic_tensors):
+        self.setup_queue.put(
+            (
+                InferenceWorkerTasks.set_actor_critic_tensors,
+                actor_critic_tensors,
+            )
+        )
+
+    def set_rollouts(self, rollouts):
+        self.setup_queue.put((InferenceWorkerTasks.set_rollouts, rollouts))
+
+    def start(self):
+        self.setup_queue.put((InferenceWorkerTasks.start, None))

--- a/habitat_baselines/rl/ver/preemption_decider.py
+++ b/habitat_baselines/rl/ver/preemption_decider.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import queue
+import time
+import warnings
+from multiprocessing.context import BaseContext
+
+import attr
+import numpy as np
+import torch
+
+from habitat import Config, logger
+from habitat_baselines.common.windowed_running_mean import WindowedRunningMean
+from habitat_baselines.rl.ddppo.ddp_utils import init_distrib_slurm, rank0_only
+from habitat_baselines.rl.ver.task_enums import (
+    PreemptionDeciderTasks,
+    ReportWorkerTasks,
+)
+from habitat_baselines.rl.ver.worker_common import (
+    ProcessBase,
+    RolloutEarlyEnds,
+    WorkerBase,
+    WorkerQueues,
+)
+
+
+@attr.s(auto_attribs=True)
+class PreemptionDeciderProcess(ProcessBase):
+    r"""Used to decide when to preempt GPU-worker stragglers when training with VER+DD-PPO.
+
+
+    This attempts to approximate the optimal preemption schedule for each rollout. The optimal
+    preemption time is defined as follows: Given the learner time, LT, and a function Time(S) that returns how long it takes to collect S steps of experience, the number of steps to collect
+    is defined as
+        argmax_S S / (Time(S) + LT)
+
+    Approximating LT is easy. That's just a simple windowed running mean of learning time as
+    that rarely changes between iterations.
+
+    Approximating Time(S) is much harder. To approximate that, we use the average step time
+    per environment (per worker) during the last rollout. This is tracked by the Inference Worker
+    sending a report to the PreemptionDecider after it has collected a step of experience and written
+    it into the learning buffer.
+    """
+    hostname: str
+    port: int
+    world_rank: int
+    world_size: int
+    config: Config
+    queues: WorkerQueues
+    my_t_zero: float
+    rollout_ends: RolloutEarlyEnds
+    opt_rollout_time_avg: WindowedRunningMean = attr.Factory(
+        lambda: WindowedRunningMean(1)
+    )
+    preemption_error_time_avg: WindowedRunningMean = attr.Factory(
+        lambda: WindowedRunningMean(16)
+    )
+    learner_time_avg: WindowedRunningMean = attr.Factory(
+        lambda: WindowedRunningMean(5)
+    )
+    my_opt_rollout_steps: float = 0.0
+    start_time: float = 0.0
+    expected_steps_collected: int = 0
+    _bin_size: float = 5.0e-3
+    _ver_extra_steps_scaling: float = 1.0
+    real_steps_collected: int = 0
+    n_rollouts_started: int = 0
+
+    def __attrs_post_init__(self):
+        self.build_dispatch_table(PreemptionDeciderTasks)
+
+    def _gather(self, arr):
+        if self.world_size == 1:
+            return arr[np.newaxis]
+
+        if self.world_rank == 0:
+            all_arr = np.empty((self.world_size, *arr.shape), dtype=arr.dtype)
+        else:
+            all_arr = None
+
+        torch.distributed.gather(
+            torch.from_numpy(arr),
+            gather_list=list(torch.from_numpy(all_arr).unbind(0))
+            if self.world_rank == 0
+            else None,
+            dst=0,
+        )
+
+        return all_arr
+
+    def _gather_all_step_averages(self):
+        my_averages = np.array(
+            [float(v) for v in self.step_averages], dtype=np.float64
+        )
+        return self._gather(my_averages), my_averages
+
+    def _all_reduce(self, val, reduce_op=torch.distributed.ReduceOp.SUM):
+        if self.world_size == 1:
+            return val
+
+        t = torch.as_tensor(val, dtype=torch.float64)
+        torch.distributed.all_reduce(t, op=reduce_op)
+        return type(val)(t)
+
+    def _reduce(self, val, mean: bool = False):
+        if self.world_size == 1:
+            return val
+
+        t = torch.as_tensor(val, dtype=torch.float64)
+        torch.distributed.reduce(t, dst=0)
+        if mean:
+            t.div_(self.world_size)
+
+        return type(val)(t)
+
+    def _bcast(self, val):
+        if self.world_size == 1:
+            return val
+
+        t = torch.as_tensor(val)
+        torch.distributed.broadcast(t, 0)
+
+        return type(val)(t)
+
+    def _compute_time(
+        self,
+        all_num_next_steps: np.ndarray,
+        all_step_averages: np.ndarray,
+        lt: float,
+    ):
+        # The maximum number of steps we can collect from 1 env. This
+        # is rollout length + 1 times the maximum difference in
+        # env speed. We also have an additional scaling factor
+        max_possible_steps = (self.config.RL.PPO.num_steps + 1) * (
+            self._ver_extra_steps_scaling
+            * np.max(all_step_averages)
+            / np.min(all_step_averages)
+        )
+
+        # A (W, N, T) sized array where each entry represents the time needed
+        # to collected t steps of experience from env n on worker w
+        rollout_lengths = all_step_averages[..., np.newaxis] * np.arange(
+            1, max_possible_steps + 1, dtype=np.float64
+        )
+
+        # Bin the rollout lengths and then compute all unique ones.
+        # Candidates lengths is in time
+        candidate_lengths, candidate_length_counts = np.unique(
+            (np.ceil(rollout_lengths / self._bin_size) * self._bin_size),
+            return_counts=True,
+        )
+        # This is the number of steps collected for each candidate length
+        candidate_length_steps = np.cumsum(candidate_length_counts)
+
+        # Mask out options where we collect too many steps
+        valids = candidate_length_steps <= (
+            self.config.RL.PPO.num_steps
+            * self.config.NUM_ENVIRONMENTS
+            * self.world_size
+        )
+
+        candidate_lengths = candidate_lengths[valids]
+        candidate_length_steps = candidate_length_steps[valids]
+
+        # Mask out options where we collect too many steps
+        # for each worker
+        valids = np.all(
+            np.count_nonzero(
+                rollout_lengths[..., np.newaxis] <= candidate_lengths,
+                axis=(1, 2),
+            )
+            <= all_num_next_steps,
+            0,
+        )
+
+        candidate_lengths = candidate_lengths[valids]
+        candidate_length_steps = candidate_length_steps[valids]
+
+        if not self.config.RL.VER.overlap_rollouts_and_learn:
+            # The total rollout time is time to collect + learning
+            # + some error factor
+            total_time = (
+                candidate_lengths
+                + lt
+                + max(float(self.preemption_error_time_avg), 0.0)
+            )
+        else:
+            # If we are overlapping, it's the
+            # max between collection time and learning time.
+            total_time = candidate_lengths + max(
+                float(self.preemption_error_time_avg), 0.0
+            )
+            if lt > np.max(total_time):
+                total_time = lt
+
+        candidate_sps = candidate_length_steps / total_time
+
+        max_sps_idx = np.argmax(candidate_sps)
+        target_length_time = candidate_lengths[max_sps_idx]
+
+        if np.any(rollout_lengths[..., -1] <= target_length_time):
+            logger.info("Growing scaling factor")
+            self._ver_extra_steps_scaling *= 1.2
+
+        self.expected_steps_collected = candidate_length_steps[max_sps_idx]
+        return target_length_time, max_possible_steps
+
+    def update(self, num_next_steps: int):
+        all_num_next_steps = self._gather(
+            np.array([num_next_steps], dtype=np.int64)
+        )
+        all_step_averages, my_step_averages = self._gather_all_step_averages()
+        lt = max(self._reduce(float(self.learner_time_avg), mean=True), 0.01)
+        target_length_time = -1.0
+        max_possible_steps = 0.0
+
+        if rank0_only():
+            if np.all(all_step_averages > 0):
+                target_length_time, max_possible_steps = self._compute_time(
+                    all_num_next_steps, all_step_averages, lt
+                )
+            else:
+                warnings.warn(
+                    "Not all environments have an estimated step time. If this warning is seen only a few times, all is fine."
+                )
+
+        target_length_time, max_possible_steps = self._bcast(
+            [float(target_length_time), float(max_possible_steps)]
+        )
+
+        if target_length_time > 0.0:
+            self.opt_rollout_time_avg += target_length_time
+            step_times = my_step_averages[:, np.newaxis] * np.arange(
+                1, max_possible_steps + 1, dtype=np.float64
+            )
+
+            self.my_opt_rollout_steps = np.count_nonzero(
+                step_times <= float(self.opt_rollout_time_avg)
+            )
+
+        if (
+            self.learner_time_avg.count == self.learner_time_avg.window_size
+            and self.opt_rollout_time_avg.count
+            == self.opt_rollout_time_avg.window_size
+        ):
+            self.rollout_ends.steps.value = float(self.my_opt_rollout_steps)
+        else:
+            self.rollout_ends.steps.value = -1
+
+    def policy_step(self, data):
+        step_time = data["t_stamp"]
+        for _, env_idx in data["steps_finished"]:
+            if self.last_step_times[env_idx] > 0:
+                self.step_averages[env_idx] += (
+                    step_time - self.last_step_times[env_idx]
+                )
+
+            self.last_step_times[env_idx] = step_time
+
+        self.real_steps_collected += len(data["steps_finished"])
+
+    def start_rollout(self, start_time: float):
+        self.start_time = self._all_reduce(
+            (start_time - self.my_t_zero),
+            reduce_op=torch.distributed.ReduceOp.MIN,
+        )
+
+        self.n_rollouts_started += 1
+        self.last_step_times[:] = -1.0
+
+        self.started = True
+        if (
+            self.learner_time_avg.count == self.learner_time_avg.window_size
+            and self.opt_rollout_time_avg.count
+            == self.opt_rollout_time_avg.window_size
+        ):
+            self.rollout_ends.time.value = (
+                self.my_t_zero
+                + self.start_time
+                + float(self.opt_rollout_time_avg)
+            )
+        else:
+            self.rollout_ends.time.value = -1
+
+    def end_rollout(self, end_steps_time: float, num_next_steps: int):
+        end_steps_time = self._all_reduce(
+            (end_steps_time - self.my_t_zero),
+            reduce_op=torch.distributed.ReduceOp.MAX,
+        )
+        self.queues.report.put(
+            (
+                ReportWorkerTasks.preemption_decider,
+                dict(
+                    real_steps_collected=self.real_steps_collected,
+                    expected_steps_collected=self.expected_steps_collected,
+                    real_rollout_time=(end_steps_time - self.start_time) * 1e3,
+                    expected_rollout_time=float(self.opt_rollout_time_avg)
+                    * 1e3,
+                ),
+            )
+        )
+
+        if self.rollout_ends.time.value > 0:
+            self.preemption_error_time_avg += (
+                end_steps_time - self.start_time
+            ) - float(self.opt_rollout_time_avg)
+
+        self.started = False
+        self.rollout_ends.time.value = -1.0
+        self.rollout_ends.steps.value = -1.0
+
+        self.update(num_next_steps)
+        self.real_steps_collected = 0
+
+    def learner_time(self, learner_time: float):
+        self.learner_time_avg += learner_time
+
+    def run(self):
+        if self.world_size > 1:
+            os.environ["MAIN_PORT"] = str(self.port)
+            init_distrib_slurm(backend="gloo")
+            torch.distributed.barrier()
+
+        self.response_queue.put(None)
+
+        self.step_averages = [
+            WindowedRunningMean(5 * self.config.RL.PPO.num_steps)
+            for _ in range(self.config.NUM_ENVIRONMENTS)
+        ]
+        self.last_step_times = np.zeros(
+            (self.config.NUM_ENVIRONMENTS,), dtype=np.float64
+        )
+
+        self.started = False
+        tasks = []
+        self.real_steps_collected = 0
+        self.n_rollouts_started = 0
+        while not self.done_event.is_set():
+            try:
+                new_tasks = self.queues.preemption_decider.get_many(
+                    timeout=1.0
+                )
+            except queue.Empty:
+                continue
+
+            if not self.started:
+                new_tasks.sort(
+                    key=lambda t: 0
+                    if t[0] == PreemptionDeciderTasks.start_rollout
+                    else 1
+                )
+
+                if new_tasks[0][0] != PreemptionDeciderTasks.start_rollout:
+                    tasks.extend(new_tasks)
+                    continue
+
+            tasks = new_tasks + tasks
+
+            did_break = False
+            for i, (task, data) in enumerate(tasks):
+                self.dispatch_task(task, data)
+
+                if task == PreemptionDeciderTasks.end_rollout:
+                    tasks = tasks[i + 1 :]
+                    did_break = True
+                    break
+
+            if not did_break:
+                tasks = []
+
+
+class PreemptionDeciderWorker(WorkerBase):
+    def __init__(
+        self,
+        mp_ctx: BaseContext,
+        hostname: str,
+        port: int,
+        world_rank: int,
+        world_size: int,
+        config: Config,
+        queues: WorkerQueues,
+        my_t_zero: float,
+    ):
+        self.rollout_ends = RolloutEarlyEnds(mp_ctx)
+        self.queues = queues
+        super().__init__(
+            mp_ctx,
+            PreemptionDeciderProcess,
+            hostname,
+            port,
+            world_rank,
+            world_size,
+            config,
+            queues,
+            my_t_zero,
+            rollout_ends=self.rollout_ends,
+        )
+
+        self.response_queue.get()
+
+    def start_rollout(self):
+        self.queues.preemption_decider.put(
+            (PreemptionDeciderTasks.start_rollout, time.perf_counter())
+        )
+
+    def end_rollout(self, num_next_steps):
+        self.queues.preemption_decider.put(
+            (
+                PreemptionDeciderTasks.end_rollout,
+                (time.perf_counter(), num_next_steps),
+            )
+        )
+
+    def learner_time(self, learning_time):
+        self.queues.preemption_decider.put(
+            (PreemptionDeciderTasks.learner_time, learning_time)
+        )

--- a/habitat_baselines/rl/ver/queue.py
+++ b/habitat_baselines/rl/ver/queue.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import TYPE_CHECKING
+
+try:
+    import faster_fifo
+
+    use_faster_fifo = True
+except ImportError:
+    use_faster_fifo = False
+
+
+if not TYPE_CHECKING and use_faster_fifo:
+    # This package contains the implementation
+    # for pickling FasterFifo with ForkingPickler,
+    # which allows the queues to be passed to processes.
+    import faster_fifo_reduction  # noqa: F401
+
+    BatchedQueue = faster_fifo.Queue
+else:
+    import queue
+    import time
+    import warnings
+
+    import torch
+
+    warnings.warn(
+        "Unable to import faster_fifo."
+        " Using the fallback. This may reduce performance."
+    )
+
+    class BatchedQueue(torch.multiprocessing.Queue):
+        def get_many(
+            self,
+            block=True,
+            timeout=10.0,
+            max_messages_to_get=1_000_000_000,
+        ):
+            msgs = [self.get(block, timeout)]
+            while len(msgs) < max_messages_to_get:
+                try:
+                    msgs.append(self.get_nowait())
+                except queue.Empty:
+                    break
+
+            return msgs
+
+        def put_many(self, xs, block=True, timeout=10.0):
+
+            t_start = time.perf_counter()
+            n_put = 0
+            for x in xs:
+                self.put(x, block, timeout - (t_start - time.perf_counter()))
+                n_put += 1
+
+            if n_put != len(xs):
+                raise RuntimeError(
+                    f"Couldn't put all. Put {n_put}, needed to put {len(xs)}"
+                )

--- a/habitat_baselines/rl/ver/report_worker.py
+++ b/habitat_baselines/rl/ver/report_worker.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import functools
+import os
+import time
+from collections import defaultdict
+from multiprocessing.context import BaseContext
+from typing import Any, Dict, Iterator, List, Optional, Tuple, cast
+
+import attr
+import numpy as np
+import torch
+
+from habitat import Config, logger
+from habitat_baselines.common.tensor_dict import (
+    NDArrayDict,
+    transpose_list_of_dicts,
+)
+from habitat_baselines.common.tensorboard_utils import (
+    TensorboardWriter,
+    get_writer,
+)
+from habitat_baselines.common.windowed_running_mean import WindowedRunningMean
+from habitat_baselines.rl.ddppo.ddp_utils import (
+    gather_objects,
+    get_distrib_size,
+    init_distrib_slurm,
+    rank0_only,
+)
+from habitat_baselines.rl.ver.queue import BatchedQueue
+from habitat_baselines.rl.ver.task_enums import ReportWorkerTasks
+from habitat_baselines.rl.ver.worker_common import ProcessBase, WorkerBase
+
+
+@attr.s(auto_attribs=True)
+class ReportWorkerProcess(ProcessBase):
+    r"""Responsible for generating reports. Reports on system performance (timings),
+    learning progress, and agent training progress.
+    """
+    port: int
+    config: Config
+    report_queue: BatchedQueue
+    my_t_zero: float
+    num_steps_done: torch.Tensor
+    time_taken: torch.Tensor
+    n_update_reports: int = 0
+    flush_secs: int = 30
+    _world_size: Optional[int] = None
+    _prev_time_taken: float = 0.0
+    timing_stats: Dict[str, Dict[str, WindowedRunningMean]] = attr.ib(
+        init=False, default=None
+    )
+    stats_this_rollout: Dict[str, List[float]] = attr.ib(
+        init=False, factory=lambda: defaultdict(list)
+    )
+    steps_delta: int = 0
+    writer: Optional[Any] = None
+    preemption_decider_report: Dict[str, float] = attr.ib(
+        factory=dict, init=False
+    )
+    window_episode_stats: Optional[Dict[str, WindowedRunningMean]] = attr.ib(
+        default=None, init=False
+    )
+
+    def __attrs_post_init__(self):
+        self.build_dispatch_table(ReportWorkerTasks)
+
+    def state_dict(self):
+        self.response_queue.put(
+            dict(
+                prev_time_taken=float(self.time_taken),
+                window_episode_stats=self.window_episode_stats,
+                num_steps_done=int(self.num_steps_done),
+                timing_stats=self.timing_stats,
+                running_frames_window=self.running_frames_window,
+                running_time_window=self.running_time_window,
+                n_update_reports=self.n_update_reports,
+            )
+        )
+
+    def load_state_dict(self, state_dict):
+        self._prev_time_taken = state_dict["prev_time_taken"]
+        self.time_taken.fill_(self._prev_time_taken)
+        self.window_episode_stats = state_dict["window_episode_stats"]
+        self.num_steps_done.fill_(int(state_dict["num_steps_done"]))
+        self.timing_stats = state_dict["timing_stats"]
+        self.running_frames_window = state_dict["running_frames_window"]
+        self.running_time_window = state_dict["running_time_window"]
+        self.n_update_reports = state_dict["n_update_reports"]
+
+    @property
+    def world_size(self) -> int:
+        if self._world_size is None:
+            if not torch.distributed.is_initialized():
+                self._world_size = 1
+            else:
+                self._world_size = torch.distributed.get_world_size()
+
+        return self._world_size
+
+    def _all_reduce(self, val, reduce_op=torch.distributed.ReduceOp.SUM):
+        if self.world_size == 1:
+            return val
+
+        t = torch.as_tensor(val, dtype=torch.float64)
+        torch.distributed.all_reduce(t, op=reduce_op)
+        return type(val)(t)
+
+    METRICS_BLACKLIST = {"top_down_map", "collisions.is_collision"}
+
+    @classmethod
+    def _extract_scalars_from_info(
+        cls, info: Dict[str, Any]
+    ) -> Iterator[Tuple[str, float]]:
+        for k, v in info.items():
+            if k in cls.METRICS_BLACKLIST:
+                continue
+
+            if isinstance(v, dict):
+                for subk, subv in cls._extract_scalars_from_info(v):
+                    yield f"{k}.{subk}", subv
+            # Things that are scalar-like will have an np.size of 1.
+            # Strings also have an np.size of 1, so explicitly ban those
+            elif np.size(v) == 1 and not isinstance(v, str):
+                yield k, float(v)
+
+    def get_time(self):
+        return time.perf_counter() - self.my_t_zero
+
+    def log_metrics(
+        self, writer: TensorboardWriter, learner_metrics: Dict[str, float]
+    ):
+        self.steps_delta = int(self._all_reduce(self.steps_delta))
+        self.num_steps_done += self.steps_delta
+        last_time_taken = float(self.time_taken)
+        self.time_taken.fill_(
+            self._all_reduce(self.get_time() - self.start_time)
+            / self.world_size
+            + self._prev_time_taken
+        )
+
+        self.running_frames_window += self.steps_delta
+        self.running_time_window += float(self.time_taken) - last_time_taken
+
+        self.steps_delta = 0
+
+        all_stats_this_rollout = gather_objects(
+            dict(self.stats_this_rollout), device=self.device
+        )
+        self.stats_this_rollout.clear()
+        if rank0_only():
+            assert all_stats_this_rollout is not None
+            assert self.window_episode_stats is not None
+            for stats in all_stats_this_rollout:
+                for k, vs in stats.items():
+                    self.window_episode_stats[k].add_many(vs)
+
+        all_learner_metrics = gather_objects(learner_metrics)
+        all_preemption_decider_reports = gather_objects(
+            self.preemption_decider_report
+        )
+
+        if rank0_only():
+            assert all_learner_metrics is not None
+            learner_metrics = cast(
+                Dict[str, float],
+                (
+                    NDArrayDict.from_tree(
+                        transpose_list_of_dicts(*all_learner_metrics)
+                    )
+                    .map(np.mean)
+                    .to_tree()
+                ),
+            )
+            n_steps = int(self.num_steps_done)
+            if "reward" in self.window_episode_stats:
+                writer.add_scalar(
+                    "reward",
+                    self.window_episode_stats["reward"].mean,
+                    n_steps,
+                )
+
+            for k in self.window_episode_stats.keys():
+                if k == "reward":
+                    continue
+
+                writer.add_scalar(
+                    f"metrics/{k}", self.window_episode_stats[k].mean, n_steps
+                )
+
+            for k, v in learner_metrics.items():
+                writer.add_scalar(f"learner/{k}", v, n_steps)
+
+            writer.add_scalar(
+                "perf/fps",
+                n_steps / float(self.time_taken),
+                n_steps,
+            )
+            writer.add_scalar(
+                "perf/fps_window",
+                float(self.running_frames_window)
+                / float(self.running_time_window),
+                n_steps,
+            )
+
+        if rank0_only():
+            assert all_preemption_decider_reports is not None
+            preemption_decider_report = cast(
+                Dict[str, float],
+                NDArrayDict.from_tree(
+                    transpose_list_of_dicts(*all_preemption_decider_reports)
+                )
+                .map(np.mean)
+                .to_tree(),
+            )
+            preemption_decider_report = {
+                k: v / (self.world_size if "time" in k else 1)
+                for k, v in preemption_decider_report.items()
+            }
+            for k, v in preemption_decider_report.items():
+                writer.add_scalar(f"preemption_decider/{k}", v, n_steps)
+
+        if self.n_update_reports % self.config.LOG_INTERVAL == 0:
+            if rank0_only():
+                logger.info(
+                    "update: {}\tfps: {:.1f}\twindow fps: {:.1f}\tframes: {:d}".format(
+                        self.n_update_reports,
+                        n_steps / float(self.time_taken),
+                        float(self.running_frames_window)
+                        / float(self.running_time_window),
+                        n_steps,
+                    )
+                )
+                if len(self.window_episode_stats) > 0:
+                    logger.info(
+                        "Average window size: {}  {}".format(
+                            next(
+                                iter(self.window_episode_stats.values())
+                            ).count,
+                            "  ".join(
+                                "{}: {:.3f}".format(k, v.mean)
+                                for k, v in self.window_episode_stats.items()
+                            ),
+                        )
+                    )
+            all_timing_stats = gather_objects(
+                {
+                    k: {sk: sv.mean for sk, sv in v.items()}
+                    for k, v in self.timing_stats.items()
+                }
+            )
+            if rank0_only():
+                assert all_timing_stats is not None
+                timing_stats = cast(
+                    Dict[str, Dict[str, float]],
+                    NDArrayDict.from_tree(
+                        transpose_list_of_dicts(*all_timing_stats)
+                    )
+                    .map(np.mean)
+                    .to_tree(),
+                )
+                for stats_name in sorted(timing_stats.keys()):
+                    logger.info(
+                        "{}: ".format(stats_name)
+                        + "  ".join(
+                            "{}: {:.1f}ms".format(k, v * 1e3)
+                            for k, v in sorted(
+                                timing_stats[stats_name].items(),
+                                key=lambda kv: kv[1],
+                                reverse=True,
+                            )
+                        )
+                    )
+
+    def episode_end(self, data):
+        self.stats_this_rollout["reward"].append(data["reward"])
+        for k, v in self._extract_scalars_from_info(data["info"]):
+            self.stats_this_rollout[k].append(v)
+
+    def num_steps_collected(self, num_steps: int):
+        self.steps_delta = num_steps
+
+    def learner_update(self, data):
+        self.n_update_reports += 1
+        self.log_metrics(self.writer, data)
+
+    def start_collection(self, start_time):
+        start_time = self._all_reduce(
+            start_time - self.my_t_zero,
+            reduce_op=torch.distributed.ReduceOp.MIN,
+        )
+        self.start_time = start_time
+
+    def preemption_decider(self, preemption_decider_report):
+        self.preemption_decider_report = preemption_decider_report
+
+    def env_timing(self, timing):
+        for k, v in timing.items():
+            self.timing_stats["env"][k] += v
+
+    def policy_timing(self, timing):
+        for k, v in timing.items():
+            self.timing_stats["policy"][k] += v
+
+    def learner_timing(self, timing):
+        for k, v in timing.items():
+            self.timing_stats["learner"][k] += v
+
+    def get_window_episode_stats(self):
+        self.response_queue.put(self.window_episode_stats)
+
+    @property
+    def task_queue(self) -> BatchedQueue:
+        return self.report_queue
+
+    def run(self):
+        self.device = torch.device("cpu")
+        if get_distrib_size()[2] > 1:
+            os.environ["MAIN_PORT"] = str(self.port)
+            init_distrib_slurm(backend="gloo")
+            torch.distributed.barrier()
+
+        self.response_queue.put(None)
+
+        ppo_cfg = self.config.RL.PPO
+
+        self.steps_delta = 0
+        if rank0_only():
+            self.window_episode_stats = defaultdict(
+                functools.partial(
+                    WindowedRunningMean,
+                    ppo_cfg.reward_window_size
+                    * self.config.NUM_ENVIRONMENTS
+                    * self.world_size,
+                )
+            )
+        else:
+            self.window_episode_stats = None
+
+        timing_types = {
+            ReportWorkerTasks.env_timing: "env",
+            ReportWorkerTasks.policy_timing: "policy",
+            ReportWorkerTasks.learner_timing: "learner",
+        }
+        self.timing_stats = {
+            n: defaultdict(
+                functools.partial(
+                    WindowedRunningMean, ppo_cfg.reward_window_size
+                )
+            )
+            for n in timing_types.values()
+        }
+        self.preemption_decider_report = {}
+
+        self.start_time = self.get_time()
+        self.running_time_window = WindowedRunningMean(
+            ppo_cfg.reward_window_size
+        )
+        self.running_frames_window = WindowedRunningMean(
+            ppo_cfg.reward_window_size
+        )
+
+        with (
+            get_writer(
+                self.config,
+                flush_secs=self.flush_secs,
+                purge_step=int(self.num_steps_done),
+            )
+            if rank0_only()
+            else contextlib.suppress()
+        ) as writer:
+            self.writer = writer
+            super().run()
+
+            self.writer = None
+
+
+class ReportWorker(WorkerBase):
+    def __init__(
+        self,
+        mp_ctx: BaseContext,
+        port: int,
+        config: Config,
+        report_queue: BatchedQueue,
+        my_t_zero: float,
+        init_num_steps=0,
+    ):
+        self.num_steps_done = torch.full(
+            (), int(init_num_steps), dtype=torch.int64
+        )
+        self.time_taken = torch.full((), 0.0, dtype=torch.float64)
+        self.num_steps_done.share_memory_()
+        self.time_taken.share_memory_()
+        self.report_queue = report_queue
+        super().__init__(
+            mp_ctx,
+            ReportWorkerProcess,
+            port,
+            config,
+            report_queue,
+            my_t_zero,
+            self.num_steps_done,
+            self.time_taken,
+        )
+
+        self.response_queue.get()
+
+    def start_collection(self):
+        self.report_queue.put(
+            (ReportWorkerTasks.start_collection, time.perf_counter())
+        )
+
+    def state_dict(self):
+        self.report_queue.put((ReportWorkerTasks.state_dict, None))
+        return self.response_queue.get()
+
+    def load_state_dict(self, state_dict):
+        if state_dict is not None:
+            self.report_queue.put(
+                (ReportWorkerTasks.load_state_dict, state_dict)
+            )
+
+    def get_window_episode_stats(self):
+        self.report_queue.put(
+            (ReportWorkerTasks.get_window_episode_stats, None)
+        )
+        return self.response_queue.get()

--- a/habitat_baselines/rl/ver/requirements.txt
+++ b/habitat_baselines/rl/ver/requirements.txt
@@ -1,0 +1,2 @@
+faster_fifo>=1.4.2
+threadpoolctl>=3.1.0

--- a/habitat_baselines/rl/ver/task_enums.py
+++ b/habitat_baselines/rl/ver/task_enums.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import enum
+
+
+class EnvironmentWorkerTasks(enum.Enum):
+    start = enum.auto()
+    step = enum.auto()
+    reset = enum.auto()
+    set_transfer_buffers = enum.auto()
+    set_action_plugin = enum.auto()
+    start_experience_collection = enum.auto()
+    wait = enum.auto()
+
+
+class ReportWorkerTasks(enum.Enum):
+    episode_end = enum.auto()
+    learner_update = enum.auto()
+    learner_timing = enum.auto()
+    env_timing = enum.auto()
+    policy_timing = enum.auto()
+    start_collection = enum.auto()
+    state_dict = enum.auto()
+    load_state_dict = enum.auto()
+    preemption_decider = enum.auto()
+    num_steps_collected = enum.auto()
+    get_window_episode_stats = enum.auto()
+
+
+class PreemptionDeciderTasks(enum.Enum):
+    policy_step = enum.auto()
+    start_rollout = enum.auto()
+    end_rollout = enum.auto()
+    learner_time = enum.auto()
+
+
+class InferenceWorkerTasks(enum.Enum):
+    set_rollouts = enum.auto()
+    set_actor_critic_tensors = enum.auto()
+    start = enum.auto()

--- a/habitat_baselines/rl/ver/timing.py
+++ b/habitat_baselines/rl/ver/timing.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+from habitat_baselines.common.windowed_running_mean import WindowedRunningMean
+
+EPS = 1e-5
+
+
+class TimingContext:
+    def __init__(self, timer, key, additive=False, average=None):
+        self._timer = timer
+        self._key = key
+        self._additive = additive
+        self._average = average
+        self._time_enter = None
+
+    def __enter__(self):
+        if self._key not in self._timer:
+            if self._average is not None:
+                self._timer[self._key] = WindowedRunningMean(self._average)
+            else:
+                self._timer[self._key] = 0
+
+        self._time_enter = time.perf_counter()
+
+    def __exit__(self, type_, value, traceback):
+        time_passed = max(
+            time.perf_counter() - self._time_enter, EPS
+        )  # EPS to prevent div by zero
+
+        if self._additive or self._average is not None:
+            self._timer[self._key] += time_passed
+        else:
+            self._timer[self._key] = time_passed
+
+
+class Timing(dict):
+    def timeit(self, key):
+        return TimingContext(self, key)
+
+    def add_time(self, key):
+        return TimingContext(self, key, additive=True)
+
+    def avg_time(self, key, average=float("inf")):
+        return TimingContext(self, key, average=average)
+
+    def __str__(self):
+        s = ""
+        i = 0
+        for key, value in self.items():
+            str_value = f"{float(value):.4f}"
+            s += f"{key}: {str_value}"
+            if i < len(self) - 1:
+                s += ", "
+            i += 1
+        return s

--- a/habitat_baselines/rl/ver/ver_rollout_storage.py
+++ b/habitat_baselines/rl/ver/ver_rollout_storage.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from habitat_baselines.common.rollout_storage import RolloutStorage
+from habitat_baselines.common.tensor_dict import DictTree, TensorDict
+from habitat_baselines.rl.models.rnn_state_encoder import (
+    _np_invert_permutation,
+    build_pack_info_from_episode_ids,
+    build_rnn_build_seq_info,
+)
+
+
+def _np_unique_not_sorted(arr: np.ndarray) -> np.ndarray:
+    sorted_unq_arr, indexes = np.unique(arr, return_index=True)
+    # Indexes contains the index of the first instance of each unique
+    # value in the array. So we can use as the sort-key to re-order
+    # the sorted unique array such that each value is in the order
+    # it appeared in the array.
+    return sorted_unq_arr[np.argsort(indexes)]
+
+
+def compute_movements_for_aliased_swaps(
+    dst_locations: np.ndarray, src_locations: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    r"""Computes the movements needed as a result of performing the all the swaps from
+    source to dest.
+
+    This is needed because just swapping t[dst_locations] with t[src_locations] will not be
+    correct in the case of aliasing. This returns a tuple of (dst, src) such that the desired
+    swaps can be performed as t[dst] = t[src]
+    """
+
+    assert len(dst_locations) == len(src_locations)
+
+    # We can think of swapping as follows:
+    # 1. We take all values from source and put them in their dst
+    # location.
+    # 2. Now the array has N - k duplicated values and N - k deleted values,
+    # where N = len(dst_locations) and k = len(intersection(dst_locations, src_locations))
+    # 3. The N - k delete values were at indices setdiff(dst_locations, src_locations)
+    # and the duplicated values are at setdiff(src_locations, dst_locations). So we
+    # put the deleted values into the locations of the duplicated values
+    # The _np_unique_not_sorted calls bellow take
+    # cat(a, b) and make it cat(a, setdiff(b, a))
+    swap_dst = _np_unique_not_sorted(
+        np.concatenate((dst_locations, src_locations), axis=0)
+    )
+    swap_src = _np_unique_not_sorted(
+        np.concatenate((src_locations, dst_locations), axis=0)
+    )
+
+    assert len(swap_src) == len(swap_dst)
+    return swap_dst, swap_src
+
+
+def partition_n_into_p(n: int, p: int) -> List[int]:
+    r"""Creates a partitioning of n elements into p bins."""
+    return [n // p + (1 if i < (n % p) else 0) for i in range(p)]
+
+
+def generate_ver_mini_batches(
+    num_mini_batch: int,
+    sequence_lengths: np.ndarray,
+    num_seqs_at_step: np.ndarray,
+    select_inds: np.ndarray,
+    last_sequence_in_batch_mask: np.ndarray,
+    episode_ids: np.ndarray,
+) -> Iterator[np.ndarray]:
+    r"""Generate mini-batches for VER.
+
+    This works by taking all the sequences of experience, putting them in a random order,
+    and then slicing their steps into :ref:`num_mini_batch` batches.
+    """
+
+    sequence_lengths = sequence_lengths.copy()
+    # We don't want to include the last step from the last sequence from each environment
+    # as this is the step we collected for bootstrapping the return.
+    sequence_lengths[last_sequence_in_batch_mask] -= 1
+
+    offset_to_step = (
+        np.cumsum(num_seqs_at_step, dtype=np.int64) - num_seqs_at_step
+    )
+    seq_ordering = np.random.permutation(len(sequence_lengths))
+
+    all_seq_steps_l = [
+        select_inds[i + offset_to_step[0 : sequence_lengths[i]]]
+        for i in range(len(sequence_lengths))
+    ]
+
+    for s_steps in all_seq_steps_l:
+        if len(s_steps) == 0:
+            continue
+
+        assert len(np.unique(episode_ids[s_steps])) == 1, episode_ids[s_steps]
+
+    all_seq_steps = np.concatenate(
+        [all_seq_steps_l[seq] for seq in seq_ordering]
+    )
+
+    mb_sizes = np.array(
+        partition_n_into_p(int(np.sum(sequence_lengths)), num_mini_batch),
+        dtype=np.int64,
+    )
+    mb_starts = np.cumsum(mb_sizes, dtype=np.int64) - mb_sizes
+
+    # Yield the mini-batches in random order since where each mb is cut
+    # isn't random otherwise
+    for mb_idx in np.random.permutation(num_mini_batch):
+        yield all_seq_steps[
+            mb_starts[mb_idx] : mb_starts[mb_idx] + mb_sizes[mb_idx]
+        ]
+
+
+class VERRolloutStorage(RolloutStorage):
+    r"""Rollout storage for VER."""
+    ptr: np.ndarray
+    prev_inds: np.ndarray
+    num_steps_collected: np.ndarray
+    rollout_done: np.ndarray
+    cpu_current_policy_version: np.ndarray
+    actor_steps_collected: np.ndarray
+    current_steps: np.ndarray
+    will_replay_step: np.ndarray
+    _first_rollout: np.ndarray
+
+    next_hidden_states: torch.Tensor
+    next_prev_actions: torch.Tensor
+    current_policy_version: torch.Tensor
+
+    def __init__(
+        self,
+        variable_experience: bool,
+        numsteps,
+        num_envs,
+        observation_space,
+        action_space,
+        recurrent_hidden_state_size,
+        num_recurrent_layers=1,
+        action_shape: Optional[Tuple[int]] = None,
+        is_double_buffered: bool = False,
+        discrete_actions: bool = True,
+    ):
+        super().__init__(
+            numsteps,
+            num_envs,
+            observation_space,
+            action_space,
+            recurrent_hidden_state_size,
+            num_recurrent_layers,
+            action_shape,
+            is_double_buffered,
+            discrete_actions,
+        )
+        self.use_is_coeffs = variable_experience
+
+        if self.use_is_coeffs:
+            self.buffers["is_coeffs"] = torch.ones_like(
+                self.buffers["returns"]
+            )
+
+        for k in (
+            "policy_version",
+            "environment_ids",
+            "episode_ids",
+            "step_ids",
+        ):
+            self.buffers[k] = torch.zeros_like(
+                self.buffers["returns"], dtype=torch.int64
+            )
+
+        self.buffers["is_stale"] = torch.ones_like(
+            self.buffers["returns"], dtype=torch.bool
+        )
+
+        self.variable_experience = variable_experience
+        self.buffer_size = (self.num_steps + 1) * self._num_envs
+
+        # The aux buffers are auxiliary things that are accessed
+        # via the annotations on this class. This is done to ensure
+        # that all of these things end up in shared memory and that
+        # we keep the torch tensor that backs the shared memory around.
+        # We use numpy arrays to access CPU-side data as that is faster,
+        # but use pytorch to manage the shared memory.
+        self._aux_buffers = TensorDict()
+        self.aux_buffers_on_device = set()
+
+        assert isinstance(
+            self.buffers["recurrent_hidden_states"], torch.Tensor
+        )
+        self._aux_buffers["next_hidden_states"] = self.buffers[
+            "recurrent_hidden_states"
+        ][0].clone()
+        assert isinstance(self.buffers["prev_actions"], torch.Tensor)
+        self._aux_buffers["next_prev_actions"] = self.buffers["prev_actions"][
+            0
+        ].clone()
+        self._aux_buffers["current_policy_version"] = torch.ones(
+            (1, 1), dtype=torch.int64
+        )
+
+        self.aux_buffers_on_device.update(set(self._aux_buffers.keys()))
+
+        self._aux_buffers["cpu_current_policy_version"] = torch.ones(
+            (1, 1), dtype=torch.int64
+        )
+
+        self._aux_buffers["num_steps_collected"] = torch.zeros(
+            (1,), dtype=torch.int64
+        )
+        self._aux_buffers["rollout_done"] = torch.zeros((1,), dtype=torch.bool)
+        self._aux_buffers["current_steps"] = torch.zeros(
+            (num_envs,), dtype=torch.int64
+        )
+        self._aux_buffers["actor_steps_collected"] = torch.zeros(
+            (num_envs,), dtype=torch.int64
+        )
+
+        self._aux_buffers["ptr"] = torch.zeros((1,), dtype=torch.int64)
+        self._aux_buffers["prev_inds"] = torch.full(
+            (num_envs,), -1, dtype=torch.int64
+        )
+        self._aux_buffers["_first_rollout"] = torch.full(
+            (1,), True, dtype=torch.bool
+        )
+        self._aux_buffers["will_replay_step"] = torch.zeros(
+            (num_envs,), dtype=torch.bool
+        )
+
+        if self.variable_experience:
+            # In VER mode, there isn't a clean assignment from
+            # (env_id, current_step) to place in the rollouts storage
+            # anymore. Instead we treat this as just a linear buffer
+            # and write into that.
+            self.buffers.map_in_place(lambda t: t.flatten(0, 1))
+
+        self._set_aux_buffers()
+
+    @property
+    def num_steps_to_collect(self) -> int:
+        if self._first_rollout:
+            return self.buffer_size
+        else:
+            return self._num_envs * self.num_steps
+
+    def _set_aux_buffers(self):
+        for k, v in self.__annotations__.items():
+            if k not in self._aux_buffers:
+                if v in (torch.Tensor, np.ndarray):
+                    raise RuntimeError(f"Annotation {k} not in aux buffers")
+                else:
+                    continue
+
+            if k in self.aux_buffers_on_device:  # noqa: SIM401
+                buf = self._aux_buffers[k]
+            else:
+                buf = self._aux_buffers[k].numpy()
+
+            assert isinstance(
+                buf, v
+            ), f"Expected aux buffer of type {v} but got {type(buf)}"
+            setattr(self, k, buf)
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = super().__getstate__().copy()
+
+        # We have to remove the aux_buffers
+        # that we assigned to the class via annotations
+        # otherwise they will get copied by pickling
+        for k in self.__annotations__.keys():
+            if k in self._aux_buffers:
+                del state[k]
+
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]):
+        super().__setstate__(state)
+
+        # On unpickle, we reset the aux buffers.
+        self._set_aux_buffers()
+
+    def copy(self, other: "VERRolloutStorage"):
+        self.buffers[:] = other.buffers
+        self._aux_buffers[:] = other._aux_buffers
+
+    def share_memory_(self):
+        self.buffers.map_in_place(lambda t: t.share_memory_())
+
+        self._aux_buffers.map_in_place(lambda t: t.share_memory_())
+
+        self._set_aux_buffers()
+
+    def to(self, device):
+        super().to(device)
+
+        for k, t in self._aux_buffers.items():
+            if k in self.aux_buffers_on_device:
+                assert isinstance(t, torch.Tensor)
+                self._aux_buffers[k] = t.to(device=device)
+
+        self._set_aux_buffers()
+
+    def after_update(self):
+        self.current_steps[:] = 1
+        self.current_steps[self.will_replay_step] -= 1
+        assert isinstance(self.buffers["is_stale"], torch.Tensor)
+        self.buffers["is_stale"].fill_(True)
+
+        if not self.variable_experience:
+            assert np.all(self.will_replay_step)
+            self.next_hidden_states[:] = self.buffers[
+                "recurrent_hidden_states"
+            ][-1]
+            self.next_prev_actions[:] = self.buffers["prev_actions"][-1]
+        else:
+            # With ver, we will have some actions
+            # in flight as we can't reset the simulator. In that case we need
+            # to save the prev rollout step data for that action (as the
+            # reward for the action in flight is for the prev rollout
+            # step). We put those into [0:num_with_action_in_flight]
+            # because that range won't be overwritten.
+            has_action_in_flight = np.logical_not(self.will_replay_step)
+            num_with_action_in_flight = np.count_nonzero(has_action_in_flight)
+
+            prev_inds_for_swap: np.ndarray = np.concatenate(
+                (
+                    self.prev_inds[has_action_in_flight],
+                    # For previous steps without an action in flight,
+                    # we will "replay" that step of experience
+                    # so we can use the new policy for inference.
+                    # We need to make sure they get overwritten in the next
+                    # rollout, so we place them at the
+                    # start of where we will write during the next rollout.
+                    self.prev_inds[np.logical_not(has_action_in_flight)],
+                )
+            )
+            dst_locations, src_locations = map(
+                lambda n: torch.from_numpy(n).to(device=self.device),
+                compute_movements_for_aliased_swaps(
+                    np.arange(len(prev_inds_for_swap)), prev_inds_for_swap
+                ),
+            )
+            self.buffers[dst_locations] = self.buffers[src_locations]
+
+            self.prev_inds[:] = -1
+            self.prev_inds[has_action_in_flight] = np.arange(
+                num_with_action_in_flight,
+                dtype=self.prev_inds.dtype,
+            )
+            self.will_replay_step[:] = False
+            self.ptr[:] = num_with_action_in_flight
+
+            # For the remaining steps, we order them such that the oldest experience
+            # get's overwritten first.
+            assert isinstance(self.buffers["policy_version"], torch.Tensor)
+            version_diff = (
+                self.current_policy_version.view(-1)
+                - self.buffers["policy_version"].view(-1)[self._num_envs :]
+            )
+            # Add index to make the sort stable
+            _, version_ordering = torch.sort(
+                version_diff * version_diff.numel()
+                + torch.arange(
+                    version_diff.numel() - 1,
+                    -1,
+                    step=-1,
+                    dtype=version_diff.dtype,
+                    device=version_diff.device,
+                ),
+                descending=True,
+            )
+
+            self.buffers.apply(
+                lambda t: t[self._num_envs :].copy_(
+                    t[self._num_envs :].index_select(0, version_ordering)
+                )
+            )
+
+        self.num_steps_collected[:] = 0
+        self.rollout_done[:] = False
+        self._first_rollout[:] = False
+
+    def increment_policy_version(self):
+        self.current_policy_version += 1
+
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+
+        self.cpu_current_policy_version += 1
+
+    def after_rollout(self):
+        assert isinstance(self.buffers["policy_version"], torch.Tensor)
+        assert isinstance(self.buffers["is_stale"], torch.Tensor)
+        self.buffers["is_stale"][:] = (
+            self.buffers["policy_version"] < self.current_policy_version
+        )
+
+        self.current_rollout_step_idxs[0] = self.num_steps + 1
+
+        if self.use_is_coeffs:
+            # To correct for the biased sampling in VER, we use importance
+            # sampling weighting. To do this we must count the number of
+            # steps of experience we got from each environment
+            assert isinstance(self.buffers["environment_ids"], torch.Tensor)
+            environment_ids = self.buffers["environment_ids"].view(-1)
+            unique_envs = torch.unique(environment_ids, sorted=False)
+            samples_per_env = (
+                (environment_ids.view(1, -1) == unique_envs.view(-1, 1))
+                .float()
+                .sum(-1)
+            )
+            is_per_env = torch.empty(
+                (self._num_envs,), dtype=torch.float32, device=self.device
+            )
+            # Use a scatter so that is_per_env.size() == num_envs
+            # and so that we don't have to have unique_envs be sorted
+            is_per_env.scatter_(
+                0,
+                unique_envs.view(-1),
+                # With uniform sampling, we'd get (numsteps + 1)
+                # per actor
+                (self.num_steps + 1) / samples_per_env,
+            )
+            assert isinstance(self.buffers["is_coeffs"], torch.Tensor)
+            self.buffers["is_coeffs"].copy_(
+                is_per_env[environment_ids].view(-1, 1)
+            )
+
+    def compute_returns(
+        self,
+        use_gae,
+        gamma,
+        tau,
+    ):
+        if not use_gae:
+            tau = 1.0
+
+        assert isinstance(self.buffers["masks"], torch.Tensor)
+        not_masks = torch.logical_not(self.buffers["masks"]).to(
+            device="cpu", non_blocking=True
+        )
+        assert isinstance(self.buffers["episode_ids"], torch.Tensor)
+        episode_ids_cpu_t = self.buffers["episode_ids"].to(
+            device="cpu", non_blocking=True
+        )
+        assert isinstance(self.buffers["environment_ids"], torch.Tensor)
+        environment_ids_cpu_t = self.buffers["environment_ids"].to(
+            device="cpu", non_blocking=True
+        )
+        assert isinstance(self.buffers["step_ids"], torch.Tensor)
+        step_ids_cpu_t = self.buffers["step_ids"].to(
+            device="cpu", non_blocking=True
+        )
+
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+
+        self.dones_cpu = not_masks.view(-1, self._num_envs).numpy()
+        self.episode_ids_cpu = episode_ids_cpu_t.view(-1).numpy()
+        self.environment_ids_cpu = environment_ids_cpu_t.view(-1).numpy()
+        self.step_ids_cpu = step_ids_cpu_t.view(-1).numpy()
+
+        assert isinstance(self.buffers["rewards"], torch.Tensor)
+        rewards_t = self.buffers["rewards"].to(device="cpu", non_blocking=True)
+        assert isinstance(self.buffers["returns"], torch.Tensor)
+        returns_t = self.buffers["returns"].to(device="cpu", non_blocking=True)
+        assert isinstance(self.buffers["is_stale"], torch.Tensor)
+        is_not_stale_t = torch.logical_not(self.buffers["is_stale"]).to(
+            device="cpu", non_blocking=True
+        )
+        assert isinstance(self.buffers["value_preds"], torch.Tensor)
+        values_t = self.buffers["value_preds"].to(
+            device="cpu", non_blocking=True
+        )
+
+        rnn_build_seq_info = build_pack_info_from_episode_ids(
+            self.episode_ids_cpu,
+            self.environment_ids_cpu,
+            self.step_ids_cpu,
+        )
+
+        (
+            self.select_inds,
+            self.num_seqs_at_step,
+            self.sequence_lengths,
+            self.sequence_starts,
+            self.last_sequence_in_batch_mask,
+        ) = (
+            rnn_build_seq_info["select_inds"],
+            rnn_build_seq_info["num_seqs_at_step"],
+            rnn_build_seq_info["sequence_lengths"],
+            rnn_build_seq_info["sequence_starts"],
+            rnn_build_seq_info["last_sequence_in_batch_mask"],
+        )
+
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+
+        rewards, values, is_not_stale = map(
+            lambda t: t.view(-1, 1).numpy()[self.select_inds],
+            (rewards_t, values_t, is_not_stale_t),
+        )
+        returns = returns_t.view(-1, 1).numpy()
+        returns[:] = returns[self.select_inds]
+
+        gae = np.zeros((self.num_seqs_at_step[0], 1))
+        last_values = gae.copy()
+        ptr = returns.size
+        for len_minus_1, n_seqs in reversed(
+            list(enumerate(self.num_seqs_at_step))
+        ):
+            curr_slice = slice(ptr - n_seqs, ptr)
+            q_est = rewards[curr_slice] + gamma * last_values[:n_seqs]
+            delta = q_est - values[curr_slice]
+            gae[:n_seqs] = delta + (tau * gamma) * gae[:n_seqs]
+
+            is_last_step = self.sequence_lengths == (len_minus_1 + 1)
+            is_last_step_for_env = (
+                is_last_step & self.last_sequence_in_batch_mask
+            )
+
+            # For the last step from each worker, we do an extra loop
+            # to fill last_values with the bootstrap.  So we re-zero
+            # the GAE value here
+            gae[is_last_step_for_env] = 0.0
+
+            # If the step isn't stale or we don't have a return
+            # calculate, use the newly calculated return value,
+            # otherwise keep the current one
+            use_new_value = is_not_stale[curr_slice] | np.logical_not(
+                np.isfinite(returns[curr_slice])
+            )
+            returns[curr_slice][use_new_value] = (
+                gae[:n_seqs] + values[curr_slice]
+            )[use_new_value]
+
+            # We also mark these with a nan
+            returns[curr_slice][is_last_step_for_env[:n_seqs]] = float("nan")
+
+            last_values[:n_seqs] = values[curr_slice]
+
+            ptr -= n_seqs
+
+        assert ptr == 0
+
+        returns[:] = returns[_np_invert_permutation(self.select_inds)]
+
+        if not self.variable_experience:
+            assert torch.all(torch.isfinite(returns_t[:-1])), dict(
+                returns=returns_t.squeeze(),
+                dones=self.dones_cpu,
+                episode_ids=self.episode_ids_cpu.reshape(-1, self._num_envs),
+                environment_ids=self.environment_ids_cpu.reshape(
+                    -1, self._num_envs
+                ),
+                step_ids=self.step_ids_cpu.reshape(-1, self._num_envs),
+                is_not_stale=is_not_stale[
+                    _np_invert_permutation(self.select_inds)
+                ].reshape(-1, self._num_envs),
+            )
+        else:
+            assert torch.isfinite(returns_t).long().sum() == (
+                self.num_steps * self._num_envs
+            ), returns_t.squeeze().numpy()[self.select_inds]
+
+        self.buffers["returns"].copy_(returns_t, non_blocking=True)
+        self.current_rollout_step_idxs[0] = self.num_steps
+
+    def recurrent_generator(
+        self,
+        advantages: Optional[torch.Tensor],
+        num_mini_batch: int,
+    ) -> Iterator[DictTree]:
+        if not self.variable_experience:
+            yield from super().recurrent_generator(advantages, num_mini_batch)
+        else:
+            for mb_inds in generate_ver_mini_batches(
+                num_mini_batch,
+                self.sequence_lengths,
+                self.num_seqs_at_step,
+                self.select_inds,
+                self.last_sequence_in_batch_mask,
+                self.episode_ids_cpu,
+            ):
+                mb_inds_cpu = torch.from_numpy(mb_inds)
+                mb_inds = mb_inds_cpu.to(device=self.device)
+
+                if not self.variable_experience:
+                    batch = self.buffers.map(lambda t: t.flatten(0, 1))[
+                        mb_inds
+                    ]
+                    if advantages is not None:
+                        batch["advantages"] = advantages.flatten(0, 1)[mb_inds]
+                else:
+                    batch = self.buffers[mb_inds]
+                    if advantages is not None:
+                        batch["advantages"] = advantages[mb_inds]
+
+                batch["rnn_build_seq_info"] = build_rnn_build_seq_info(
+                    device=self.device,
+                    build_fn_result=build_pack_info_from_episode_ids(
+                        self.episode_ids_cpu[mb_inds_cpu],
+                        self.environment_ids_cpu[mb_inds_cpu],
+                        self.step_ids_cpu[mb_inds_cpu],
+                    ),
+                )
+
+                rnn_build_seq_info = batch["rnn_build_seq_info"]
+                assert isinstance(
+                    batch["recurrent_hidden_states"], torch.Tensor
+                )
+                batch["recurrent_hidden_states"] = batch[
+                    "recurrent_hidden_states"
+                ].index_select(
+                    0,
+                    rnn_build_seq_info["first_step_for_env"],
+                )
+
+                yield batch.to_tree()

--- a/habitat_baselines/rl/ver/ver_trainer.py
+++ b/habitat_baselines/rl/ver/ver_trainer.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import os
+import random
+import time
+from typing import List
+
+import numpy as np
+import torch
+from gym import spaces
+from torch.optim.lr_scheduler import LambdaLR
+
+from habitat import logger
+from habitat.utils import profiling_wrapper
+from habitat_baselines.common.baseline_registry import baseline_registry
+from habitat_baselines.rl.ddppo.ddp_utils import (
+    EXIT,
+    add_signal_handlers,
+    get_distrib_size,
+    get_free_port_distributed,
+    get_main_addr,
+    init_distrib_slurm,
+    is_slurm_batch_job,
+    load_resume_state,
+    rank0_only,
+    requeue_job,
+    save_resume_state,
+)
+from habitat_baselines.rl.ppo.ppo_trainer import PPOTrainer
+from habitat_baselines.rl.ver.environment_worker import (
+    build_action_plugin_from_policy_action_space,
+    construct_environment_workers,
+)
+from habitat_baselines.rl.ver.inference_worker import (
+    InferenceWorker,
+    InferenceWorkerProcess,
+)
+from habitat_baselines.rl.ver.preemption_decider import PreemptionDeciderWorker
+from habitat_baselines.rl.ver.report_worker import ReportWorker
+from habitat_baselines.rl.ver.task_enums import ReportWorkerTasks
+from habitat_baselines.rl.ver.timing import Timing
+from habitat_baselines.rl.ver.ver_rollout_storage import VERRolloutStorage
+from habitat_baselines.rl.ver.worker_common import (
+    InferenceWorkerSync,
+    WorkerBase,
+    WorkerQueues,
+)
+from habitat_baselines.utils.common import (
+    cosine_decay,
+    get_num_actions,
+    inference_mode,
+    is_continuous_action_space,
+)
+
+try:
+    torch.backends.cudnn.allow_tf32 = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+except AttributeError:
+    pass
+
+
+@baseline_registry.register_trainer(name="ver")
+class VERTrainer(PPOTrainer):
+    rollouts: VERRolloutStorage
+
+    def _init_train(self, resume_state):
+        if self._is_distributed:
+            local_rank, world_rank, _ = get_distrib_size()
+
+            self.config.defrost()
+            self.config.TORCH_GPU_ID = local_rank
+            self.config.SIMULATOR_GPU_ID = local_rank
+            # Multiply by the number of simulators to make sure they also get unique seeds
+            self.config.TASK_CONFIG.SEED += (
+                world_rank * self.config.NUM_ENVIRONMENTS
+            )
+            self.config.freeze()
+
+        random.seed(self.config.TASK_CONFIG.SEED)
+        np.random.seed(self.config.TASK_CONFIG.SEED)
+        torch.manual_seed(self.config.TASK_CONFIG.SEED)
+
+        self.mp_ctx = torch.multiprocessing.get_context("forkserver")
+        self.queues = WorkerQueues(self.config.NUM_ENVIRONMENTS)
+        self.environment_workers = construct_environment_workers(
+            self.config,
+            self.mp_ctx,
+            self.queues,
+        )
+        [ew.start() for ew in self.environment_workers]
+        [ew.reset() for ew in self.environment_workers]
+
+        if self.config.RL.DDPPO.force_distributed:
+            self._is_distributed = True
+
+        if is_slurm_batch_job():
+            add_signal_handlers()
+
+        if self._is_distributed:
+            #  os.environ["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"
+            local_rank, tcp_store = init_distrib_slurm(
+                self.config.RL.DDPPO.distrib_backend
+            )
+            if rank0_only():
+                logger.info(
+                    "Initialized VER+DD-PPO with {} workers".format(
+                        torch.distributed.get_world_size()
+                    )
+                )
+        else:
+            logger.info("Initialized VER")
+            tcp_store = None
+
+        self._last_should_end_val = None
+        self._last_should_end_calc_time = 0
+
+        if rank0_only() and self.config.VERBOSE:
+            logger.info(f"config: {self.config}")
+
+        profiling_wrapper.configure(
+            capture_start_step=self.config.PROFILING.CAPTURE_START_STEP,
+            num_steps_to_capture=self.config.PROFILING.NUM_STEPS_TO_CAPTURE,
+        )
+
+        self._all_workers: List[WorkerBase] = []
+
+        if self._is_distributed:
+            world_rank = torch.distributed.get_rank()
+            world_size = torch.distributed.get_world_size()
+        else:
+            world_rank = 0
+            world_size = 1
+
+        self._my_t_zero = time.perf_counter()
+        self.preemption_decider = PreemptionDeciderWorker(
+            self.mp_ctx,
+            get_main_addr(),
+            get_free_port_distributed("preemption", tcp_store),
+            world_rank,
+            world_size,
+            self.config,
+            self.queues,
+            self._my_t_zero,
+        )
+
+        self.report_worker = ReportWorker(
+            self.mp_ctx,
+            get_free_port_distributed("report", tcp_store),
+            self.config,
+            self.queues.report,
+            self._my_t_zero,
+            self.num_steps_done,
+        )
+        if (
+            resume_state is not None
+            and "report_worker_state" in resume_state["requeue_stats"]
+        ):
+            self.report_worker.load_state_dict(
+                resume_state["requeue_stats"]["report_worker_state"]
+            )
+
+        init_reports = [self.environment_workers[0].get_init_report()]
+
+        action_space = init_reports[0]["act_space"]
+
+        self.policy_action_space = action_space
+        [
+            ew.set_action_plugin(
+                build_action_plugin_from_policy_action_space(
+                    self.policy_action_space
+                )
+            )
+            for ew in self.environment_workers
+        ]
+        if is_continuous_action_space(action_space):
+            # Assume ALL actions are NOT discrete
+            action_shape = (get_num_actions(action_space),)
+            discrete_actions = False
+        else:
+            # For discrete pointnav
+            action_shape = (1,)
+            discrete_actions = True
+
+        ppo_cfg = self.config.RL.PPO
+        if torch.cuda.is_available():
+            self.device = torch.device("cuda", self.config.TORCH_GPU_ID)
+            torch.cuda.set_device(self.device)
+        else:
+            self.device = torch.device("cpu")
+
+        if rank0_only() and not os.path.exists(self.config.CHECKPOINT_FOLDER):
+            os.makedirs(self.config.CHECKPOINT_FOLDER)
+
+        actor_obs_space = init_reports[0]["obs_space"]
+        self.obs_space = copy.deepcopy(actor_obs_space)
+        self.ver_config = self.config.RL.VER
+
+        self._setup_actor_critic_agent(ppo_cfg)
+        if resume_state is not None:
+            self.agent.load_state_dict(resume_state["state_dict"])
+            self.agent.optimizer.load_state_dict(resume_state["optim_state"])
+
+        rollouts_obs_space = copy.deepcopy(self.obs_space)
+        if self._static_encoder:
+            rollouts_obs_space = spaces.Dict(
+                {
+                    "visual_features": spaces.Box(
+                        low=np.finfo(np.float32).min,
+                        high=np.finfo(np.float32).max,
+                        shape=self._encoder.output_shape,
+                        dtype=np.float32,
+                    ),
+                    **rollouts_obs_space.spaces,
+                }
+            )
+
+        n_inference_workers = self.ver_config.num_inference_workers
+        main_is_iw = not self.ver_config.overlap_rollouts_and_learn
+        with inference_mode():
+            storage_kwargs = dict(
+                variable_experience=self.ver_config.variable_experience,
+                numsteps=ppo_cfg.num_steps,
+                num_envs=len(self.environment_workers),
+                action_space=self.policy_action_space,
+                recurrent_hidden_state_size=ppo_cfg.hidden_size,
+                num_recurrent_layers=self.actor_critic.net.num_recurrent_layers,
+                action_shape=action_shape,
+                discrete_actions=discrete_actions,
+                observation_space=rollouts_obs_space,
+            )
+            self.rollouts = VERRolloutStorage(**storage_kwargs)
+            self.rollouts.to(self.device)
+            self.rollouts.share_memory_()
+            if self.ver_config.overlap_rollouts_and_learn:
+                self.learning_rollouts = VERRolloutStorage(**storage_kwargs)
+                self.learning_rollouts.to(self.device)
+            else:
+                self.learning_rollouts = self.rollouts
+
+            storage_kwargs["observation_space"] = actor_obs_space
+            storage_kwargs["numsteps"] = 1
+
+            self._transfer_buffers = (
+                VERRolloutStorage(**storage_kwargs)
+                .buffers.slice_keys(
+                    "rewards",
+                    "masks",
+                    "observations",
+                    "episode_ids",
+                    "environment_ids",
+                    "actions",
+                    "step_ids",
+                )
+                .map_in_place(lambda t: t.share_memory_())
+            )[
+                slice(0, len(self.environment_workers))
+                if self.ver_config.variable_experience
+                else 0
+            ]
+
+        self.actor_critic.share_memory()
+
+        if self._is_distributed:
+            self.agent.init_distributed(find_unused_params=False)
+
+        logger.info(
+            "agent number of parameters: {}".format(
+                sum(
+                    param.numel()
+                    for param in self.agent.actor_critic.parameters()
+                )
+            )
+        )
+        self._iw_sync = InferenceWorkerSync(
+            self.mp_ctx,
+            n_inference_workers,
+        )
+
+        inference_worker_args = (
+            n_inference_workers,
+            self.config,
+            self.queues,
+            self._iw_sync,
+            self._transfer_buffers,
+            self.config.RL.POLICY.name,
+            (self.config, self.obs_space, self.policy_action_space),
+            self.device,
+            self.preemption_decider.rollout_ends,
+        )
+
+        self._transfer_policy_tensors = list(
+            self.actor_critic.all_policy_tensors()
+        )
+
+        self.inference_workers = [
+            InferenceWorker(self.mp_ctx, i, *inference_worker_args)
+            for i in range(1 if main_is_iw else 0, n_inference_workers)
+        ]
+        if main_is_iw:
+            self._inference_worker_impl = InferenceWorkerProcess(
+                None,
+                None,
+                None,
+                0,
+                *inference_worker_args,
+            )
+            self._inference_worker_impl.set_actor_critic_tensors(
+                self._transfer_policy_tensors
+            )
+            self._inference_worker_impl.set_rollouts(self.rollouts)
+        else:
+            self._inference_worker_impl = None
+
+        for iw in self.inference_workers:
+            # We send the policy weights and the rollouts
+            # via a torch.multiprocessing.SimpleQueue instead
+            # of in the constructor as otherwise the shared
+            # cuda tensors don't get properly freed on
+            # destruction which causes an error.
+            iw.set_actor_critic_tensors(self._transfer_policy_tensors)
+            iw.set_rollouts(self.rollouts)
+            iw.start()
+
+        ews_to_wait = []
+        for i, ew in enumerate(self.environment_workers):
+            ew.set_transfer_buffers(self._transfer_buffers)
+            if i > 0:
+                init_reports.append(ew.get_init_report())
+
+            ew.wait_start()
+            ews_to_wait.append(ew)
+            if len(ews_to_wait) >= 4:
+                [a.wait_sync() for a in ews_to_wait]
+                ews_to_wait = []
+
+        [a.wait_sync() for a in ews_to_wait]
+        ews_to_wait = []
+
+        if self._is_distributed:
+            torch.distributed.barrier()
+        [aw.start_experience_collection() for aw in self.environment_workers]
+        self.report_worker.start_collection()
+
+        self.timer = Timing()
+
+        self._all_workers.extend(self.environment_workers)
+        self._all_workers.extend(self.inference_workers)
+        self._all_workers.append(self.report_worker)
+        self._all_workers.append(self.preemption_decider)
+
+    @profiling_wrapper.RangeContext("_update_agent")
+    def _update_agent(self):
+        torch.backends.cudnn.benchmark = True
+        ppo_cfg = self.config.RL.PPO
+
+        with self.timer.avg_time("learn"):
+
+            t_compute_returns = time.perf_counter()
+
+            with self.timer.avg_time("compute returns"), inference_mode():
+                self.learning_rollouts.compute_returns(
+                    ppo_cfg.use_gae,
+                    ppo_cfg.gamma,
+                    ppo_cfg.tau,
+                )
+
+            compute_returns_time = time.perf_counter() - t_compute_returns
+
+            if self._is_distributed:
+                with self.timer.avg_time("synchronize"):
+                    torch.distributed.barrier()
+
+            t_update_model = time.perf_counter()
+            with self.timer.avg_time("update agent"):
+                self.agent.train()
+
+                losses = self.agent.update(self.learning_rollouts)
+
+            with self.timer.avg_time("after update"), inference_mode():
+                for t_src, t_dst in zip(
+                    self.actor_critic.all_policy_tensors(),
+                    self._transfer_policy_tensors,
+                ):
+                    # Some torch modules update their buffers out of place.
+                    # So we may need to copy the new value into the transfer
+                    # buffers.
+                    if t_src is not t_dst:
+                        t_dst.copy_(t_src)
+
+                if not self.ver_config.overlap_rollouts_and_learn:
+                    self.learning_rollouts.after_update()
+                    self._iw_sync.should_start_next.set()
+
+                self.rollouts.increment_policy_version()
+
+        self._learning_time = (
+            time.perf_counter() - t_update_model
+        ) + compute_returns_time
+        torch.backends.cudnn.benchmark = False
+
+        return losses
+
+    @profiling_wrapper.RangeContext("train")
+    def train(self) -> None:
+        r"""Main method for training DD/PPO.
+
+        Returns:
+            None
+        """
+        torch.backends.cudnn.enabled = True
+        torch.backends.cudnn.benchmark = False
+        self.num_steps_done = 0
+        resume_state = load_resume_state(self.config)
+        if resume_state is not None:
+            self.config = resume_state["config"]
+
+            requeue_stats = resume_state["requeue_stats"]
+            self.num_steps_done = requeue_stats["num_steps_done"]
+            self.num_updates_done = requeue_stats["num_updates_done"]
+
+        self._init_train(resume_state)
+
+        count_checkpoints = 0
+
+        lr_scheduler = LambdaLR(
+            optimizer=self.agent.optimizer,
+            lr_lambda=lambda x: cosine_decay(self.percent_done()),
+        )
+
+        if resume_state is not None:
+            lr_scheduler.load_state_dict(resume_state["lr_sched_state"])
+
+            requeue_stats = resume_state["requeue_stats"]
+            self._last_checkpoint_percent = requeue_stats[
+                "_last_checkpoint_percent"
+            ]
+            count_checkpoints = requeue_stats["count_checkpoints"]
+
+        ppo_cfg = self.config.RL.PPO
+        if self.ver_config.overlap_rollouts_and_learn:
+            self.preemption_decider.start_rollout()
+
+        while not self.is_done():
+            profiling_wrapper.on_start_step()
+
+            if ppo_cfg.use_linear_clip_decay:
+                self.agent.clip_param = ppo_cfg.clip_param * (
+                    1 - self.percent_done()
+                )
+
+            if rank0_only() and self._should_save_resume_state():
+                requeue_stats = dict(
+                    count_checkpoints=count_checkpoints,
+                    num_steps_done=self.num_steps_done,
+                    num_updates_done=self.num_updates_done,
+                    _last_checkpoint_percent=self._last_checkpoint_percent,
+                    report_worker_state=self.report_worker.state_dict(),
+                )
+                resume_state = dict(
+                    state_dict=self.agent.state_dict(),
+                    optim_state=self.agent.optimizer.state_dict(),
+                    lr_sched_state=lr_scheduler.state_dict(),
+                    config=self.config,
+                    requeue_stats=requeue_stats,
+                )
+
+                save_resume_state(
+                    resume_state,
+                    self.config,
+                )
+
+            if EXIT.is_set():
+                profiling_wrapper.range_pop()  # train update
+                [w.close() for w in self._all_workers]
+                [w.join() for w in self._all_workers]
+
+                requeue_job()
+                break
+
+            with inference_mode():
+                if not self.ver_config.overlap_rollouts_and_learn:
+                    self.preemption_decider.start_rollout()
+                    while not self.rollouts.rollout_done:
+                        self._inference_worker_impl.try_one_step()
+
+                    self._inference_worker_impl.finish_rollout()
+
+                self._iw_sync.rollout_done.wait()
+                self._iw_sync.rollout_done.clear()
+
+                if self._iw_sync.all_workers.n_waiting > 0:
+                    raise RuntimeError(
+                        f"{self._iw_sync.all_workers.n_waiting} inference worker(s) is(are) still waiting on the IW barrier. "
+                        "Likely they never waited on it.\n"
+                    )
+
+                self.rollouts.after_rollout()
+
+                if self.ver_config.overlap_rollouts_and_learn:
+                    with self.timer.avg_time("overlap_transfers"):
+                        self.learning_rollouts.copy(self.rollouts)
+
+                self.preemption_decider.end_rollout(
+                    self.rollouts.num_steps_to_collect
+                )
+
+                self.queues.report.put(
+                    (
+                        ReportWorkerTasks.num_steps_collected,
+                        int(self.rollouts.num_steps_collected),
+                    )
+                )
+
+                if self.ver_config.overlap_rollouts_and_learn:
+                    with self.timer.avg_time("overlap_transfers"):
+                        self.rollouts.after_update()
+                        self._iw_sync.should_start_next.set()
+                        self.preemption_decider.start_rollout()
+
+            losses = self._update_agent()
+
+            self.preemption_decider.learner_time(self._learning_time)
+
+            self.queues.report.put_many(
+                (
+                    (
+                        ReportWorkerTasks.learner_timing,
+                        self.timer,
+                    ),
+                    (
+                        ReportWorkerTasks.learner_update,
+                        losses,
+                    ),
+                )
+            )
+            self.timer = Timing()
+
+            if ppo_cfg.use_linear_lr_decay:
+                lr_scheduler.step()  # type: ignore
+
+            self.num_steps_done = int(self.report_worker.num_steps_done)
+
+            self.num_updates_done += 1
+            # checkpoint model
+            if rank0_only() and self.should_checkpoint():
+                self.save_checkpoint(
+                    f"ckpt.{count_checkpoints}.pth",
+                    dict(
+                        step=self.num_steps_done,
+                        wall_time=self.report_worker.time_taken,
+                    ),
+                )
+                count_checkpoints += 1
+
+        self.window_episode_stats = (
+            self.report_worker.get_window_episode_stats()
+        )
+
+        [w.close() for w in self._all_workers]
+        [w.join() for w in self._all_workers]
+
+        if self._is_distributed:
+            torch.distributed.barrier()

--- a/habitat_baselines/rl/ver/worker_common.py
+++ b/habitat_baselines/rl/ver/worker_common.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import enum
+import inspect
+import queue
+import signal
+from multiprocessing import SimpleQueue
+from multiprocessing.context import BaseContext
+from multiprocessing.process import BaseProcess
+from multiprocessing.sharedctypes import Synchronized
+from multiprocessing.synchronize import Barrier, Event, Lock
+from typing import Any, Callable, Dict, List, Optional, Type
+
+import attr
+import threadpoolctl
+import torch
+
+from habitat_baselines.rl.ver.queue import BatchedQueue
+
+
+@attr.s(auto_attribs=True, init=False, slots=True)
+class WorkerQueues:
+    environments: List[BatchedQueue]
+    inference: BatchedQueue
+    report: BatchedQueue
+    preemption_decider: BatchedQueue
+
+    def __init__(self, num_environments):
+        self.environments = [
+            BatchedQueue(8 * 1024 * 1024) for _ in range(num_environments)
+        ]
+        self.inference = BatchedQueue(1024 * 1024 * num_environments)
+        self.report = BatchedQueue(1024 * 1024 * num_environments)
+        self.preemption_decider = BatchedQueue(1024 * 1024 * num_environments)
+
+
+@attr.s(auto_attribs=True, init=False, slots=True)
+class RolloutEarlyEnds:
+    steps: Synchronized
+    time: Synchronized
+
+    def __init__(self, mp_ctx: BaseContext) -> None:
+        self.steps = mp_ctx.Value("d", -1.0, lock=False)
+        self.time = mp_ctx.Value("d", -1.0, lock=False)
+
+
+@attr.s(auto_attribs=True, slots=True, init=False)
+class InferenceWorkerSync:
+    lock: Lock
+    all_workers: Barrier
+    should_start_next: Event
+    rollout_done: Event
+
+    def __init__(
+        self,
+        mp_ctx: BaseContext,
+        n_inference_workers: int,
+    ) -> None:
+        self.lock = mp_ctx.Lock()
+        self.all_workers = mp_ctx.Barrier(n_inference_workers)
+        self.should_start_next = mp_ctx.Event()
+        self.should_start_next.set()
+        self.rollout_done = mp_ctx.Event()
+        self.rollout_done.clear()
+
+
+@attr.s(auto_attribs=True)
+class ProcessBase:
+    done_event: Event
+    response_queue: SimpleQueue
+    _dispatch_table: Dict[enum.Enum, Callable[[Any], None]] = attr.ib(
+        init=False, factory=dict
+    )
+
+    @staticmethod
+    def _build_dispatcher(
+        func: Callable[..., None], n_params: int, task: enum.Enum
+    ) -> Callable[[Any], None]:
+        def _dispatcher(data: Optional[Any]) -> None:
+            if n_params == 0:
+                if data is not None:
+                    raise RuntimeError(
+                        f"Function for task {task} does not take a data argument, "
+                        f"but data\n{data}\n was given."
+                    )
+                func()
+            else:
+                if data is None:
+                    raise RuntimeError(
+                        f"Function for task {task} takes no data."
+                    )
+                elif n_params == 1:
+                    func(data)
+                elif len(data) != n_params:
+                    raise RuntimeError(
+                        f"Function for task {task} takes {n_params} but only got {len(data)}"
+                    )
+                else:
+                    if isinstance(data, dict):
+                        func(**data)
+                    else:
+                        func(*data)
+
+        return _dispatcher
+
+    def build_dispatch_table(self, task_enum: enum.EnumMeta) -> None:
+        for task in task_enum:  # type: enum.Enum
+            func = getattr(self, task.name.lower())
+            assert func is not None
+
+            sig = inspect.signature(func)
+
+            self._dispatch_table[task] = self._build_dispatcher(
+                func, len(sig.parameters), task
+            )
+
+    def dispatch_task(self, task: enum.Enum, data: Optional[Any]) -> None:
+        if task not in self._dispatch_table:
+            raise RuntimeError(f"Unknown task: {task}")
+
+        self._dispatch_table[task](data)
+
+    @property
+    def task_queue(self) -> BatchedQueue:
+        raise NotImplementedError("Must implement the task_queue property")
+
+    def run(self):
+        while not self.done_event.is_set():
+            try:
+                tasks_datas = self.task_queue.get_many(timeout=1.0)
+            except queue.Empty:
+                pass
+            else:
+                for task, data in tasks_datas:
+                    self.dispatch_task(task, data)
+
+
+@attr.s(auto_attribs=True, init=False, slots=True)
+class WorkerBase:
+    _proc_done_event: Event
+    response_queue: SimpleQueue
+    _proc: Optional[BaseProcess]
+
+    def __init__(
+        self,
+        mp_ctx: BaseContext,
+        process_class: Type[ProcessBase],
+        *process_args,
+        **process_kwargs,
+    ):
+        assert issubclass(process_class, ProcessBase)
+        self._proc = None
+
+        self._proc_done_event = mp_ctx.Event()
+        self._proc_done_event.clear()
+        self.response_queue = mp_ctx.SimpleQueue()
+        p = mp_ctx.Process(
+            target=self._worker_fn,
+            args=(
+                process_class,
+                (
+                    self._proc_done_event,
+                    self.response_queue,
+                    *process_args,
+                ),
+                process_kwargs,
+            ),
+        )
+
+        p.daemon = True
+        p.start()
+        self._proc = p
+
+    @staticmethod
+    def _worker_fn(
+        process_class: Type[ProcessBase], process_args, process_kwargs
+    ):
+        #  signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+        signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+        signal.signal(signal.SIGUSR2, signal.SIG_IGN)
+
+        torch.set_num_threads(1)
+        threadpoolctl.threadpool_limits(limits=1)
+
+        with torch.no_grad():
+            try:
+                process_class(*process_args, **process_kwargs).run()
+            except KeyboardInterrupt:
+                pass
+
+    def close(self):
+        if self._proc is not None:
+            self._proc_done_event.set()
+
+    def join(self):
+        self.close()
+
+        if self._proc is not None:
+            self._proc.join(5.0)
+            if self._proc.is_alive():
+                self._proc.kill()
+            self._proc = None
+
+    def __del__(self):
+        self.join()

--- a/habitat_baselines/utils/common.py
+++ b/habitat_baselines/utils/common.py
@@ -45,6 +45,12 @@ else:
     inference_mode = torch.no_grad
 
 
+def cosine_decay(progress: float) -> float:
+    progress = min(max(progress, 0.0), 1.0)
+
+    return (1.0 + math.cos(progress * math.pi)) / 2.0
+
+
 class CustomFixedCategorical(torch.distributions.Categorical):  # type: ignore
     def sample(
         self, sample_shape: Size = torch.Size()  # noqa: B008
@@ -105,48 +111,58 @@ class GaussianNet(nn.Module):
         self.action_activation = config.action_activation
         self.use_log_std = config.use_log_std
         self.use_softplus = config.use_softplus
-        self.use_std_param = config.use_std_param
+        use_std_param = config.use_std_param
         self.clamp_std = config.clamp_std
-        if config.use_log_std:
+
+        if self.use_log_std:
             self.min_std = config.min_log_std
             self.max_std = config.max_log_std
             std_init = 0.0  # initialize std value so that exp(std) ~ 1
+        elif self.use_softplus:
+            inv_softplus = lambda x: math.log(math.exp(x) - 1)
+            self.min_std = inv_softplus(config.min_std)
+            self.max_std = inv_softplus(config.max_std)
+            std_init = inv_softplus(1.0)
         else:
             self.min_std = config.min_std
             self.max_std = config.max_std
             std_init = 1.0  # initialize std value so that std ~ 1
 
-        self.mu = nn.Linear(num_inputs, num_outputs)
-        nn.init.orthogonal_(self.mu.weight, gain=0.01)
-        nn.init.constant_(self.mu.bias, 0)
-
-        if self.use_std_param:
+        if use_std_param:
             self.std = torch.nn.parameter.Parameter(
                 torch.randn(num_outputs) * 0.01 + std_init
             )
+            num_linear_outputs = num_outputs
         else:
-            self.std = nn.Linear(num_inputs, num_outputs)
-            nn.init.orthogonal_(self.std.weight, gain=0.01)
-            nn.init.constant_(self.std.bias, std_init)
+            self.std = None
+            num_linear_outputs = 2 * num_outputs
+
+        self.mu_maybe_std = nn.Linear(num_inputs, num_linear_outputs)
+        nn.init.orthogonal_(self.mu_maybe_std.weight, gain=0.01)
+        nn.init.constant_(self.mu_maybe_std.bias, 0)
+
+        if not use_std_param:
+            nn.init.constant_(self.mu_maybe_std.bias[num_outputs:], std_init)
 
     def forward(self, x: Tensor) -> CustomNormal:
-        mu = self.mu(x)
+        mu_maybe_std = self.mu_maybe_std(x).float()
+        if self.std is not None:
+            mu = mu_maybe_std
+            std = self.std
+        else:
+            mu, std = torch.chunk(mu_maybe_std, 2, -1)
+
         if self.action_activation == "tanh":
             mu = torch.tanh(mu)
 
-        if self.use_std_param:
-            std = self.std
-        else:
-            std = self.std(x)
-
         if self.clamp_std:
-            std = torch.clamp(std, min=self.min_std, max=self.max_std)
+            std = torch.clamp(std, self.min_std, self.max_std)
         if self.use_log_std:
             std = torch.exp(std)
         if self.use_softplus:
             std = torch.nn.functional.softplus(std)
 
-        return CustomNormal(mu, std)
+        return CustomNormal(mu, std, validate_args=False)
 
 
 def linear_decay(epoch: int, total_num_updates: int) -> float:
@@ -167,7 +183,7 @@ class _ObservationBatchingCache(metaclass=Singleton):
     r"""Helper for batching observations that maintains a cpu-side tensor
     that is the right size and is pinned to cuda memory
     """
-    _pool: Dict[Any, Union[torch.Tensor, np.ndarray]] = attr.Factory(dict)
+    _pool: Dict[Any, Union[torch.Tensor, np.ndarray]] = {}
 
     def get(
         self,

--- a/scripts/generate_profile_shell_scripts.py
+++ b/scripts/generate_profile_shell_scripts.py
@@ -212,7 +212,7 @@ fi
 #SBATCH --open-mode=append
 export GLOG_minloglevel=2
 export MAGNUM_LOG=quiet
-MAIN_ADDR=$(srun --ntasks=1 hostname 2>&1 | tail -n1)
+MAIN_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
 export MAIN_ADDR
 set -x
 srun bash capture_profile_slurm_task.sh

--- a/test/test_baseline_training.py
+++ b/test/test_baseline_training.py
@@ -49,7 +49,8 @@ def setup_function(test_trainers):
         ("habitat_baselines/config/imagenav/ddppo_imagenav_example.yaml", 3),
     ],
 )
-def test_trainers(config_path, num_updates):
+@pytest.mark.parametrize("trainer_name", ["ddppo", "ver"])
+def test_trainers(config_path, num_updates, trainer_name):
     # Remove the checkpoints from previous tests
     for f in glob.glob("data/test_checkpoints/test_training/*"):
         os.remove(f)
@@ -63,6 +64,8 @@ def test_trainers(config_path, num_updates):
             -1.0,
             "CHECKPOINT_FOLDER",
             "data/test_checkpoints/test_training",
+            "TRAINER_NAME",
+            trainer_name,
         ],
     )
     random.seed(config.TASK_CONFIG.SEED)
@@ -73,9 +76,10 @@ def test_trainers(config_path, num_updates):
     if config.FORCE_TORCH_SINGLE_THREADED and torch.cuda.is_available():
         torch.set_num_threads(1)
 
-    assert (
-        config.TRAINER_NAME == "ddppo"
-    ), "This test can only be used with ddppo trainer"
+    assert config.TRAINER_NAME in (
+        "ddppo",
+        "ver",
+    ), "This test can only be used with ddppo/ver trainer"
 
     trainer_init = baseline_registry.get_trainer(config.TRAINER_NAME)
     assert trainer_init is not None, f"{config.TRAINER_NAME} is not supported"
@@ -100,7 +104,8 @@ def test_trainers(config_path, num_updates):
         ("habitat_baselines/config/pointnav/ddppo_pointnav.yaml", 1000, 2.0),
     ],
 )
-def test_trainers_large(config_path, num_updates, target_reward):
+@pytest.mark.parametrize("trainer_name", ["ddppo", "ver"])
+def test_trainers_large(config_path, num_updates, target_reward, trainer_name):
     # Remove the checkpoints from previous tests
     for f in glob.glob("data/test_checkpoints/test_training/*"):
         os.remove(f)
@@ -114,6 +119,8 @@ def test_trainers_large(config_path, num_updates, target_reward):
             -1.0,
             "CHECKPOINT_FOLDER",
             "data/test_checkpoints/test_training",
+            "TRAINER_NAME",
+            trainer_name,
         ],
     )
     random.seed(config.TASK_CONFIG.SEED)
@@ -124,9 +131,10 @@ def test_trainers_large(config_path, num_updates, target_reward):
     if config.FORCE_TORCH_SINGLE_THREADED and torch.cuda.is_available():
         torch.set_num_threads(1)
 
-    assert (
-        config.TRAINER_NAME == "ddppo"
-    ), "This test can only be used with ddppo trainer"
+    assert config.TRAINER_NAME in (
+        "ddppo",
+        "ver",
+    ), "This test can only be used with ddppo/ver trainer"
 
     trainer_init = baseline_registry.get_trainer(config.TRAINER_NAME)
     assert trainer_init is not None, f"{config.TRAINER_NAME} is not supported"
@@ -136,12 +144,19 @@ def test_trainers_large(config_path, num_updates, target_reward):
     trainer.train()
 
     # Gather the data
-    deltas = {
-        k: ((v[-1] - v[0]).sum().item() if len(v) > 1 else v[0].sum().item())
-        for k, v in trainer.window_episode_stats.items()
-    }
-    deltas["count"] = max(deltas["count"], 1.0)
-    reward = deltas["reward"] / deltas["count"]
+    if config.TRAINER_NAME == "ddppo":
+        deltas = {
+            k: (
+                (v[-1] - v[0]).sum().item()
+                if len(v) > 1
+                else v[0].sum().item()
+            )
+            for k, v in trainer.window_episode_stats.items()
+        }
+        deltas["count"] = max(deltas["count"], 1.0)
+        reward = deltas["reward"] / deltas["count"]
+    else:
+        reward = trainer.window_episode_stats["reward"].mean
 
     # Make sure the final reward is greater than the target
     assert (

--- a/test/test_rnn_state_encoder.py
+++ b/test/test_rnn_state_encoder.py
@@ -17,6 +17,12 @@ from habitat_baselines.rl.models.rnn_state_encoder import (
 
 
 def test_rnn_state_encoder():
+    try:
+        torch.backends.cudnn.allow_tf32 = False
+        torch.backends.cuda.matmul.allow_tf32 = False
+    except AttributeError:
+        pass
+
     device = (
         torch.device("cuda")
         if torch.cuda.is_available()


### PR DESCRIPTION
## Motivation and Context

Adds the core of the training code for VER.

See https://github.com/facebookresearch/habitat-lab/blob/ver-part-1/habitat_baselines/rl/ver/README.md for how this code is laid out.

Each component of the system (expect for the learner, which just the main process) is implemented via a Worker class that spins up the subprocess and has some methods for interacting with the process. The process then runs code in the corresponding WorkerProcess class.

The environment worker, report worker, and preemption decider all operate on an interface defined by their task enum. Tasks are given via a tuple in the form `(task, data?)` put into the appropriate queue. Each task corresponds to a method name to be called and the data is the arguments to this method (if any).

The inference worker receives tasks as simply the environment ID that is reporting a new step of experience has been generated.

When experience collection and learning aren't overlapped, the main process alternates between acting as an inference worker and learning. When they are overlapped, the main process just learns.

## How Has This Been Tested

With the tests.

## Types of changes

- New feature (non-breaking change which adds functionality)

