### PR TITLE
[Bugfix] [Rearrange] Reset the sensors positons correctly

### DIFF
--- a/habitat/tasks/rearrange/multi_task/composite_task.py
+++ b/habitat/tasks/rearrange/multi_task/composite_task.py
@@ -66,4 +66,4 @@ class CompositeTask(RearrangeTask):
         if self._cur_node_idx >= 0:
             self.jump_to_node(self._cur_node_idx, episode)
 
-        return self._get_observations(episode)
+        return self._get_first_observations(episode)

--- a/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat/tasks/rearrange/rearrange_sim.py
@@ -628,8 +628,7 @@ class RearrangeSim(HabitatSim):
                 add_back_viz_objs[name] = (before_pos, r)
             self.viz_ids = defaultdict(lambda: None)
 
-        if self.habitat_config.UPDATE_ROBOT:
-            self.robots_mgr.update_robots()
+        self.maybe_update_robot()
 
         if self.habitat_config.CONCUR_RENDER:
             self._prev_sim_obs = self.start_async_render()
@@ -669,6 +668,16 @@ class RearrangeSim(HabitatSim):
             obs["robot_third_rgb"] = debug_obs["robot_third_rgb"][:, :, :3]
 
         return obs
+
+    def maybe_update_robot(self):
+        """
+        Calls the update robots method on the robot manager if the
+        `UPDATE_ROBOT` configuration is set to True. Among other
+        things, this will set the robot's sensors' positions to their new
+        positions.
+        """
+        if self.habitat_config.UPDATE_ROBOT:
+            self.robots_mgr.update_robots()
 
     def visualize_position(
         self,

--- a/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat/tasks/rearrange/rearrange_task.py
@@ -137,11 +137,17 @@ class RearrangeTask(NavigationTask):
         self._done = False
         self._cur_episode_step = 0
         if fetch_observations:
-            return self._get_observations(episode)
+            return self._get_first_observations(episode)
         else:
             return None
 
-    def _get_observations(self, episode):
+    def _get_first_observations(self, episode):
+        """
+        Retrieve the first observations after a reset.
+        Should only be called after/within a reset call.
+        Tries to updates the robot's sensor position before
+        retrieving observations.
+        """
         self._sim.maybe_update_robot()
         obs = self._sim.get_sensor_observations()
         obs = self._sim._sensor_suite.get_observations(obs)

--- a/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat/tasks/rearrange/rearrange_task.py
@@ -142,6 +142,7 @@ class RearrangeTask(NavigationTask):
             return None
 
     def _get_observations(self, episode):
+        self._sim.maybe_update_robot()
         obs = self._sim.get_sensor_observations()
         obs = self._sim._sensor_suite.get_observations(obs)
 

--- a/habitat/tasks/rearrange/sub_tasks/articulated_object_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/articulated_object_task.py
@@ -186,7 +186,7 @@ class SetArticulatedObjectTask(RearrangeTask):
         self.prev_dist_to_push = -1
 
         self.prev_snapped_marker_name = None
-        return self._get_observations(episode)
+        return self._get_first_observations(episode)
 
     def _disable_art_sleep(self):
         """

--- a/habitat/tasks/rearrange/sub_tasks/nav_to_obj_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/nav_to_obj_task.py
@@ -344,7 +344,7 @@ class DynNavRLEnv(RearrangeTask):
                 r=0.2,
             )
 
-        return self._get_observations(episode)
+        return self._get_first_observations(episode)
 
 
 def get_robo_start_pos(

--- a/habitat/tasks/rearrange/sub_tasks/pick_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/pick_task.py
@@ -283,5 +283,5 @@ class RearrangePickTaskV1(RearrangeTask):
         self._targ_idx = sel_idx
 
         if fetch_observations:
-            return self._get_observations(episode)
+            return self._get_first_observations(episode)
         return None

--- a/habitat/tasks/rearrange/sub_tasks/place_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/place_task.py
@@ -41,4 +41,4 @@ class RearrangePlaceTaskV1(RearrangePickTaskV1):
         self.was_prev_holding = self.targ_idx
 
         sim.internal_step(-1)
-        return self._get_observations(episode)
+        return self._get_first_observations(episode)

--- a/habitat/tasks/rearrange/sub_tasks/reach_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/reach_task.py
@@ -61,4 +61,4 @@ class RearrangeReachTaskV1(RearrangeTask):
                 global_pos, self._sim.viz_ids["reach_target"]
             )
 
-        return self._get_observations(episode)
+        return self._get_first_observations(episode)


### PR DESCRIPTION
## Motivation and Context

When resetting a rearrange task, the first observation is taken from the origin instead of the position of the robot. this change addresses the issue.

How to reproduce : 

Run this code : 
```

import habitat
import habitat.utils.gym_definitions
import gym
import numpy as np
import matplotlib
import matplotlib.pyplot as plt

mode = "rgb_array"
# mode = "human"
# config_file="/Users/vincentpierre/Documents/habitat-lab/configs/tasks/pointnav.yaml"
config_file="/Users/vincentpierre/Documents/habitat-lab/configs/tasks/rearrange/pick.yaml"

#env = gym.make("HabitatPick-v0")
env = gym.make(
    "Habitat-v0",
    cfg_file_path=config_file,
    use_render_mode=False,
)

#call robot.update()

action = np.array([0.0] * 8, dtype=np.float32)
if isinstance(env.action_space, gym.spaces.Discrete):
	action = 0

_=env.reset();reset_frame_0=env.render(mode)
_=env.step(action);step_frame_0=env.render(mode)
_=env.reset();reset_frame_1=env.render(mode)
_=env.step(action);step_frame_1=env.render(mode)
_=env.reset();reset_frame_2=env.render(mode)
_=env.step(action);step_frame_2=env.render(mode)

plt.figure()
#subplot(r,c) provide the no. of rows and columns
f, axarr = plt.subplots(3,2) 
axarr[0,0].imshow(reset_frame_0);
axarr[0,1].imshow(step_frame_0);
axarr[1,0].imshow(reset_frame_1);
axarr[1,1].imshow(step_frame_1);
axarr[2,0].imshow(reset_frame_2);
axarr[2,1].imshow(step_frame_2);

plt.show()
```

It will generate the following on main: 
<img width="467" alt="Screen Shot 2022-09-15 at 11 40 19" src="https://user-images.githubusercontent.com/28320361/190484888-6a91190a-ce8f-44ca-a9c5-133b0ace9151.png">

And looks like this after the fix :  

<img width="498" alt="Screen Shot 2022-09-15 at 11 30 42" src="https://user-images.githubusercontent.com/28320361/190484927-b54b6a1c-282b-41b1-829e-074c4952f3b2.png">


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- ~[ ] I have added tests to cover my changes.~
- [x] All new and existing tests passed.
