### PR TITLE
Fixing multiagent with topdownmap

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -980,9 +980,9 @@ class PPOTrainer(BaseRLTrainer):
         ] = {}  # dict of dicts that stores stats per episode
         ep_eval_count: Dict[Any, int] = defaultdict(lambda: 0)
 
-        rgb_frames = [
+        rgb_frames: List[List[np.ndarray]] = [
             [] for _ in range(self.config.habitat_baselines.num_environments)
-        ]  # type: List[List[np.ndarray]]
+        ]
         if len(self.config.habitat_baselines.eval.video_option) > 0:
             os.makedirs(self.config.habitat_baselines.video_dir, exist_ok=True)
 

--- a/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -22,7 +22,6 @@ from torch.optim.lr_scheduler import LambdaLR
 from habitat import VectorEnv, logger
 from habitat.config import read_write
 from habitat.config.default import get_agent_config
-from habitat.tasks.nav.nav import NON_SCALAR_METRICS
 from habitat.tasks.rearrange.rearrange_sensors import GfxReplayMeasure
 from habitat.tasks.rearrange.utils import write_gfx_replay
 from habitat.utils import profiling_wrapper
@@ -67,6 +66,11 @@ from habitat_baselines.utils.common import (
     get_num_actions,
     inference_mode,
     is_continuous_action_space,
+)
+from habitat_baselines.utils.info_dict import (
+    NON_SCALAR_METRICS,
+    extract_scalars_from_info,
+    extract_scalars_from_infos,
 )
 
 if TYPE_CHECKING:
