### PR TITLE
Faster episode generation

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -308,6 +308,7 @@ class RearrangeEpisodeGenerator:
         self._ao_state_samplers: Dict[
             str, samplers.ArticulatedObjectStateSampler
         ] = {}
+        self.ao_states: Dict[str, Dict[int, float]] = {}
         for ao_info in self.cfg.ao_state_samplers:
             assert "name" in ao_info
             assert "type" in ao_info
@@ -778,9 +779,9 @@ class RearrangeEpisodeGenerator:
         else:
             if self.sim.config.sim_cfg.scene_id == scene_name:
                 rom = self.sim.get_rigid_object_manager()
-                for object in rom.get_object_handles():
-                    if object not in self.existing_rigid_objects:
-                        rom.remove_object_by_handle(object)
+                for obj in rom.get_object_handles():
+                    if obj not in self.existing_rigid_objects:
+                        rom.remove_object_by_handle(obj)
                 aom = self.sim.get_articulated_object_manager()
                 for ao_handle in self.ao_states.keys():
                     aom.get_object_by_handle(ao_handle).clear_joint_states()

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -470,7 +470,7 @@ class RearrangeEpisodeGenerator:
         rom = self.sim.get_rigid_object_manager()
         self.existing_rigid_objects = set(rom.get_object_handles())
 
-        scene_name = ep_scene_handle.split(".")[0]
+        scene_name = osp.basename(ep_scene_handle).split(".")[0]
         navmesh_path = osp.join(
             scene_base_dir, "navmeshes", scene_name + ".navmesh"
         )


### PR DESCRIPTION
## Motivation and Context

Greatly speed up episode generation script. Instead of reconfiguring (resetting) sim after each episode, just remove sampled objects and reset articulated object joints.

## How Has This Been Tested

Run `habitat-lab/habitat/datasets/rearrange/run_episode_generator.py` with the new floorplanner config (`habitat-lab/habitat/datasets/rearrange/configs/rearrange_floorplanner.yaml`) and ensure sampled objects are gone at the start of each episode generation.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->

- Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
