### PR TITLE
Change the way rgb and depth obs are processed in ResNetEncoder

### DIFF
--- a/examples/tutorials/colabs/Habitat2_Quickstart.ipynb
+++ b/examples/tutorials/colabs/Habitat2_Quickstart.ipynb
@@ -275,7 +275,7 @@
     "            self._task.target_object_index\n",
     "        ]\n",
     "        relative_start_pos = T_inv.transform_point(start_pos)\n",
-    "        return relative_start_pos\n",
+    "        return np.asarray(relative_start_pos)\n",
     "\n",
     "\n",
     "@registry.register_measure\n",

--- a/examples/tutorials/nb_python/Habitat2_Quickstart.py
+++ b/examples/tutorials/nb_python/Habitat2_Quickstart.py
@@ -235,7 +235,7 @@ class TargetStartSensor(Sensor):
             self._task.target_object_index
         ]
         relative_start_pos = T_inv.transform_point(start_pos)
-        return relative_start_pos
+        return np.asarray(relative_start_pos)
 
 
 @registry.register_measure

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -216,28 +216,18 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
     """
     render_obs_images: List[np.ndarray] = []
     for sensor_name in observation:
-        if "rgb" in sensor_name:
-            rgb = observation[sensor_name]
-            if not isinstance(rgb, np.ndarray):
-                rgb = rgb.cpu().numpy()
-
-            render_obs_images.append(rgb)
-        elif "depth" in sensor_name:
-            depth_map = observation[sensor_name].squeeze() * 255.0
-            if not isinstance(depth_map, np.ndarray):
-                depth_map = depth_map.cpu().numpy()
-
-            depth_map = depth_map.astype(np.uint8)
-            depth_map = np.stack([depth_map for _ in range(3)], axis=2)
-            render_obs_images.append(depth_map)
-
-    # add image goal if observation has image_goal info
-    if "imagegoal" in observation:
-        rgb = observation["imagegoal"]
-        if not isinstance(rgb, np.ndarray):
-            rgb = rgb.cpu().numpy()
-
-        render_obs_images.append(rgb)
+        if len(observation[sensor_name].shape) > 1:
+            obs_k = observation[sensor_name]
+            if not isinstance(obs_k, np.ndarray):
+                obs_k = obs_k.cpu().numpy()
+            if obs_k.dtype == np.float:  # type: ignore
+                obs_k = obs_k * 255.0
+                obs_k = obs_k.astype(np.uint8)
+            if len(obs_k.shape) == 2:
+                obs_k = obs_k.squeeze()
+            if obs_k.shape[2] == 1:
+                obs_k = np.stack([obs_k for _ in range(3)], axis=2)
+            render_obs_images.append(obs_k)
 
     assert (
         len(render_obs_images) > 0

--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -220,13 +220,11 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
             obs_k = observation[sensor_name]
             if not isinstance(obs_k, np.ndarray):
                 obs_k = obs_k.cpu().numpy()
-            if obs_k.dtype == np.float:  # type: ignore
+            if obs_k.dtype != np.uint8:
                 obs_k = obs_k * 255.0
                 obs_k = obs_k.astype(np.uint8)
-            if len(obs_k.shape) == 2:
-                obs_k = obs_k.squeeze()
             if obs_k.shape[2] == 1:
-                obs_k = np.stack([obs_k for _ in range(3)], axis=2)
+                obs_k = np.concatenate([obs_k for _ in range(3)], axis=2)
             render_obs_images.append(obs_k)
 
     assert (


### PR DESCRIPTION
## Motivation and Context

This change allows users to train environments that do not necessarily use our convention of naming our RGB and depth sensor keys. With this change, observations will be processed based of their shapes and dtype instead of observation keys.
Made `normalize_visual_inputs` always true. Please advise on wether or not this is wise.


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

Tried with Breakout and it learns!

```
rm -rf data/new_checkpoints/ ;python -u habitat_baselines/run.py --exp-config habitat_baselines/config/rearrange/ddppo_place.yaml --run-type train NUM_UPDATES 100 TOTAL_NUM_STEPS -1.0 NUM_ENVIRONMENTS 3 RL.POLICY.action_distribution_type categorical TASK_CONFIG.ENV_TASK GymRegistryEnv  TASK_CONFIG.ENV_TASK_GYM_ID Breakout-v0
```

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
