### PR TITLE
Fix Miniconda installation on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
               then
                 curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
                 chmod +x ~/miniconda.sh
-                ~/miniconda.sh -b -p $HOME/miniconda
+                bash ~/miniconda.sh -b -p $HOME/miniconda
                 rm ~/miniconda.sh
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
                 conda create -y -n habitat python=3.7


### PR DESCRIPTION
## Motivation and Context

The latest Miniconda installer (22.11.1) fails to work with sh. To circumvent this issue, this change invokes `miniconda.sh` with bash instead of sh.
[The same change was applied to habitat-sim.](https://github.com/facebookresearch/habitat-sim/pull/1977)

## How Has This Been Tested

Tested on CI.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
