### PR TITLE
removing unused attribute, adding initialization of _fog_of_war_mask

### DIFF
--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -695,7 +695,6 @@ class TopDownMap(Measure):
     ):
         self._sim = sim
         self._config = config
-        self._grid_delta = config.map_padding
         self._step_count: Optional[int] = None
         self._map_resolution = config.map_resolution
         self._ind_x_min: Optional[int] = None
@@ -704,6 +703,7 @@ class TopDownMap(Measure):
         self._ind_y_max: Optional[int] = None
         self._previous_xy_location: Optional[Tuple[int, int]] = None
         self._top_down_map: Optional[np.ndarray] = None
+        self._fog_of_war_mask: Optional[np.ndarray] = None
         self._shortest_path_points: Optional[List[Tuple[int, int]]] = None
         self.line_thickness = int(
             np.round(self._map_resolution * 2 / MAP_THICKNESS_SCALAR)


### PR DESCRIPTION
## Motivation and Context

The attribute on line 698 (`self._grid_delta`) is not used at all anywhere in the repo, so it can be deleted.
On the other hand, `self._fog_of_war_mask` IS used a lot but is NOT in the `__init__`, which confuses IDEs like PyCharm when writing code for inheriting this class and trying to access/edit `self._fog_of_war_mask`.  Thus it is added here.

## How Has This Been Tested

Non-breaking changes

## Types of changes

- Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
