### PR TITLE
[bug fix] Replace visual_feats with static string

### DIFF
--- a/habitat_baselines/rl/ddppo/policy/__init__.py
+++ b/habitat_baselines/rl/ddppo/policy/__init__.py
@@ -4,4 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .resnet_policy import PointNavResNetPolicy  # noqa: F401.
+from .resnet_policy import (  # noqa: F401.
+    PointNavResNetNet,
+    PointNavResNetPolicy,
+)

--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -432,6 +432,8 @@ class PointNavResNetNet(Net):
         x = []
         aux_loss_state = {}
         if not self.is_blind:
+            # We CANNOT use observations.get() here because self.visual_encoder(observations)
+            # is an expensive operation. Therefore, we need `# noqa: SIM401`
             if (  # noqa: SIM401
                 PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY
                 in observations

--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -224,6 +224,7 @@ class PointNavResNetNet(Net):
     goal vector with CNN's output and passes that through RNN.
     """
 
+    PRETRAINED_VISUAL_FEATURES_KEY = "visual_features"
     prev_action_embedding: nn.Module
 
     def __init__(
@@ -431,10 +432,10 @@ class PointNavResNetNet(Net):
         x = []
         aux_loss_state = {}
         if not self.is_blind:
-            if "visual_feats" in observations:  # noqa: SIM401
-                visual_feats = observations["visual_feats"]
-            else:
-                visual_feats = self.visual_encoder(observations)
+            visual_feats = observations.get(
+                PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY,
+                self.visual_encoder(observations),
+            )
 
             visual_feats = self.visual_fc(visual_feats)
             aux_loss_state["perception_embed"] = visual_feats

--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -432,10 +432,15 @@ class PointNavResNetNet(Net):
         x = []
         aux_loss_state = {}
         if not self.is_blind:
-            visual_feats = observations.get(
-                PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY,
-                self.visual_encoder(observations),
-            )
+            if (  # noqa: SIM401
+                PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY
+                in observations
+            ):
+                visual_feats = observations[
+                    PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY
+                ]
+            else:
+                visual_feats = self.visual_encoder(observations)
 
             visual_feats = self.visual_fc(visual_feats)
             aux_loss_state["perception_embed"] = visual_feats

--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -49,6 +49,7 @@ from habitat_baselines.rl.ddppo.ddp_utils import (
     save_resume_state,
 )
 from habitat_baselines.rl.ddppo.policy import (  # noqa: F401.
+    PointNavResNetNet,
     PointNavResNetPolicy,
 )
 from habitat_baselines.rl.hrl.hierarchical_policy import (  # noqa: F401.
@@ -283,7 +284,7 @@ class PPOTrainer(BaseRLTrainer):
             self._encoder = self.actor_critic.net.visual_encoder
             obs_space = spaces.Dict(
                 {
-                    "visual_features": spaces.Box(
+                    PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY: spaces.Box(
                         low=np.finfo(np.float32).min,
                         high=np.finfo(np.float32).max,
                         shape=self._encoder.output_shape,
@@ -314,7 +315,9 @@ class PPOTrainer(BaseRLTrainer):
 
         if self._static_encoder:
             with inference_mode():
-                batch["visual_features"] = self._encoder(batch)
+                batch[
+                    PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY
+                ] = self._encoder(batch)
 
         self.rollouts.buffers["observations"][0] = batch  # type: ignore
 
@@ -529,7 +532,9 @@ class PPOTrainer(BaseRLTrainer):
 
         if self._static_encoder:
             with inference_mode():
-                batch["visual_features"] = self._encoder(batch)
+                batch[
+                    PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY
+                ] = self._encoder(batch)
 
         self.rollouts.insert(
             next_observations=batch,

--- a/habitat_baselines/rl/ver/ver_trainer.py
+++ b/habitat_baselines/rl/ver/ver_trainer.py
@@ -31,6 +31,7 @@ from habitat_baselines.rl.ddppo.ddp_utils import (
     requeue_job,
     save_resume_state,
 )
+from habitat_baselines.rl.ddppo.policy import PointNavResNetNet  # noqa: F401.
 from habitat_baselines.rl.ppo.ppo_trainer import PPOTrainer
 from habitat_baselines.rl.ver.environment_worker import (
     build_action_plugin_from_policy_action_space,
@@ -211,7 +212,7 @@ class VERTrainer(PPOTrainer):
         if self._static_encoder:
             rollouts_obs_space = spaces.Dict(
                 {
-                    "visual_features": spaces.Box(
+                    PointNavResNetNet.PRETRAINED_VISUAL_FEATURES_KEY: spaces.Box(
                         low=np.finfo(np.float32).min,
                         high=np.finfo(np.float32).max,
                         shape=self._encoder.output_shape,


### PR DESCRIPTION
## Motivation and Context

Addressing issue raised in #937.
Replacing "visual_feats" with "visual_features" to make the encoder use the pretrained visual features when available.
Use a static string as key rather than a hard coded string to avoid future typos.

## How Has This Been Tested

Using CI only.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
