### PR TITLE
Fixed Skill Key Mismatch in TP-SRL

### DIFF
--- a/habitat_baselines/config/default.py
+++ b/habitat_baselines/config/default.py
@@ -101,6 +101,7 @@ _C.RL.preemption.save_state_batch_only = False
 _C.RL.POLICY = CN()
 _C.RL.POLICY.name = "PointNavResNetPolicy"
 _C.RL.POLICY.action_distribution_type = "categorical"  # or 'gaussian'
+_C.RL.POLICY.order_keys = False
 # If the list is empty, all keys will be included.
 # For gaussian action distribution:
 _C.RL.POLICY.ACTION_DIST = CN()

--- a/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -94,6 +94,10 @@ class PointNavResNetPolicy(NetPolicy):
         action_space,
         **kwargs,
     ):
+        if not config.RL.POLICY.get("order_keys", False):
+            fuse_keys = config.TASK_CONFIG.GYM.OBS_KEYS
+        else:
+            fuse_keys = None
         return cls(
             observation_space=observation_space,
             action_space=action_space,
@@ -104,7 +108,7 @@ class PointNavResNetPolicy(NetPolicy):
             normalize_visual_inputs="rgb" in observation_space.spaces,
             force_blind_policy=config.FORCE_BLIND_POLICY,
             policy_config=config.RL.POLICY,
-            fuse_keys=None,
+            fuse_keys=fuse_keys,
         )
 
 
@@ -267,7 +271,7 @@ class PointNavResNetNet(Net):
         # Only fuse the 1D state inputs. Other inputs are processed by the
         # visual encoder
         if fuse_keys is None:
-            fuse_keys = observation_space.spaces.keys()
+            fuse_keys = sorted(observation_space.spaces.keys())
             # removing keys that correspond to goal sensors
             goal_sensor_keys = {
                 IntegratedPointGoalGPSAndCompassSensor.cls_uuid,

--- a/habitat_baselines/rl/hrl/skills/nn_skill.py
+++ b/habitat_baselines/rl/hrl/skills/nn_skill.py
@@ -135,6 +135,11 @@ class NnSkillPolicy(SkillPolicy):
             policy_cfg = ckpt_dict["config"]
         policy = baseline_registry.get_policy(config.name)
 
+        if "order_keys" in config:
+            policy_cfg.defrost()
+            policy_cfg.RL.POLICY.order_keys = config.order_keys
+            policy_cfg.freeze()
+
         expected_obs_keys = policy_cfg.TASK_CONFIG.GYM.OBS_KEYS
         filtered_obs_space = spaces.Dict(
             OrderedDict(


### PR DESCRIPTION
Bug fix for TP-SRL method in the NeurIPS 2022 Rearrangement Challenge.

Newly trained skills were not compatible with TP-SRL due to a mismatch in the ordering of state-based inputs to the policy between skill training and TP-SRL evaluation.