### PR TITLE
added fix for drawing topdown map

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -1132,7 +1132,9 @@ class PPOTrainer(BaseRLTrainer):
                         frame = observations_to_image(
                             {k: v[i] * 0.0 for k, v in batch.items()}, infos[i]
                         )
-                    frame = overlay_frame(frame, infos[i])
+                    frame = overlay_frame(
+                        frame, self._extract_scalars_from_info(infos[i])
+                    )
                     rgb_frames[i].append(frame)
 
                 # episode ended

--- a/habitat-lab/habitat/utils/visualizations/utils.py
+++ b/habitat-lab/habitat/utils/visualizations/utils.py
@@ -241,11 +241,15 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
     if "collisions" in info and info["collisions"]["is_collision"]:
         render_frame = draw_collision(render_frame)
 
-    if "top_down_map" in info:
+    if "top_down_map.map" in info:
+        map_info = {
+            k[len("top_down_map."):]: v
+            for k, v in info.items()
+            if k.startswith("top_down_map.")
+        }
         top_down_map = maps.colorize_draw_agent_and_fit_to_height(
-            info["top_down_map"], render_frame.shape[0]
+            map_info, render_frame.shape[0]
         )
-        render_frame = np.concatenate((render_frame, top_down_map), axis=1)
     return render_frame
 
 


### PR DESCRIPTION
## Motivation and Context

There is a bug that prevents video generation if non-scalar Measurements are used, such as the widely-used `top_down_map` for navigation tasks. In other words, navigation videos with maps can no longer be generated.

## How Has This Been Tested

Using this command:
```
python -u habitat_baselines/run.py \
    --exp-config habitat_baselines/config/pointnav/ddppo_pointnav.yaml \
    --run-type eval \
    habitat_baselines.eval.video_option=["disk"] \
    habitat/task/measurements="[distance_to_goal, success, spl, distance_to_goal_reward, top_down_map]" \
    habitat_baselines.load_resume_state_config=False
```

will successfully generate videos with the map using this PR.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
