### PR TITLE
Train hl modif2

### DIFF
--- a/habitat-baselines/habitat_baselines/config/habitat_baselines/rl/policy/hierarchical_tp_noop_onav.yaml
+++ b/habitat-baselines/habitat_baselines/config/habitat_baselines/rl/policy/hierarchical_tp_noop_onav.yaml
@@ -36,12 +36,14 @@ hierarchical_policy:
       obs_skill_inputs: ["obj_start_sensor"]
       max_skill_steps: 1
       apply_postconds: True
+      force_end_on_timeout: False
 
     place:
       skill_name: "NoopSkillPolicy"
       obs_skill_inputs: ["obj_goal_sensor"]
       max_skill_steps: 1
       apply_postconds: True
+      force_end_on_timeout: False
 
     nav_to_obj:
       skill_name: "OracleNavPolicy"

--- a/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
@@ -318,7 +318,7 @@ class HierarchicalPolicy(nn.Module, Policy):
             )
 
             # LL skills are not allowed to terminate the overall episode.
-            actions[batch_ids] = action_data.actions
+            actions[batch_ids] += action_data.actions
             # Add actions from apply_postcond
             rnn_hidden_states[batch_ids] = action_data.rnn_hidden_states
         actions[:, self._stop_action_idx] = 0.0

--- a/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
@@ -212,7 +212,7 @@ class HierarchicalPolicy(nn.Module, Policy):
             masks,
             self._cur_skills,
             log_info,
-        )
+        ).cpu()
         # Compute the actions from the current skills
         actions = torch.zeros(
             (self._num_envs, get_num_actions(self._action_space)),

--- a/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
@@ -239,9 +239,12 @@ class HierarchicalPolicy(nn.Module, Policy):
                 # Policy has not prediced a skill yet.
                 should_terminate[batch_ids] = 1.0
                 continue
+            # TODO: either change name of the function or assign actions somewhere
+            # else. Updating actions in should_terminate is counterintuitive 
             (
                 should_terminate[batch_ids],
                 bad_should_terminate[batch_ids],
+                actions[batch_ids]
             ) = self._skills[skill_id].should_terminate(
                 **dat,
                 batch_idx=batch_ids,
@@ -316,6 +319,7 @@ class HierarchicalPolicy(nn.Module, Policy):
 
             # LL skills are not allowed to terminate the overall episode.
             actions[batch_ids] = action_data.actions
+            # Add actions from apply_postcond
             rnn_hidden_states[batch_ids] = action_data.rnn_hidden_states
         actions[:, self._stop_action_idx] = 0.0
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/oracle_nav.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/oracle_nav.py
@@ -116,7 +116,7 @@ class OracleNavPolicy(NnSkillPolicy):
         masks,
         batch_idx,
     ) -> torch.BoolTensor:
-        ret = torch.zeros(masks.shape[0], dtype=torch.bool).to(masks.device)
+        ret = torch.zeros(masks.shape[0], dtype=torch.bool)
 
         cur_pos = observations[LocalizationSensor.cls_uuid].cpu()
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/skill.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/skill.py
@@ -38,7 +38,7 @@ class SkillPolicy(Policy):
             None for _ in range(self._batch_size)
         ]
 
-        if "pddl_apply_action" in action_space:
+        if "pddl_apply_action" in list(action_space.keys()):
             self._pddl_ac_start, _ = find_action_range(
                 action_space, "pddl_apply_action"
             )


### PR DESCRIPTION
## Motivation and Context

This pull request solves a bug that didn't allow to perform actions when `apply_postconds` was set to True

## How Has This Been Tested

Generated a robot trajectory using:

```
python -u habitat-baselines/habitat_baselines/run.py   --exp-config habitat-baselines/habitat_baselines/config/rearrange/rl_hl_srl_onav.yaml   --run-type eval   habitat_baselines/rl/policy=hierarchical_tp_noop_onav
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
