### PR TITLE
Remove unnecessary setup of rgb and depth cameras

### DIFF
--- a/habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_base.yaml
+++ b/habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_base.yaml
@@ -9,13 +9,3 @@ defaults:
 habitat:
   environment:
     max_episode_steps: 500
-  simulator:
-    agents:
-      main_agent:
-        sim_sensors:
-          rgb_sensor:
-            width: 256
-            height: 256
-          depth_sensor:
-            width: 256
-            height: 256


### PR DESCRIPTION
## Motivation and Context

The depth and rgb cameras are included by default anyway when this config is invoked, due to line 6. Setting these cameras up again from line 12 is not only redundant, but also prevents the user from using Hydra overriding for the agent from a downstream yaml file, or using command line args, like so:

``` bash
python habitat_baselines/run.py \
  --exp-config habitat_baselines/config/pointnav/ddppo_pointnav.yaml \
  --run-type train \
  habitat/simulator/agents@habitat.simulator.agents.main_agent=depth_agent
```

^The above does NOT work in the current state of the file, but by removing lines 12 and on, it does work.

## How Has This Been Tested

Running the above command to successfully train

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
