### PR TITLE
fix small typo in README about using VER

### DIFF
--- a/habitat-baselines/habitat_baselines/README.md
+++ b/habitat-baselines/habitat_baselines/README.md
@@ -33,7 +33,7 @@ setting `trainer_name` to `"ver"` in either the config or via the command line.
 
 ```bash
 python -u habitat_baselines/run.py --exp-config habitat-baselines/habitat_baselines/config/pointnav/ppo_pointnav_example.yaml --run-type train \
-  trainer_name ver
+  habitat_baselines.trainer_name ver
 ```
 
 **test**:


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Typo in README about switching to ver for training

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Verified using:
`python -m habitat_baselines.run --run-type train  --exp-config habitat-baselines/habitat_baselines/config/objectnav/ddppo_objectnav_hm3d.yaml habitat_baselines.trainer_name ver`

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
