### PR TITLE
[CI] Fixing pytorch restoration from cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,12 +144,12 @@ jobs:
           no_output_timeout: 20m
           background: true
           command: |
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat;
               if [ ! -f ~/miniconda/pytorch_installed ]
               then
-                export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-                . activate habitat;
-                conda install -y pytorch==1.4.0 torchvision cudatoolkit=10.0 -c pytorch
                 echo "Installing pytorch"
+                conda install -y pytorch==1.4.0 torchvision cudatoolkit=10.0 -c pytorch
               fi
               touch ~/miniconda/pytorch_installed
               python -c 'import torch; print("Has cuda ? ",torch.cuda.is_available()); print("torch version : ",torch.__version__);'


### PR DESCRIPTION
## Motivation and Context

Installing pytorch from cache without activating the conda environment prevents importing torch to check its version

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
