### PR TITLE
Fix link in colab

### DIFF
--- a/examples/tutorials/colabs/Habitat2_Quickstart.ipynb
+++ b/examples/tutorials/colabs/Habitat2_Quickstart.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "source": [
     "# Local installation\n",
-    "Follow the steps on the [Habitat Lab README](https://github.com/facebookresearch/habitat-lab/tree/challenge_tasks#installation)."
+    "Follow the steps on the [Habitat Lab README](https://github.com/facebookresearch/habitat-lab#installation)."
    ]
   },
   {

--- a/examples/tutorials/nb_python/Habitat2_Quickstart.py
+++ b/examples/tutorials/nb_python/Habitat2_Quickstart.py
@@ -103,7 +103,7 @@ importlib.reload(PIL.TiffTags)  # To potentially avoid PIL problem
 
 # %% [markdown]
 # # Local installation
-# Follow the steps on the [Habitat Lab README](https://github.com/facebookresearch/habitat-lab/tree/challenge_tasks#installation).
+# Follow the steps on the [Habitat Lab README](https://github.com/facebookresearch/habitat-lab#installation).
 
 # %% [markdown]
 # # Quickstart


### PR DESCRIPTION
## Motivation and Context

There was a broken link in the [Habitat2_Quickstart.ipynb](https://github.com/facebookresearch/habitat-lab/blob/main/examples/tutorials/colabs/Habitat2_Quickstart.ipynb) notebook, local installation section. 

## How Has This Been Tested

No need to run mypy or pytest since there are no python files. Ran notebook and verified that the new link connects to the installation instructions.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
