### PR TITLE
[Bugfix] [Rearrange] Reset the sensors positons correctly version 2

### DIFF
--- a/habitat/tasks/rearrange/multi_task/composite_task.py
+++ b/habitat/tasks/rearrange/multi_task/composite_task.py
@@ -66,4 +66,5 @@ class CompositeTask(RearrangeTask):
         if self._cur_node_idx >= 0:
             self.jump_to_node(self._cur_node_idx, episode)
 
+        self._sim.maybe_update_robot()
         return self._get_observations(episode)

--- a/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat/tasks/rearrange/rearrange_sim.py
@@ -628,8 +628,7 @@ class RearrangeSim(HabitatSim):
                 add_back_viz_objs[name] = (before_pos, r)
             self.viz_ids = defaultdict(lambda: None)
 
-        if self.habitat_config.UPDATE_ROBOT:
-            self.robots_mgr.update_robots()
+        self.maybe_update_robot()
 
         if self.habitat_config.CONCUR_RENDER:
             self._prev_sim_obs = self.start_async_render()
@@ -669,6 +668,16 @@ class RearrangeSim(HabitatSim):
             obs["robot_third_rgb"] = debug_obs["robot_third_rgb"][:, :, :3]
 
         return obs
+
+    def maybe_update_robot(self):
+        """
+        Calls the update robots method on the robot manager if the
+        `UPDATE_ROBOT` configuration is set to True. Among other
+        things, this will set the robot's sensors' positions to their new
+        positions.
+        """
+        if self.habitat_config.UPDATE_ROBOT:
+            self.robots_mgr.update_robots()
 
     def visualize_position(
         self,

--- a/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat/tasks/rearrange/rearrange_task.py
@@ -168,6 +168,7 @@ class RearrangeTask(NavigationTask):
         self._done = False
         self._cur_episode_step = 0
         if fetch_observations:
+            self._sim.maybe_update_robot()
             return self._get_observations(episode)
         else:
             return None

--- a/habitat/tasks/rearrange/sub_tasks/articulated_object_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/articulated_object_task.py
@@ -186,6 +186,7 @@ class SetArticulatedObjectTask(RearrangeTask):
         self.prev_dist_to_push = -1
 
         self.prev_snapped_marker_name = None
+        self._sim.maybe_update_robot()
         return self._get_observations(episode)
 
     def _disable_art_sleep(self):

--- a/habitat/tasks/rearrange/sub_tasks/nav_to_obj_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/nav_to_obj_task.py
@@ -343,7 +343,7 @@ class DynNavRLEnv(RearrangeTask):
                 sim.viz_ids["nav_targ_pos"],
                 r=0.2,
             )
-
+        self._sim.maybe_update_robot()
         return self._get_observations(episode)
 
 

--- a/habitat/tasks/rearrange/sub_tasks/pick_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/pick_task.py
@@ -283,5 +283,6 @@ class RearrangePickTaskV1(RearrangeTask):
         self._targ_idx = sel_idx
 
         if fetch_observations:
+            self._sim.maybe_update_robot()
             return self._get_observations(episode)
         return None

--- a/habitat/tasks/rearrange/sub_tasks/place_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/place_task.py
@@ -41,4 +41,5 @@ class RearrangePlaceTaskV1(RearrangePickTaskV1):
         self.was_prev_holding = self.targ_idx
 
         sim.internal_step(-1)
+        self._sim.maybe_update_robot()
         return self._get_observations(episode)

--- a/habitat/tasks/rearrange/sub_tasks/reach_task.py
+++ b/habitat/tasks/rearrange/sub_tasks/reach_task.py
@@ -61,4 +61,5 @@ class RearrangeReachTaskV1(RearrangeTask):
                 global_pos, self._sim.viz_ids["reach_target"]
             )
 
+        self._sim.maybe_update_robot()
         return self._get_observations(episode)


### PR DESCRIPTION
## Motivation and Context

This is an alternative fix for #949
In this version, instead of updating the robot in the first observation, we reset the robot manually in each task reset.
This is potentially cleaner since there is no need to change `_get_observations` but it requires adding a method call in all existing (an future) reset calls of classes that implement the RearrangeTaskv1 class.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