@@ -413,45 +417,6 @@ class PPOTrainer(BaseRLTrainer):
         """
         return torch.load(checkpoint_path, *args, **kwargs)
 
-    @classmethod
-    def _extract_scalars_from_info(
-        cls, info: Dict[str, Any]
-    ) -> Dict[str, float]:
-        result = {}
-        for k, v in info.items():
-            if not isinstance(k, str) or k in NON_SCALAR_METRICS:
-                continue
-
-            if isinstance(v, dict):
-                result.update(
-                    {
-                        k + "." + subk: subv
-                        for subk, subv in cls._extract_scalars_from_info(
-                            v
-                        ).items()
-                        if isinstance(subk, str)
-                        and k + "." + subk not in NON_SCALAR_METRICS
-                    }
-                )
-            # Things that are scalar-like will have an np.size of 1.
-            # Strings also have an np.size of 1, so explicitly ban those
-            elif np.size(v) == 1 and not isinstance(v, str):
-                result[k] = float(v)
-
-        return result
-
-    @classmethod
-    def _extract_scalars_from_infos(
-        cls, infos: List[Dict[str, Any]]
-    ) -> Dict[str, List[float]]:
-
-        results = defaultdict(list)
-        for i in range(len(infos)):
-            for k, v in cls._extract_scalars_from_info(infos[i]).items():
-                results[k].append(v)
-
-        return results
-
     def _compute_actions_and_step_envs(self, buffer_index: int = 0):
         num_envs = self.envs.num_envs
         env_slice = slice(
@@ -552,7 +517,7 @@ class PPOTrainer(BaseRLTrainer):
         current_ep_reward = self.current_episode_reward[env_slice]
         self.running_episode_stats["reward"][env_slice] += current_ep_reward.where(done_masks, current_ep_reward.new_zeros(()))  # type: ignore
         self.running_episode_stats["count"][env_slice] += done_masks.float()  # type: ignore
-        for k, v_k in self._extract_scalars_from_infos(infos).items():
+        for k, v_k in extract_scalars_from_infos(infos).items():
             v = torch.tensor(
                 v_k,
                 dtype=torch.float,
@@ -1133,7 +1098,7 @@ class PPOTrainer(BaseRLTrainer):
                             {k: v[i] * 0.0 for k, v in batch.items()}, infos[i]
                         )
                     frame = overlay_frame(
-                        frame, self._extract_scalars_from_info(infos[i])
+                        frame, extract_scalars_from_info(infos[i])
                     )
                     rgb_frames[i].append(frame)
 
@@ -1143,9 +1108,7 @@ class PPOTrainer(BaseRLTrainer):
                     episode_stats = {
                         "reward": current_episode_reward[i].item()
                     }
-                    episode_stats.update(
-                        self._extract_scalars_from_info(infos[i])
-                    )
+                    episode_stats.update(extract_scalars_from_info(infos[i]))
                     current_episode_reward[i] = 0
                     k = (
                         current_episodes_info[i].scene_id,
@@ -1165,7 +1128,7 @@ class PPOTrainer(BaseRLTrainer):
                             images=rgb_frames[i],
                             episode_id=current_episodes_info[i].episode_id,
                             checkpoint_idx=checkpoint_index,
-                            metrics=self._extract_scalars_from_info(infos[i]),
+                            metrics=extract_scalars_from_info(infos[i]),
                             fps=self.config.habitat_baselines.video_fps,
                             tb_writer=writer,
                             keys_to_include_in_name=self.config.habitat_baselines.eval_keys_to_include_in_name,

--- a/habitat-baselines/habitat_baselines/utils/info_dict.py
+++ b/habitat-baselines/habitat_baselines/utils/info_dict.py
@@ -23,19 +23,11 @@ def extract_scalars_from_info(info: Dict[str, Any]) -> Dict[str, float]:
     for k, v in info.items():
         if not isinstance(k, str) or k in NON_SCALAR_METRICS:
             continue
-
-        if isinstance(v, dict):
-            result.update(
-                {
-                    k + "." + subk: subv
-                    for subk, subv in extract_scalars_from_info(v).items()
-                    if isinstance(subk, str)
-                    and k + "." + subk not in NON_SCALAR_METRICS
-                }
-            )
+        if k.split(".")[0] in NON_SCALAR_METRICS:
+            continue
         # Things that are scalar-like will have an np.size of 1.
         # Strings also have an np.size of 1, so explicitly ban those
-        elif np.size(v) == 1 and not isinstance(v, str):
+        if np.size(v) == 1 and not isinstance(v, str):
             result[k] = float(v)
 
     return result

--- a/habitat-baselines/habitat_baselines/utils/info_dict.py
+++ b/habitat-baselines/habitat_baselines/utils/info_dict.py
@@ -1,0 +1,62 @@
+from collections import defaultdict
+from typing import Any, Dict, List
+
+import numpy as np
+
+# These metrics are not scalars and cannot be easily reported
+# (unless using videos)
+NON_SCALAR_METRICS = {"top_down_map", "collisions.is_collision"}
+
+
+def extract_scalars_from_info(info: Dict[str, Any]) -> Dict[str, float]:
+    r"""From an environment info dictionary, returns a flattened
+    dictionary of string to floats by filtering all non-scalar
+    metrics.
+
+        Args:
+            info: A gym.Env  info dict
+
+        Returns:
+            dictionary of scalar values
+    """
+    result = {}
+    for k, v in info.items():
+        if not isinstance(k, str) or k in NON_SCALAR_METRICS:
+            continue
+
+        if isinstance(v, dict):
+            result.update(
+                {
+                    k + "." + subk: subv
+                    for subk, subv in extract_scalars_from_info(v).items()
+                    if isinstance(subk, str)
+                    and k + "." + subk not in NON_SCALAR_METRICS
+                }
+            )
+        # Things that are scalar-like will have an np.size of 1.
+        # Strings also have an np.size of 1, so explicitly ban those
+        elif np.size(v) == 1 and not isinstance(v, str):
+            result[k] = float(v)
+
+    return result
+
+
+def extract_scalars_from_infos(
+    infos: List[Dict[str, Any]]
+) -> Dict[str, List[float]]:
+    r"""From alist of gym.Env info dictionary, returns a
+    dictionary of string to list of floats. Also filters
+    all non-scalar metrics.
+
+        Args:
+            info: A list of gym.Env type info dict
+
+        Returns:
+            dict of list of scalar values
+    """
+    results = defaultdict(list)
+    for i in range(len(infos)):
+        for k, v in extract_scalars_from_info(infos[i]).items():
+            results[k].append(v)
+
+    return results

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -40,6 +40,7 @@ class EnvironmentConfig(HabitatBaseConfig):
 @dataclass
 class ActionConfig(HabitatBaseConfig):
     type: str = MISSING
+    agent_index: int = 0
 
 
 @dataclass

--- a/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
+++ b/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
@@ -15,7 +15,6 @@ defaults:
     - robot_colls
     - composite_success
     - num_steps
-    - top_down_map
   - /habitat/task/lab_sensors:
     - relative_resting_pos_sensor
     - target_start_sensor

--- a/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
+++ b/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
@@ -15,6 +15,7 @@ defaults:
     - robot_colls
     - composite_success
     - num_steps
+    - top_down_map
   - /habitat/task/lab_sensors:
     - relative_resting_pos_sensor
     - target_start_sensor
@@ -42,6 +43,11 @@ actions:
     grip_controller: MagicGraspAction
   agent_1_arm_action:
     grip_controller: MagicGraspAction
+    agent_index : 1
+  agent_1_base_velocity:
+    agent_index : 1
+  agent_1_rearrange_stop:
+    agent_index : 1
 measurements:
   force_terminate:
     max_accum_force: 100000.0

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -580,7 +580,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
             original pose and returns false.
         """
         agent = self.get_agent(agent_id)
