### PR TITLE
[Feature] Adding human render to gym wrapper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,7 @@ jobs:
               python setup.py develop --all
               find . -name ci-requirements.txt | xargs -I {} pip install -r {}
               export PYTHONPATH=.:$PYTHONPATH
+              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
               python setup.py test --addopts "-s --cov-report=xml --cov-report term  --cov=./"
 
               bash <(curl -s https://codecov.io/bash) -f coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
               python setup.py develop --all
               find . -name ci-requirements.txt | xargs -I {} pip install -r {}
               export PYTHONPATH=.:$PYTHONPATH
-              python setup.py test --addopts "--cov-report=xml --cov-report term  --cov=./"
+              python setup.py test --addopts "-s --cov-report=xml --cov-report term  --cov=./"
 
               bash <(curl -s https://codecov.io/bash) -f coverage.xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
               find . -name ci-requirements.txt | xargs -I {} pip install -r {}
               export PYTHONPATH=.:$PYTHONPATH
               export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
-              python setup.py test --addopts "-s --cov-report=xml --cov-report term  --cov=./"
+              python setup.py test --addopts " --cov-report=xml --cov-report term  --cov=./"
 
               bash <(curl -s https://codecov.io/bash) -f coverage.xml
       - run:

--- a/habitat/utils/gym_adapter.py
+++ b/habitat/utils/gym_adapter.py
@@ -325,8 +325,6 @@ class HabGymWrapper(gym.Env):
             self._screen.fill((0, 0, 0))  # type: ignore[attr-defined]
             self._screen.blit(draw_frame, (0, 0))  # type: ignore[attr-defined]
             pygame.display.update()
-            pygame.event.pump()
-            pygame.event.get()
         else:
             raise ValueError(f"Render mode {mode} not currently supported.")
 

--- a/habitat/utils/gym_adapter.py
+++ b/habitat/utils/gym_adapter.py
@@ -301,7 +301,7 @@ class HabGymWrapper(gym.Env):
         self._last_obs = obs
         return self._transform_obs(obs)
 
-    def render(self, mode: str = "rgb_array") -> np.ndarray:
+    def render(self, mode: str = "human") -> np.ndarray:
         frame = None
         if mode == "rgb_array":
             frame = observations_to_image(

--- a/habitat/utils/gym_adapter.py
+++ b/habitat/utils/gym_adapter.py
@@ -320,10 +320,14 @@ class HabGymWrapper(gym.Env):
                 self._screen = pygame.display.set_mode(
                     [frame.shape[1], frame.shape[0]]
                 )
-            draw_frame = np.transpose(frame, (1, 0, 2))
+            draw_frame = np.transpose(
+                frame, (1, 0, 2)
+            )  # (H, W, C) -> (W, H, C)
             draw_frame = pygame.surfarray.make_surface(draw_frame)
-            self._screen.fill((0, 0, 0))  # type: ignore[attr-defined]
-            self._screen.blit(draw_frame, (0, 0))  # type: ignore[attr-defined]
+            BLACK_COLOR = (0, 0, 0)
+            self._screen.fill(BLACK_COLOR)  # type: ignore[attr-defined]
+            TOP_CORNER = (0, 0)
+            self._screen.blit(draw_frame, TOP_CORNER)  # type: ignore[attr-defined]
             pygame.display.update()
         else:
             raise ValueError(f"Render mode {mode} not currently supported.")

--- a/habitat/utils/gym_definitions.py
+++ b/habitat/utils/gym_definitions.py
@@ -16,7 +16,6 @@ import habitat
 import habitat.utils.env_utils
 from habitat.config.default import Config
 from habitat.core.environments import get_env_class
-from habitat.utils.render_wrapper import HabRenderWrapper
 
 HABLAB_INSTALL_PATH = "HABLAB_BASE_CFG_PATH"
 
@@ -25,7 +24,7 @@ base_dir = os.environ.get(
     osp.dirname(osp.dirname(osp.dirname(osp.abspath(__file__)))),
 )
 
-gym_task_config_dir = osp.join(base_dir, "configs/tasks/rearrange/")
+gym_task_config_dir = osp.join(base_dir, "configs/tasks/")
 
 
 def _get_gym_name(cfg: Config) -> Optional[str]:
@@ -77,8 +76,6 @@ def _make_habitat_gym_env(
     # Re-loading the config since we modified the override_options
     config = habitat.get_config(cfg_file_path, override_options)
     env = make_gym_from_config(config)
-    if use_render_mode:
-        env = HabRenderWrapper(env)
     return env
 
 

--- a/habitat/utils/render_wrapper.py
+++ b/habitat/utils/render_wrapper.py
@@ -7,7 +7,6 @@
 from typing import List
 
 import cv2
-import gym
 import numpy as np
 
 from habitat.utils.gym_adapter import flatten_dict
@@ -80,50 +79,3 @@ def overlay_frame(frame, info, additional=None):
     frame = append_text_to_image(frame, lines, font_size=0.25)
 
     return frame
-
-
-class HabRenderWrapper(gym.Wrapper):
-    """
-    Overlays the measures values as text over the rendered frame. Only affects
-    the behavior of the `.render()` method. Also records and displays the
-    accumulated reward and number of steps. Example usage:
-    ```
-    env = make_gym_from_config(config)
-    env = HabRenderWrapper(env)
-    ```
-    """
-
-    def __init__(self, env):
-        if not isinstance(env, gym.Env):
-            raise ValueError("Can only wrap gym env")
-        super().__init__(env)
-        self._last_info = None
-        self._total_reward = 0.0
-        self._n_step = 0
-
-    def step(self, action):
-        obs, reward, done, info = super().step(action)
-        self._last_info = info
-        self._total_reward += reward
-        self._n_step += 1
-
-        return obs, reward, done, info
-
-    def reset(self):
-        self._last_info = None
-        self._total_reward = 0.0
-        self._n_step = 0
-        return super().reset()
-
-    def render(self, mode="rgb_array"):
-        frame = super().render(mode=mode)
-        if self._last_info is not None:
-            frame = overlay_frame(
-                frame,
-                self._last_info,
-                [
-                    f"Step {self._n_step}",
-                    f"Total Reward {self._total_reward:.4f}",
-                ],
-            )
-        return frame

--- a/test/test_gym_wrapper.py
+++ b/test/test_gym_wrapper.py
@@ -4,6 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+
+import mock
+
+# using mock for pygame to avoid having a pygame windows
+sys.modules["pygame"] = mock.MagicMock()
+
 from glob import glob
 
 import gym

--- a/test/test_gym_wrapper.py
+++ b/test/test_gym_wrapper.py
@@ -15,7 +15,6 @@ import habitat.utils.env_utils
 import habitat.utils.gym_definitions
 from habitat.core.environments import get_env_class
 from habitat.utils.gym_definitions import _get_env_name
-from habitat.utils.render_wrapper import HabRenderWrapper
 
 
 @pytest.mark.parametrize(
@@ -64,7 +63,6 @@ def test_gym_wrapper_contract_continuous(
         env_class=env_class, config=config
     )
 
-    env = HabRenderWrapper(env)
     assert isinstance(env.action_space, spaces.Box)
     assert (
         env.action_space.shape[0] == expected_action_dim
@@ -113,8 +111,6 @@ def test_gym_wrapper_contract_discrete(
     env = habitat.utils.env_utils.make_env_fn(
         env_class=env_class, config=config
     )
-
-    env = HabRenderWrapper(env)
     assert isinstance(env.action_space, spaces.Discrete)
     assert (
         env.action_space.n == expected_action_dim
@@ -213,6 +209,7 @@ def test_auto_gym_wrapper(test_cfg_path):
         "HabitatSetTable-v0",
         "HabitatNavPick-v0",
         "HabitatNavPickNavPlace-v0",
+        "HabitatImageNav-v0",
     ],
 )
 def test_gym_premade_envs(name):

--- a/test/test_gym_wrapper.py
+++ b/test/test_gym_wrapper.py
@@ -16,14 +16,6 @@ import habitat.utils.gym_definitions
 from habitat.core.environments import get_env_class
 from habitat.utils.gym_definitions import _get_env_name
 
-try:
-    import pygame
-
-    pygame_installed = True
-except ImportError:
-    pygame = None
-    pygame_installed = False
-
 
 @pytest.mark.parametrize(
     "config_file,overrides,expected_action_dim,expected_obs_type",
@@ -187,8 +179,7 @@ def test_auto_gym_wrapper(test_cfg_path):
     config = habitat.get_config(test_cfg_path)
     if "GYM" not in config or config.GYM.AUTO_NAME == "":
         pytest.skip(f"Gym environment name isn't set for {test_cfg_path}.")
-    if not pygame_installed:
-        pytest.skip("pygame is required for this test.")
+    pytest.importorskip("pygame")
     for prefix in ["", "Render"]:
         full_gym_name = f"Habitat{prefix}{config.GYM.AUTO_NAME}-v0"
 

--- a/test/test_gym_wrapper.py
+++ b/test/test_gym_wrapper.py
@@ -4,17 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib
 import sys
-
-import mock
-
-# using mock for pygame to avoid having a pygame windows
-sys.modules["pygame"] = mock.MagicMock()
-
 from glob import glob
 
 import gym
 import gym.spaces as spaces
+import mock
 import numpy as np
 import pytest
 
@@ -22,6 +18,10 @@ import habitat.utils.env_utils
 import habitat.utils.gym_definitions
 from habitat.core.environments import get_env_class
 from habitat.utils.gym_definitions import _get_env_name
+
+# using mock for pygame to avoid having a pygame windows
+sys.modules["pygame"] = mock.MagicMock()
+importlib.reload(habitat.utils.gym_adapter)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation and Context

 - Removing `HabRenderWrapper` since it seems it only adds extra metrics to the rendering (these metrics should be added to the task configuration if they are needed). Please advise
 - Using pygame to render the environment in human mode in a similar manner to interactive play. Made it so that if pygame is not installed, human render mode will not be usable. Please advise.
 - Future? Remove the HabitatRenderXXX default gym tasks. These add the third RGB camera as an observation so I find adding Render to the name is misleading. Thoughts?

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
