### PR TITLE
[Hydra migration] Moving the data generation code to omegaconf

### DIFF
--- a/habitat-baselines/habitat_baselines/agents/ppo_agents.py
+++ b/habitat-baselines/habitat_baselines/agents/ppo_agents.py
@@ -7,6 +7,7 @@
 
 import argparse
 import random
+from dataclasses import dataclass
 from typing import Dict, Optional
 
 import numpy as np
@@ -14,7 +15,7 @@ import torch
 from gym.spaces import Box
 from gym.spaces import Dict as SpaceDict
 from gym.spaces import Discrete
-from yacs.config import CfgNode as Config
+from omegaconf import DictConfig
 
 import habitat
 from habitat.core.agent import Agent
@@ -23,22 +24,25 @@ from habitat_baselines.rl.ddppo.policy import PointNavResNetPolicy
 from habitat_baselines.utils.common import batch_obs
 
 
-def get_default_config() -> Config:
-    c = Config()
-    c.INPUT_TYPE = "rgb"
-    c.MODEL_PATH = "data/checkpoints/gibson-rgb-best.pth"
-    c.RESOLUTION = 256
-    c.hidden_size = 512
-    c.RANDOM_SEED = 7
-    c.PTH_GPU_ID = 0
-    c.goal_sensor_uuid = "pointgoal_with_gps_compass"
-    return c
+@dataclass
+class PPOAgentConfig:
+    INPUT_TYPE: str = "rgb"
+    MODEL_PATH: str = "data/checkpoints/gibson-rgb-best.pth"
+    RESOLUTION: int = 256
+    HIDDEN_SIZE: int = 512
+    RANDOM_SEED: int = 7
+    PTH_GPU_ID: int = 0
+    GOAL_SENSOR_UUID: str = "pointgoal_with_gps_compass"
+
+
+def get_default_config() -> DictConfig:
+    return PPOAgentConfig()
 
 
 class PPOAgent(Agent):
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: DictConfig) -> None:
         spaces = {
-            get_default_config().goal_sensor_uuid: Box(
+            get_default_config().GOAL_SENSOR_UUID: Box(
                 low=np.finfo(np.float32).min,
                 high=np.finfo(np.float32).max,
                 shape=(2,),
@@ -70,7 +74,7 @@ class PPOAgent(Agent):
             if torch.cuda.is_available()
             else torch.device("cpu")
         )
-        self.hidden_size = config.hidden_size
+        self.hidden_size = config.HIDDEN_SIZE
 
         random.seed(config.RANDOM_SEED)
         torch.random.manual_seed(config.RANDOM_SEED)

--- a/habitat-lab/habitat/datasets/eqa/mp3d_eqa_dataset.py
+++ b/habitat-lab/habitat/datasets/eqa/mp3d_eqa_dataset.py
@@ -9,8 +9,7 @@ import json
 import os
 from typing import List, Optional
 
-from yacs.config import CfgNode as Config
-
+from habitat.config.default_structured_configs import DatasetConfig
 from habitat.core.dataset import Dataset
 from habitat.core.registry import registry
 from habitat.core.simulator import AgentState
@@ -23,12 +22,12 @@ EQA_MP3D_V1_VAL_EPISODE_COUNT = 1950
 DEFAULT_SCENE_PATH_PREFIX = "data/scene_datasets/"
 
 
-def get_default_mp3d_v1_config(split: str = "val"):
-    config = Config()
-    config.name = "MP3DEQA-v1"
-    config.data_path = "data/datasets/eqa/mp3d/v1/{split}.json.gz"
-    config.split = split
-    return config
+def get_default_mp3d_v1_config(split: str = "val") -> DatasetConfig:
+    return DatasetConfig(
+        type="MP3DEQA-v1",
+        split=split,
+        data_path="data/datasets/eqa/mp3d/v1/{split}.json.gz",
+    )
 
 
 @registry.register_dataset(name="MP3DEQA-v1")
@@ -46,10 +45,10 @@ class Matterport3dDatasetV1(Dataset):
     question_vocab: VocabDict
 
     @staticmethod
-    def check_config_paths_exist(config: Config) -> bool:
+    def check_config_paths_exist(config: DatasetConfig) -> bool:
         return os.path.exists(config.data_path.format(split=config.split))
 
-    def __init__(self, config: Config = None) -> None:
+    def __init__(self, config: DatasetConfig = None) -> None:
         self.episodes = []
 
         if config is None:

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -5,17 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 import os.path as osp
-from collections import defaultdict
+from collections import Sequence, defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
 import magnum as mn
 import numpy as np
 from tqdm import tqdm
-from yacs.config import CfgNode as CN
 
 import habitat.datasets.rearrange.samplers as samplers
 import habitat.sims.habitat_simulator.sim_utilities as sutils
 import habitat_sim
+from habitat.config import DictConfig
 from habitat.core.logging import logger
 from habitat.datasets.rearrange.rearrange_dataset import RearrangeEpisode
 from habitat.datasets.rearrange.samplers.receptacle import (
@@ -56,7 +56,7 @@ class RearrangeEpisodeGenerator:
 
     def __init__(
         self,
-        cfg: CN,
+        cfg: DictConfig,
         debug_visualization: bool = False,
         limit_scene_set: Optional[str] = None,
     ) -> None:
@@ -117,8 +117,8 @@ class RearrangeEpisodeGenerator:
                 assert (
                     list_key in scene_set
                 ), f"Expected list key '{list_key}'."
-                assert (
-                    type(scene_set[list_key]) is list
+                assert isinstance(
+                    scene_set[list_key], Sequence
                 ), f"cfg.scene_sets - '{scene_set['name']}' '{list_key}' must be a list of strings."
             self._scene_sets[
                 scene_set["name"]
@@ -138,8 +138,8 @@ class RearrangeEpisodeGenerator:
                 assert (
                     list_key in object_set
                 ), f"Expected list key '{list_key}'."
-                assert (
-                    type(object_set[list_key]) is list
+                assert isinstance(
+                    object_set[list_key], Sequence
                 ), f"cfg.object_sets - '{object_set['name']}' '{list_key}' must be a list of strings."
             self._obj_sets[
                 object_set["name"]
@@ -165,8 +165,8 @@ class RearrangeEpisodeGenerator:
                 assert (
                     list_key in receptacle_set
                 ), f"Expected list key '{list_key}'."
-                assert (
-                    type(receptacle_set[list_key]) is list
+                assert isinstance(
+                    receptacle_set[list_key], Sequence
                 ), f"cfg.receptacle_sets - '{receptacle_set['name']}' '{list_key}' must be a list of strings."
 
             self._receptacle_sets[receptacle_set["name"]] = ReceptacleSet(

--- a/habitat-lab/habitat/datasets/rearrange/run_episode_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/run_episode_generator.py
@@ -7,10 +7,13 @@
 import os
 import os.path as osp
 import random
+from dataclasses import dataclass, field
+from typing import Any, List
 
 import numpy as np
-from yacs.config import CfgNode as CN
+from omegaconf import OmegaConf
 
+from habitat.config import DictConfig
 from habitat.core.logging import logger
 from habitat.datasets.rearrange.rearrange_dataset import RearrangeDatasetV0
 from habitat.datasets.rearrange.rearrange_generator import (
@@ -21,63 +24,77 @@ from habitat.datasets.rearrange.samplers.receptacle import (
 )
 
 
-def get_config_defaults() -> CN:
-    """
-    Populates and resturns a default config for a RearrangeEpisode.
-    """
-    _C = CN()
-    # The minimum distance from the target object starting position to its goal
-    _C.min_dist_from_start_to_goal = 0.5
+@dataclass
+class SceneSamplerParamsConfig:
+    scene: str = "v3_sc1_staging_00"
+    scene_sets: List[Any] = field(default_factory=list)
 
+
+@dataclass
+class SceneSamplerConfig:
+    type: str = "single"
+    params: SceneSamplerParamsConfig = SceneSamplerParamsConfig()
+    comment: str = ""
+
+
+@dataclass
+class RearrangeEpisodeGeneratorConfig:
+    # The minimum distance from the target object starting position to its goal
+    min_dist_from_start_to_goal: float = 0.5
     # ----- import/initialization parameters ------
     # the scene dataset from which scenes and objects are sampled
-    _C.dataset_path = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    dataset_path: str = "data/replica_cad/replicaCAD.scene_dataset_config.json"
     # any additional object assets to load before defining object sets
-    _C.additional_object_paths = ["data/objects/ycb/"]
-
+    additional_object_paths: List[str] = field(
+        default_factory=lambda: ["data/objects/ycb/"]
+    )
     # ----- resource set definitions ------
     # Define the sets of scenes, objects, and receptacles which can be sampled from.
     # The SceneDataset will be searched for resources of each type with handles containing ANY "included" substrings and NO "excluded" substrings.
 
     # Define sets of scene instance handles which can be sampled from for initialization:
-    _C.scene_sets = [
-        {
-            "name": "any",
-            "included_substrings": [""],
-            "excluded_substrings": [],
-            # NOTE: The "comment" key is intended for notes and descriptions and not consumed by the generator.
-            "comment": "The empty substring acts like a wildcard, selecting all scenes.",
-        },
-    ]
-
+    scene_sets: List[Any] = field(
+        default_factory=lambda: [
+            {
+                "name": "any",
+                "included_substrings": [""],
+                "excluded_substrings": [],
+                # NOTE: The "comment" key is intended for notes and descriptions and not consumed by the generator.
+                "comment": "The empty substring acts like a wildcard, selecting all scenes.",
+            },
+        ]
+    )
     # Define the sets of object handles which can be sampled from for placement and target sampling:
     # NOTE: Each set must have a unique name.
-    _C.object_sets = [
-        {
-            "name": "any",
-            "included_substrings": [""],
-            "excluded_substrings": [],
-            # NOTE: The "comment" key is intended for notes and descriptions and not consumed by the generator.
-            "comment": "The empty substring acts like a wildcard, selecting all objects.",
-        },
-    ]
+    object_sets: List[Any] = field(
+        default_factory=lambda: [
+            {
+                "name": "any",
+                "included_substrings": [""],
+                "excluded_substrings": [],
+                # NOTE: The "comment" key is intended for notes and descriptions and not consumed by the generator.
+                "comment": "The empty substring acts like a wildcard, selecting all objects.",
+            },
+        ]
+    )
 
     # Define the sets of receptacles which can be sampled from for placing objects and targets:
     # The SceneDataset will be searched for objects containing receptacle metadata.
     # Receptacle name substrings are used to further constrain sets.
     # NOTE: Each set must have a unique name.
-    _C.receptacle_sets = [
-        {
-            "name": "any",
-            "included_object_substrings": [""],
-            "excluded_object_substrings": [],
-            "included_receptacle_substrings": [""],
-            "excluded_receptacle_substrings": [],
-            # NOTE: The "comment" key is intended for notes and descriptions and not consumed by the generator.
-            "comment": "The empty substrings act like wildcards, selecting all receptacles for all objects.",
-        },
-    ]
-
+    receptacle_sets: List[Any] = field(
+        default_factory=lambda: [
+            {
+                "name": "any",
+                "included_object_substrings": [""],
+                "excluded_object_substrings": [],
+                "included_receptacle_substrings": [""],
+                "excluded_receptacle_substrings": [],
+                # NOTE: The "comment" key is intended for notes and descriptions and not consumed by the generator.
+                "comment": "The empty substrings act like wildcards, selecting all receptacles for all objects.",
+            },
+        ]
+    )
     # ----- sampler definitions ------
     # Define the scene sampling configuration
     # NOTE: There must be exactly one scene sampler!
@@ -89,87 +106,79 @@ def get_config_defaults() -> CN:
     # NOTE: "single" scene sampler asserts that only a single scene contains the "scene" name substring
     # NOTE: "subset" scene sampler allows sampling from multiple scene sets by name
     # TODO: This default is a bit ugly, but we must use ConfigNodes and define all options to directly nest dicts with yacs|yaml...
-    _C.scene_sampler = CN()
-    _C.scene_sampler.type = "single"
-    _C.scene_sampler.params = CN()
-    _C.scene_sampler.params.scene = "v3_sc1_staging_00"
-    _C.scene_sampler.params.scene_sets = []
-    _C.scene_sampler.comment = ""
+    scene_sampler: SceneSamplerConfig = SceneSamplerConfig()
 
     # Specify name of receptacle and maximum # of placemenets in
     # receptacle. To allow only two objects in the chair, specify:
     # - ["receptacle_aabb_Chr1_Top1_frl_apartment_chair_01", 2]
-    _C.max_objects_per_receptacle = []
+    max_objects_per_receptacle: List[Any] = field(default_factory=list)
 
     # Define the object sampling configuration
-    _C.object_samplers = [
-        # {"name":str, "type:str", "params":{})
-        # - uniform sampler params: {"object_sets":[str], "receptacle_sets":[str], "num_samples":[min, max], "orientation_sampling":str)
-        # NOTE: "orientation_sampling" options: "none", "up", "all"
-        # TODO: convert some special examples to yaml:
-        # (
-        #     "fridge_middle",
-        #     "uniform",
-        #     (["any"], ["fridge_middle"], 1, 30, "up"),
-        # ),
-        # Composite object sampling (e.g. apple in bowl)
-        #  - parameterized by object and receptacle sets, but inclusive of listed samplers BEFORE the composite sampler
-        # Example: sample a basket placement on a table and then place apples in the basket
-        # ("basket_sampling", "uniform", (["basket"], ["table"], 1, 1, "up")),
-        # (
-        #     "in_basket_sampling",
-        #     "uniform",
-        #     (["apple"], ["basket"], 1, 2, "any"),
-        # ),
-        # {
-        #     "name": "any_one",
-        #     "type": "uniform",
-        #     "params": {
-        #         "object_sets": ["any"],
-        #         "receptacle_sets": ["any"],
-        #         "num_samples": [1, 1],
-        #         "orientation_sampling": "up",
-        #     },
-        #     "comment": "Sample any one object from any receptacle.",
-        # }
-    ]
+    object_samplers: List[Any] = field(default_factory=list)
+    # {"name":str, "type:str", "params":{})
+    # - uniform sampler params: {"object_sets":[str], "receptacle_sets":[str], "num_samples":[min, max], "orientation_sampling":str)
+    # NOTE: "orientation_sampling" options: "none", "up", "all"
+    # TODO: convert some special examples to yaml:
+    # (
+    #     "fridge_middle",
+    #     "uniform",
+    #     (["any"], ["fridge_middle"], 1, 30, "up"),
+    # ),
+    # Composite object sampling (e.g. apple in bowl)
+    #  - parameterized by object and receptacle sets, but inclusive of listed samplers BEFORE the composite sampler
+    # Example: sample a basket placement on a table and then place apples in the basket
+    # ("basket_sampling", "uniform", (["basket"], ["table"], 1, 1, "up")),
+    # (
+    #     "in_basket_sampling",
+    #     "uniform",
+    #     (["apple"], ["basket"], 1, 2, "any"),
+    # ),
+    # {
+    #     "name": "any_one",
+    #     "type": "uniform",
+    #     "params": {
+    #         "object_sets": ["any"],
+    #         "receptacle_sets": ["any"],
+    #         "num_samples": [1, 1],
+    #         "orientation_sampling": "up",
+    #     },
+    #     "comment": "Sample any one object from any receptacle.",
+    # }
 
     # Define the desired object target sampling (i.e., where should an existing object be moved to)
-    _C.object_target_samplers = [
-        # {"name":str, "type:str", "params":{})
-        # - uniform target sampler params:
-        # {"object_samplers":[str], "receptacle_sets":[str], "num_samples":[min, max], "orientation_sampling":str)
-        # NOTE: random instances are chosen from the specified, previously excecuted object sampler up to the maximum number specified in params.
-        # NOTE: previous samplers referenced must have: combined minimum samples >= minimum requested targets
-        # {
-        #     "name": "any_one_target",
-        #     "type": "uniform",
-        #     "params": {
-        #         "object_samplers": ["any_one"],
-        #         "receptacle_sets": ["any"],
-        #         "num_samples": [1, 1],
-        #         "orientation_sampling": "up",
-        #     },
-        #     "comment": "Sample a target for the object instanced by the 'any_one' object sampler from any receptacle.",
-        # }
-    ]
+    object_target_samplers: List[Any] = field(default_factory=list)
+    # {"name":str, "type:str", "params":{})
+    # - uniform target sampler params:
+    # {"object_samplers":[str], "receptacle_sets":[str], "num_samples":[min, max], "orientation_sampling":str)
+    # NOTE: random instances are chosen from the specified, previously excecuted object sampler up to the maximum number specified in params.
+    # NOTE: previous samplers referenced must have: combined minimum samples >= minimum requested targets
+    # {
+    #     "name": "any_one_target",
+    #     "type": "uniform",
+    #     "params": {
+    #         "object_samplers": ["any_one"],
+    #         "receptacle_sets": ["any"],
+    #         "num_samples": [1, 1],
+    #         "orientation_sampling": "up",
+    #     },
+    #     "comment": "Sample a target for the object instanced by the 'any_one' object sampler from any receptacle.",
+    # }
 
     # define ArticulatedObject(AO) joint state sampling (when a scene is initialized, all samplers are run for all matching AOs)
-    _C.ao_state_samplers = [
-        # TODO: the cupboard asset needs to be modified to remove self-collisions or have collision geometry not intersecting the wall.
-        # TODO: does not support spherical joints (3 dof joints)
-        # - uniform continuous range for a single joint. params: ("ao_handle", "link name", min, max)
-        # Example:
-        #     {"name": "open_fridge_top_door",
-        #     "type": "uniform",
-        #     "params": ["fridge", "top_door", 1.5, 1.5]}
-        # - "composite" type sampler (rejection sampling of composite configuration)
-        # params: [{"ao_handle":str, "joint_states":[[link name, min max], ], "should_sample_all_joints:bool"}, ]
-        # If should_sample_all_joints is True (defaults to False) then all joints of an AO will be sampled and not just the one the target is in.
-        # for example, should_sample_all_joints should be true for the fridge since the joints (the door) angle need to be sampled when the object
-        # is inside. But for kitchen drawers, this should be false since the joints (all drawers) should not be sampled when the object is on the
-        # countertop (only need to sample for the drawer the object is in)
-    ]
+    ao_state_samplers: List[Any] = field(default_factory=list)
+    # TODO: the cupboard asset needs to be modified to remove self-collisions or have collision geometry not intersecting the wall.
+    # TODO: does not support spherical joints (3 dof joints)
+    # - uniform continuous range for a single joint. params: ("ao_handle", "link name", min, max)
+    # Example:
+    #     {"name": "open_fridge_top_door",
+    #     "type": "uniform",
+    #     "params": ["fridge", "top_door", 1.5, 1.5]}
+    # - "composite" type sampler (rejection sampling of composite configuration)
+    # params: [{"ao_handle":str, "joint_states":[[link name, min max], ], "should_sample_all_joints:bool"}, ]
+    # If should_sample_all_joints is True (defaults to False) then all joints of an AO will be sampled and not just the one the target is in.
+    # for example, should_sample_all_joints should be true for the fridge since the joints (the door) angle need to be sampled when the object
+    # is inside. But for kitchen drawers, this should be false since the joints (all drawers) should not be sampled when the object is on the
+    # countertop (only need to sample for the drawer the object is in)
 
     # ----- marker definitions ------
     # A marker defines a point in the local space of a rigid object or articulated link which can be registered to instances in a scene and tracked
@@ -181,9 +190,14 @@ def get_config_defaults() -> CN:
     #   "link": str (if "articulated_object")
     #   "offset": vec3 []
     #  }
-    _C.markers = []
+    markers: List[Any] = field(default_factory=list)
 
-    return _C.clone()
+
+def get_config_defaults() -> DictConfig:
+    """
+    Populates and resturns a default config for a RearrangeEpisode.
+    """
+    return OmegaConf.create(RearrangeEpisodeGeneratorConfig())
 
 
 if __name__ == "__main__":
@@ -261,7 +275,8 @@ if __name__ == "__main__":
         assert osp.exists(
             args.config
         ), f"Provided config, '{args.config}', does not exist."
-        cfg.merge_from_file(args.config)
+        override_config = OmegaConf.load(args.config)
+        cfg = OmegaConf.merge(cfg, override_config)
 
     logger.info(f"\n\nModified Config:\n{cfg}\n\n")
 

--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -436,6 +436,7 @@ class ReceptacleSet:
     included_receptacle_substrings: List[str]
     excluded_receptacle_substrings: List[str]
     is_on_top_of_sampler: bool = False
+    comment: str = ""
 
 
 class ReceptacleTracker:

--- a/habitat-lab/requirements.txt
+++ b/habitat-lab/requirements.txt
@@ -1,6 +1,5 @@
 gym>=0.22.0,<0.23.1
 numpy>=1.20.0
-yacs>=0.1.8
 numpy-quaternion>=2019.3.18.14.33.20
 attrs>=19.1.0
 opencv-python>=3.3.0

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -4,18 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from habitat.config.default import get_config
 
-from glob import glob
-
-import pytest
-from yacs.config import CfgNode
-
-import habitat
-from habitat.config.default import _HABITAT_CFG_DIR, get_config
-
-_C = CfgNode()
 CFG_TEST = "test/habitat_all_sensors_test.yaml"
-CFG_EQA = "test/habitat_mp3d_eqa_test.yaml"
 MAX_TEST_STEPS_LIMIT = 3
 
 
@@ -28,30 +19,3 @@ def test_overwrite_options():
         assert (
             config.habitat.environment.max_episode_steps == steps_limit
         ), "Overwriting of config options failed."
-
-
-CONFIGS_ALLOWED_TO_HAVE_NON_DEFAULT_KEYS = [
-    # Trainer excluded because does not use the default config
-    _HABITAT_CFG_DIR + "/baselines/ppo.yaml",
-    _HABITAT_CFG_DIR + "/task/rearrange/rearrange_easy_multi_agent.yaml",
-    # Planning Domain Definition Language configs are
-    # excluded since they do not implement the default config
-] + glob(_HABITAT_CFG_DIR + "/**/pddl/*.yaml", recursive=True)
-
-
-@pytest.mark.parametrize(
-    "config_path",
-    glob(_HABITAT_CFG_DIR + "/benchmark/**/*.yaml", recursive=True),
-)
-def test_no_core_config_has_non_default_keys(config_path):
-    if config_path in CONFIGS_ALLOWED_TO_HAVE_NON_DEFAULT_KEYS:
-        pytest.skip(f"File {config_path} manually excluded from test")
-    # We manually disallow new keys when merging to make sure all keys
-    # are in the default config
-    _C.set_new_allowed(False)
-    try:
-        habitat.get_config(config_path)
-    except KeyError as e:
-        raise KeyError(f"Failed for config {config_path}") from e
-    finally:
-        _C.set_new_allowed(True)


### PR DESCRIPTION
## Motivation and Context

The dataset generation code for rearrange is using YACS.
We are removing YACS.
Code must change.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

My 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
