### PR TITLE
Unpin habitat-lab requirements

### DIFF
--- a/habitat-lab/requirements.txt
+++ b/habitat-lab/requirements.txt
@@ -10,5 +10,5 @@ imageio-ffmpeg>=0.2.0
 scipy>=1.0.0
 tqdm>=4.0.0
 numba>=0.44.0
-hydra-core==1.2.0
-omegaconf==2.2.3
+hydra-core>=1.2.0
+omegaconf>=2.2.3


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Pinning the hydra version so strongly is not recommended and could prevent bugfixes and cause compatibility issues. None of the other requirements for habitat-lab are pinned (exception for protobuf and tensorboard for specific reasons). I would recommend unpinning them to prevent issues down the line. I would even be okay if you wanted to pin hydra only, but I don't see a reason to pin the minor version of either library. This will prevent us from getting potential bugfixes and support for newer Python versions.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
* Locally and with CI
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
