### PR TITLE
[v0.2.3] [Stretch] play stretch demo

### DIFF
--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -72,7 +72,7 @@ try:
 except ImportError:
     pygame = None
 
-DEFAULT_CFG = "benchmark/rearrange/play.yaml"
+DEFAULT_CFG = "benchmark/rearrange/play_stretch.yaml"
 DEFAULT_RENDER_STEPS_LIMIT = 60
 SAVE_VIDEO_DIR = "./data/vids"
 SAVE_ACTIONS_DIR = "./data/interactive_play_replays"
@@ -108,6 +108,10 @@ def get_input_vel_ctlr(
         ]
         arm_ctrlr = env.task.actions[arm_action_name].arm_ctrlr
         base_action = None
+    elif "stretch" in DEFAULT_CFG:
+        arm_action_space = np.zeros(10)
+        arm_ctrlr = None
+        base_action = [0, 0]
     else:
         arm_action_space = np.zeros(7)
         arm_ctrlr = None
@@ -182,6 +186,44 @@ def get_input_vel_ctlr(
                 arm_action[6] = 1.0
             elif keys[pygame.K_7]:
                 arm_action[6] = -1.0
+
+        elif arm_action_space.shape[0] == 10:
+            # Velocity control. A different key for each joint
+            if keys[pygame.K_q]:
+                arm_action[0] = 1.0
+            elif keys[pygame.K_1]:
+                arm_action[0] = -1.0
+
+            elif keys[pygame.K_w]:
+                arm_action[4] = 1.0
+            elif keys[pygame.K_2]:
+                arm_action[4] = -1.0
+
+            elif keys[pygame.K_e]:
+                arm_action[5] = 1.0
+            elif keys[pygame.K_3]:
+                arm_action[5] = -1.0
+
+            elif keys[pygame.K_r]:
+                arm_action[6] = 1.0
+            elif keys[pygame.K_4]:
+                arm_action[6] = -1.0
+
+            elif keys[pygame.K_t]:
+                arm_action[7] = 1.0
+            elif keys[pygame.K_5]:
+                arm_action[7] = -1.0
+
+            elif keys[pygame.K_y]:
+                arm_action[8] = 1.0
+            elif keys[pygame.K_6]:
+                arm_action[8] = -1.0
+
+            elif keys[pygame.K_u]:
+                arm_action[9] = 1.0
+            elif keys[pygame.K_7]:
+                arm_action[9] = -1.0
+
         elif isinstance(arm_ctrlr, ArmEEAction):
             EE_FACTOR = 0.5
             # End effector control

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -72,7 +72,7 @@ try:
 except ImportError:
     pygame = None
 
-DEFAULT_CFG = "benchmark/rearrange/play_stretch.yaml"
+DEFAULT_CFG = "benchmark/rearrange/play.yaml"
 DEFAULT_RENDER_STEPS_LIMIT = 60
 SAVE_VIDEO_DIR = "./data/vids"
 SAVE_ACTIONS_DIR = "./data/interactive_play_replays"

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_stretch.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_stretch.yaml
@@ -35,7 +35,7 @@ habitat:
       - "data/objects/ycb/configs/"
     agent_0:
       radius: 0.3
-      robot_urdf: hab_stretch/urdf/hab_stretch.urdf
+      robot_urdf: data/robots/hab_stretch/urdf/hab_stretch.urdf
       robot_type: "StretchRobot"
       sim_sensors:
         head_rgb_sensor:

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_stretch.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_stretch.yaml
@@ -1,0 +1,56 @@
+# @package _global_
+
+defaults:
+  - /habitat: habitat_config_base
+  - /agent@habitat.simulator.agent_0: agent_base
+  - /habitat/simulator/sim_sensors:
+    - head_rgb_sensor
+    - head_depth_sensor
+    - arm_rgb_sensor
+    - arm_depth_sensor
+  - /habitat/task/rearrange: play
+  - /habitat/dataset/rearrangement: replica_cad
+  - _self_
+
+# Config for empty task to explore the scene.
+habitat:
+  environment:
+    max_episode_steps: 0
+  task:
+    actions:
+      arm_action:
+        type: "ArmAction"
+        arm_controller: "ArmRelPosKinematicReducedActionStretch"
+        grip_controller: "MagicGraspAction"
+        arm_joint_mask: [1,0,0,0,1,1,1,1,1,1]
+        arm_joint_dimensionality: 10
+        grasp_thresh_dist: 0.15
+        disable_grip: False
+        delta_pos_limit: 0.0125
+        ee_ctrl_lim: 0.015
+  simulator:
+    type: RearrangeSim-v0
+    seed: 100
+    additional_object_paths:
+      - "data/objects/ycb/configs/"
+    agent_0:
+      radius: 0.3
+      robot_urdf: hab_stretch/urdf/hab_stretch.urdf
+      robot_type: "StretchRobot"
+      sim_sensors:
+        head_rgb_sensor:
+          height: 212
+          width: 120
+        head_depth_sensor:
+          height: 212
+          width: 120
+        arm_depth_sensor:
+          height: 212
+          width: 120
+        arm_rgb_sensor:
+          height: 212
+          width: 120
+    habitat_sim_v0:
+      enable_physics: True
+  dataset:
+    data_path: data/datasets/replica_cad/rearrange/v1/{split}/all_receptacles_10k_1k.json.gz

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -106,7 +106,7 @@ class ArmActionConfig(ActionConfig):
     type: str = "ArmAction"
     arm_controller: str = "ArmRelPosAction"
     grip_controller: Optional[str] = None
-    arm_joint_mask: Optional[list[int]] = None
+    arm_joint_mask: Optional[List[int]] = None
     arm_joint_dimensionality: int = 7
     grasp_thresh_dist: float = 0.15
     disable_grip: bool = False

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -106,6 +106,7 @@ class ArmActionConfig(ActionConfig):
     type: str = "ArmAction"
     arm_controller: str = "ArmRelPosAction"
     grip_controller: Optional[str] = None
+    arm_joint_mask: Optional[list[int]] = None
     arm_joint_dimensionality: int = 7
     grasp_thresh_dist: float = 0.15
     disable_grip: bool = False


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? --> 

Provide a demo for running Stretch. Download the stretch asset using data loader in Habitat sim. 

Then run 
```python examples/interactive_play.py --never-end --cfg [path to stretch]/play_stretch.yaml```, 

then you can use a keyboard to control Stretch.

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

https://user-images.githubusercontent.com/55121504/203428657-bbe63057-7a44-4072-b9af-7029a5b7ff43.mp4


## How Has This Been Tested

Locally

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
