### PR TITLE
[eval] blacking out last frame in videos

### DIFF
--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -1051,6 +1051,12 @@ class PPOTrainer(BaseRLTrainer):
                     frame = observations_to_image(
                         {k: v[i] for k, v in batch.items()}, infos[i]
                     )
+                    if not not_done_masks[i].item():
+                        # The last frame corresponds to the first frame of the next episode
+                        # but the info is correct. So we use a black frame
+                        frame = observations_to_image(
+                            {k: v[i] * 0.0 for k, v in batch.items()}, infos[i]
+                        )
                     if self.config.VIDEO_RENDER_ALL_INFO:
                         frame = overlay_frame(frame, infos[i])
                     rgb_frames[i].append(frame)


### PR DESCRIPTION
## Motivation and Context

In a previous PR, we rendered the last frame of evaluation videos to have access to the last info dict. However, the last observation corresponds to the first frame of the next episode. As such, we blacken the last frame since it is not relevant to the current episode but keep the overlayed info.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