-        new_state = self.get_agent_state(agent_id)
+        new_state = self.get_agent(agent_id).get_state()
         new_state.position = position
         new_state.rotation = rotation
 

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -61,10 +61,6 @@ cv2 = try_cv2_import()
 
 MAP_THICKNESS_SCALAR: int = 128
 
-# These metrics are not scalars and cannot be easily reported
-# (unless using videos)
-NON_SCALAR_METRICS = {"top_down_map", "collisions.is_collision"}
-
 
 @attr.s(auto_attribs=True, kw_only=True)
 class NavigationGoal:

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -886,8 +886,8 @@ class TopDownMap(Measure):
             "agent_angle": map_angles,
         }
 
-    @classmethod
-    def get_polar_angle(cls, agent_state):
+    @staticmethod
+    def get_polar_angle(agent_state):
         # quaternion is in x, y, z, w format
         ref_rotation = agent_state.rotation
         heading_vector = quaternion_rotate_vector(

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -699,7 +699,7 @@ class TopDownMap(Measure):
         self._ind_x_max: Optional[int] = None
         self._ind_y_min: Optional[int] = None
         self._ind_y_max: Optional[int] = None
-        self._previous_xy_location: Optional[Tuple[int, int]] = None
+        self._previous_xy_location: List[Optional[Tuple[int, int]]] = None
         self._top_down_map: Optional[np.ndarray] = None
         self._shortest_path_points: Optional[List[Tuple[int, int]]] = None
         self.line_thickness = int(
@@ -849,18 +849,12 @@ class TopDownMap(Measure):
         return ref_floor_height <= height < ref_floor_height + ceiling_height
 
     def reset_metric(self, episode, *args: Any, **kwargs: Any):
-        self._step_count = 0
         self._top_down_map = self.get_original_map()
+        self._step_count = 0
         agent_position = self._sim.get_agent_state().position
-        a_x, a_y = maps.to_grid(
-            agent_position[2],
-            agent_position[0],
-            (self._top_down_map.shape[0], self._top_down_map.shape[1]),
-            sim=self._sim,
-        )
-        self._previous_xy_location = (a_y, a_x)
-
-        self.update_fog_of_war_mask(np.array([a_x, a_y]))
+        self._previous_xy_location = [
+            None for _ in range(len(self._sim.habitat_config.agents))
+        ]
 
         if hasattr(episode, "goals"):
             # draw source and target parts last to avoid overlap
@@ -874,40 +868,36 @@ class TopDownMap(Measure):
                 episode.start_position, maps.MAP_SOURCE_POINT_INDICATOR
             )
 
-        self._metric = {
-            "map": self._top_down_map,
-            "fog_of_war_mask": self._fog_of_war_mask,
-            "agent_map_coord": (a_x, a_y),
-            "agent_angle": self.get_polar_angle(),
-        }
+        self.update_metric(episode, None)
+        self._step_count = 0
 
     def update_metric(self, episode, action, *args: Any, **kwargs: Any):
         self._step_count += 1
-        house_map, map_agent_x, map_agent_y = self.update_map(
-            self._sim.get_agent_state().position
-        )
-
+        map_positions: List[Tuple[float]] = []
+        map_angles = []
+        for agent_index in range(len(self._sim.habitat_config.agents)):
+            agent_state = self._sim.get_agent_state(agent_index)
+            map_positions.append(self.update_map(agent_state, agent_index))
+            map_angles.append(TopDownMap.get_polar_angle(agent_state))
         self._metric = {
-            "map": house_map,
+            "map": self._top_down_map,
             "fog_of_war_mask": self._fog_of_war_mask,
-            "agent_map_coord": (map_agent_x, map_agent_y),
-            "agent_angle": self.get_polar_angle(),
+            "agent_map_coord": map_positions,
+            "agent_angle": map_angles,
         }
 
-    def get_polar_angle(self):
-        agent_state = self._sim.get_agent_state()
+    @classmethod
+    def get_polar_angle(cls, agent_state):
         # quaternion is in x, y, z, w format
         ref_rotation = agent_state.rotation
-
         heading_vector = quaternion_rotate_vector(
             ref_rotation.inverse(), np.array([0, 0, -1])
         )
+        phi = cartesian_to_polar(heading_vector[2], -heading_vector[0])[1]
+        return np.array(phi)
 
-        phi = cartesian_to_polar(-heading_vector[2], heading_vector[0])[1]
-        z_neg_z_flip = np.pi
-        return np.array(phi) + z_neg_z_flip
-
-    def update_map(self, agent_position):
+    def update_map(self, agent_state: AgentState, agent_index: int):
+        agent_position = agent_state.position
         a_x, a_y = maps.to_grid(
             agent_position[2],
             agent_position[0],
@@ -921,26 +911,27 @@ class TopDownMap(Measure):
             )
 
             thickness = self.line_thickness
-            cv2.line(
-                self._top_down_map,
-                self._previous_xy_location,
-                (a_y, a_x),
-                color,
-                thickness=thickness,
-            )
+            if self._previous_xy_location[agent_index] is not None:
+                cv2.line(
+                    self._top_down_map,
+                    self._previous_xy_location[agent_index],
+                    (a_y, a_x),
+                    color,
+                    thickness=thickness,
+                )
+        angle = TopDownMap.get_polar_angle(agent_state)
+        self.update_fog_of_war_mask(np.array([a_x, a_y]), angle)
 
-        self.update_fog_of_war_mask(np.array([a_x, a_y]))
+        self._previous_xy_location[agent_index] = (a_y, a_x)
+        return a_x, a_y
 
-        self._previous_xy_location = (a_y, a_x)
-        return self._top_down_map, a_x, a_y
-
-    def update_fog_of_war_mask(self, agent_position):
+    def update_fog_of_war_mask(self, agent_position, angle):
         if self._config.fog_of_war.draw:
             self._fog_of_war_mask = fog_of_war.reveal_fog_of_war(
                 self._top_down_map,
                 self._fog_of_war_mask,
                 agent_position,
-                self.get_polar_angle(),
+                angle,
                 fov=self._config.fog_of_war.fov,
                 max_line_len=self._config.fog_of_war.visibility_dist
                 / maps.calculate_meters_per_pixel(

--- a/habitat-lab/habitat/tasks/rearrange/actions/robot_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/robot_action.py
@@ -19,10 +19,7 @@ class RobotAction(SimulatorTaskAction):
         """
         Underlying robot mananger for the robot instance the action is attached to.
         """
-
-        if "agent" not in self._config or self._config.agent is None:
-            return self._sim.robots_mgr[0]
-        return self._sim.robots_mgr[self._config.agent]
+        return self._sim.robots_mgr[self._config.agent_index]
 
     @property
     def _ik_helper(self):
@@ -52,7 +49,4 @@ class RobotAction(SimulatorTaskAction):
         Returns the action prefix to go in front of sensor / action names if
         there are multiple agents.
         """
-
-        if "agent" in self._config and self._config.agent is not None:
-            return f"agent_{self._config.agent}_"
-        return ""
+        return f"agent_{self._config.agent_index}_"

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -622,9 +622,15 @@ class RearrangeSim(HabitatSim):
     def get_agent_state(self, agent_id: int = 0) -> habitat_sim.AgentState:
         robot = self.get_robot_data(agent_id).robot
         rotation = mn.Quaternion.rotation(
-            mn.Rad(robot.base_rot) - mn.Rad(np.pi / 2), mn.Vector3(0, 1, 0)
+            mn.Rad(robot.base_rot) - mn.Rad(0 * np.pi / 2), mn.Vector3(0, 1, 0)
         )
-        return AgentState(robot.base_pos, quat_from_magnum(rotation))
+        rot_offset = mn.Quaternion.rotation(
+            mn.Rad(-np.pi / 2), mn.Vector3(0, 1, 0)
+        )
+        return AgentState(
+            robot.base_pos,
+            quat_from_magnum(robot.sim_obj.rotation * rot_offset),
+        )
 
     def set_agent_state(
         self,

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -632,15 +632,6 @@ class RearrangeSim(HabitatSim):
             quat_from_magnum(robot.sim_obj.rotation * rot_offset),
         )
 
-    def set_agent_state(
-        self,
-        position: List[float],
-        rotation: List[float],
-        agent_id: int = 0,
-        reset_sensors: bool = True,
-    ) -> bool:
-        raise NotImplementedError
-
     def step(self, action: Union[str, int]) -> Observations:
         rom = self.get_rigid_object_manager()
 

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -24,7 +24,7 @@ import numpy.typing as npt
 import habitat_sim
 from habitat.config import read_write
 from habitat.core.registry import registry
-from habitat.core.simulator import Observations
+from habitat.core.simulator import AgentState, Observations
 
 # flake8: noqa
 from habitat.robots import FetchRobot, FetchRobotNoWheels
@@ -43,6 +43,7 @@ from habitat.tasks.rearrange.utils import (
 from habitat_sim.nav import NavMeshSettings
 from habitat_sim.physics import CollisionGroups, JointMotorSettings, MotionType
 from habitat_sim.sim import SimulatorBackend
+from habitat_sim.utils.common import quat_from_magnum
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -617,6 +618,22 @@ class RearrangeSim(HabitatSim):
             else:
                 for grasp_mgr in self.robots_mgr.grasp_iter:
                     grasp_mgr.desnap(True)
+
+    def get_agent_state(self, agent_id: int = 0) -> habitat_sim.AgentState:
+        robot = self.get_robot_data(agent_id).robot
+        rotation = mn.Quaternion.rotation(
+            mn.Rad(robot.base_rot) - mn.Rad(np.pi / 2), mn.Vector3(0, 1, 0)
+        )
+        return AgentState(robot.base_pos, quat_from_magnum(rotation))
+
+    def set_agent_state(
+        self,
+        position: List[float],
+        rotation: List[float],
+        agent_id: int = 0,
+        reset_sensors: bool = True,
+    ) -> bool:
+        raise NotImplementedError
 
     def step(self, action: Union[str, int]) -> Observations:
         rom = self.get_rigid_object_manager()

--- a/habitat-lab/habitat/utils/gym_adapter.py
+++ b/habitat-lab/habitat/utils/gym_adapter.py
@@ -303,18 +303,15 @@ class HabGymWrapper(gym.Env):
 
     def render(self, mode: str = "human") -> np.ndarray:
         frame = None
+        last_infos = flatten_dict(self._env._env.get_metrics())
         if mode == "rgb_array":
-            frame = observations_to_image(
-                self._last_obs, self._env._env.get_metrics()
-            )
+            frame = observations_to_image(self._last_obs, last_infos)
         elif mode == "human":
             if pygame is None:
                 raise ValueError(
                     "Render mode human not supported without pygame."
                 )
-            frame = observations_to_image(
-                self._last_obs, self._env._env.get_metrics()
-            )
+            frame = observations_to_image(self._last_obs, last_infos)
             if self._screen is None:
                 pygame.init()
                 self._screen = pygame.display.set_mode(

--- a/habitat-lab/habitat/utils/visualizations/maps.py
+++ b/habitat-lab/habitat/utils/visualizations/maps.py
@@ -414,13 +414,15 @@ def colorize_draw_agent_and_fit_to_height(
     top_down_map = colorize_topdown_map(
         top_down_map, topdown_map_info["fog_of_war_mask"]
     )
-    map_agent_pos = topdown_map_info["agent_map_coord"]
-    top_down_map = draw_agent(
-        image=top_down_map,
-        agent_center_coord=map_agent_pos,
-        agent_rotation=topdown_map_info["agent_angle"],
-        agent_radius_px=min(top_down_map.shape[0:2]) // 32,
-    )
+    for agent_idx in range(len(topdown_map_info["agent_map_coord"])):
+        map_agent_pos = topdown_map_info["agent_map_coord"][agent_idx]
+        map_agent_angle = topdown_map_info["agent_angle"][agent_idx]
+        top_down_map = draw_agent(
+            image=top_down_map,
+            agent_center_coord=map_agent_pos,
+            agent_rotation=map_agent_angle,
+            agent_radius_px=min(top_down_map.shape[0:2]) // 32,
+        )
 
     if top_down_map.shape[0] > top_down_map.shape[1]:
         top_down_map = np.rot90(top_down_map, 1)

--- a/test/test_visual_utils.py
+++ b/test/test_visual_utils.py
@@ -22,8 +22,8 @@ def test_observations_to_image():
         "top_down_map.fog_of_war_mask": np.random.randint(
             low=0, high=1, size=(300, 300)
         ),
-        "top_down_map.agent_map_coord": (10, 10),
-        "top_down_map.agent_angle": np.random.random(),
+        "top_down_map.agent_map_coord": [(10, 10)],
+        "top_down_map.agent_angle": [np.random.random()],
     }
     image = observations_to_image(observations, info)
     assert image.shape == (
@@ -48,8 +48,8 @@ def test_different_dim_observations_to_image():
         "top_down_map.fog_of_war_mask": np.random.randint(
             low=0, high=1, size=(300, 300)
         ),
-        "top_down_map.agent_map_coord": (10, 10),
-        "top_down_map.agent_angle": np.random.random(),
+        "top_down_map.agent_map_coord": [(10, 10)],
+        "top_down_map.agent_angle": [np.random.random()],
     }
     image = observations_to_image(observations, info)
     assert image.shape == (


### PR DESCRIPTION
## Motivation and Context

On top of making TopDownMap work for rearrangement tasks, I also added an agent_index to the actions allowing to control the agents from the gym interface. Running this code : 

```
import habitat
import numpy as np

cli_arg = ['+habitat/task/measurements=top_down_map']
config = habitat.get_config('benchmark/rearrange/rearrange_easy_multi_agent.yaml', cli_arg)
from habitat.utils.gym_definitions import make_gym_from_config
env = make_gym_from_config(config)

env.reset();env.render()

while True:
   _,_,_,_ = env.step(np.array(([0.0] * 8 + [0.2, 1.0] + [0.0]) + ([0.0] * 8 + [0.2, -1.0] + [0.0]) , dtype=np.float32))
   _=env.render()

```

Gives the following pygame output : 

![multi-agent-top-down](https://user-images.githubusercontent.com/28320361/211686053-0bd61aa6-38e0-42af-963b-1fc3df66b3c3.gif)

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
