### PR TITLE
Fixed Speed Regression in Rearrangement Tasks

### DIFF
--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -93,16 +93,13 @@ def get_input_vel_ctlr(
 
     arm_action_name = "arm_action"
     base_action_name = "base_velocity"
-    arm_key = "arm_action"
-    grip_key = "grip_action"
-    base_key = "base_vel"
+    agent_k = f"agent_{agent_to_control}"
     if multi_agent:
-        agent_k = f"agent_{agent_to_control}"
         arm_action_name = f"{agent_k}_{arm_action_name}"
         base_action_name = f"{agent_k}_{base_action_name}"
-        arm_key = f"{agent_k}_{arm_key}"
-        grip_key = f"{agent_k}_{grip_key}"
-        base_key = f"{agent_k}_{base_key}"
+    arm_key = f"{agent_k}_arm_action"
+    grip_key = f"{agent_k}_grip_action"
+    base_key = f"{agent_k}_base_vel"
 
     if arm_action_name in env.action_space.spaces:
         arm_action_space = env.action_space.spaces[arm_action_name].spaces[

--- a/habitat-lab/habitat/core/embodied_task.py
+++ b/habitat-lab/habitat/core/embodied_task.py
@@ -371,7 +371,7 @@ class EmbodiedTask:
         :param sim_config: config for simulator.
         :param episode: current episode.
         """
-        raise NotImplementedError
+        return sim_config
 
     def _check_episode_is_active(
         self,

--- a/habitat-lab/habitat/core/env.py
+++ b/habitat-lab/habitat/core/env.py
@@ -335,14 +335,11 @@ class Env:
         self._task.seed(seed)
 
     def reconfigure(self, config: "DictConfig") -> None:
-        self._config = config
+        self._config = self._task.overwrite_sim_config(
+            config, self.current_episode
+        )
 
-        with read_write(self._config):
-            self._config.simulator = self._task.overwrite_sim_config(
-                self._config.simulator, self.current_episode
-            )
-
-        self._sim.reconfigure(self._config.simulator)
+        self._sim.reconfigure(self._config.simulator, self.current_episode)
 
     def render(self, mode="rgb") -> np.ndarray:
         return self._sim.render(mode)

--- a/habitat-lab/habitat/core/simulator.py
+++ b/habitat-lab/habitat/core/simulator.py
@@ -277,7 +277,7 @@ class Simulator:
     def seed(self, seed: int) -> None:
         raise NotImplementedError
 
-    def reconfigure(self, config: "DictConfig") -> None:
+    def reconfigure(self, config: "DictConfig", episode: Episode) -> None:
         raise NotImplementedError
 
     def geodesic_distance(

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import attr
 import numpy as np
@@ -36,7 +36,7 @@ class RearrangeEpisode(Episode):
     ao_states: Dict[str, Dict[int, float]]
     rigid_objs: List[Tuple[str, np.ndarray]]
     targets: Dict[str, np.ndarray]
-    markers: Dict[str, Tuple[str, Tuple]] = {}
+    markers: List[Dict[str, Any]] = []
     target_receptacles: List[Tuple[str, int]] = []
     goal_receptacles: List[Tuple[str, int]] = []
     name_to_receptacle: Dict[str, str] = {}

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -436,6 +436,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
     def reconfigure(
         self,
         habitat_config: DictConfig,
+        ep_info: Episode,
         should_close_on_new_scene: bool = True,
     ) -> None:
         # TODO(maksymets): Switch to Habitat-Sim more efficient caching
@@ -446,7 +447,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
             self._current_scene = habitat_config.scene
             if should_close_on_new_scene:
                 self.close(destroy=False)
-            super().reconfigure(self.sim_config)
+            super().reconfigure(self.sim_config, ep_info)
 
         self._update_agents_state()
 

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -25,6 +25,7 @@ import habitat_sim
 from habitat.config import read_write
 from habitat.core.registry import registry
 from habitat.core.simulator import AgentState, Observations
+from habitat.datasets.rearrange.rearrange_dataset import RearrangeEpisode
 
 # flake8: noqa
 from habitat.robots import FetchRobot, FetchRobotNoWheels
@@ -76,9 +77,9 @@ class RearrangeSim(HabitatSim):
         super().__init__(config)
 
         self.first_setup = True
-        self.ep_info: Optional["DictConfig"] = None
+        self.ep_info: Optional[RearrangeEpisode] = None
         self.prev_loaded_navmesh = None
-        self.prev_scene_id = None
+        self.prev_scene_id: Optional[str] = None
 
         # Number of physics updates per action
         self.ac_freq_ratio = self.habitat_config.ac_freq_ratio
@@ -153,10 +154,10 @@ class RearrangeSim(HabitatSim):
         for _, ao in aom.get_objects_by_handle_substring().items():
             ao.awake = False
 
-    def add_markers(self, ep_info: "DictConfig"):
+    def add_markers(self, ep_info: RearrangeEpisode):
         self._markers = {}
         aom = self.get_articulated_object_manager()
-        for marker in ep_info["markers"]:
+        for marker in ep_info.markers:
             p = marker["params"]
             ao = aom.get_object_by_handle(p["object"])
             name_to_link = {}
@@ -190,22 +191,20 @@ class RearrangeSim(HabitatSim):
             self.reset_agent(i)
         return None
 
-    def reconfigure(self, config: "DictConfig"):
-        self.step_idx = 0
-        ep_info = config["ep_info"][0]
-        self.instance_handle_to_ref_handle = ep_info["info"]["object_labels"]
+    def reconfigure(self, config: "DictConfig", ep_info: RearrangeEpisode):
+        self.instance_handle_to_ref_handle = ep_info.info["object_labels"]
 
         with read_write(config):
-            config["scene"] = ep_info["scene_id"]
+            config["scene"] = ep_info.scene_id
 
-        super().reconfigure(config, should_close_on_new_scene=False)
+        super().reconfigure(config, ep_info, should_close_on_new_scene=False)
 
         self.ref_handle_to_rigid_obj_id = {}
 
         self.ep_info = ep_info
         self._try_acquire_context()
 
-        new_scene = self.prev_scene_id != ep_info["scene_id"]
+        new_scene = self.prev_scene_id != ep_info.scene_id
 
         if new_scene:
             self._prev_obj_names = None
@@ -213,13 +212,13 @@ class RearrangeSim(HabitatSim):
         self.robots_mgr.reconfigure(new_scene)
 
         # Only remove and re-add objects if we have a new set of objects.
-        obj_names = [x[0] for x in ep_info["rigid_objs"]]
+        obj_names = [x[0] for x in ep_info.rigid_objs]
         should_add_objects = self._prev_obj_names != obj_names
         self._prev_obj_names = obj_names
 
         self._clear_objects(should_add_objects)
 
-        self.prev_scene_id = ep_info["scene_id"]
+        self.prev_scene_id = ep_info.scene_id
         self._viz_templates = {}
         self._viz_handle_to_template = {}
 
@@ -235,7 +234,7 @@ class RearrangeSim(HabitatSim):
 
         # add episode clutter objects additional to base scene objects
         self._add_objs(ep_info, should_add_objects)
-        self._setup_targets()
+        self._setup_targets(ep_info)
 
         self.add_markers(ep_info)
 
@@ -244,7 +243,7 @@ class RearrangeSim(HabitatSim):
             self.sleep_all_objects()
 
         if new_scene:
-            self._load_navmesh()
+            self._load_navmesh(ep_info)
 
         # Get the starting positions of the target objects.
         rom = self.get_rigid_object_manager()
@@ -310,20 +309,20 @@ class RearrangeSim(HabitatSim):
                 break
         if attempt_i == max_attempts - 1:
             rearrange_logger.warning(
-                f"Could not find a collision free start for {self.ep_info['episode_id']}"
+                f"Could not find a collision free start for {self.ep_info.episode_id}"
             )
         return start_pos, start_rot
 
-    def _setup_targets(self):
+    def _setup_targets(self, ep_info):
         self._targets = {}
-        for target_handle, transform in self.ep_info["targets"].items():
+        for target_handle, transform in ep_info.targets.items():
             self._targets[target_handle] = mn.Matrix4(
                 [[transform[j][i] for j in range(4)] for i in range(4)]
             )
 
-    def _load_navmesh(self):
-        scene_name = self.ep_info["scene_id"].split("/")[-1].split(".")[0]
-        base_dir = osp.join(*self.ep_info["scene_id"].split("/")[:2])
+    def _load_navmesh(self, ep_info):
+        scene_name = ep_info.scene_id.split("/")[-1].split(".")[0]
+        base_dir = osp.join(*ep_info.scene_id.split("/")[:2])
 
         navmesh_path = osp.join(base_dir, "navmeshes", scene_name + ".navmesh")
         self.pathfinder.load_nav_mesh(navmesh_path)
@@ -362,13 +361,12 @@ class RearrangeSim(HabitatSim):
         # managed by the underlying sim.
         self.art_objs = []
 
-    def _set_ao_states_from_ep(self, ep_info: "DictConfig") -> None:
+    def _set_ao_states_from_ep(self, ep_info: RearrangeEpisode) -> None:
         """
         Sets the ArticulatedObject states for the episode which are differ from base scene state.
         """
         aom = self.get_articulated_object_manager()
-        # NOTE: ep_info["ao_states"]: Dict[str, Dict[int, float]] : {instance_handle -> {link_ix, state}}
-        for aoi_handle, joint_states in ep_info["ao_states"].items():
+        for aoi_handle, joint_states in ep_info.ao_states.items():
             ao = aom.get_object_by_handle(aoi_handle)
             ao_pose = ao.joint_positions
             for link_ix, joint_state in joint_states.items():
@@ -414,14 +412,13 @@ class RearrangeSim(HabitatSim):
         return new_pos
 
     def _add_objs(
-        self, ep_info: "DictConfig", should_add_objects: bool
+        self, ep_info: RearrangeEpisode, should_add_objects: bool
     ) -> None:
         # Load clutter objects:
-        # NOTE: ep_info["rigid_objs"]: List[Tuple[str, np.array]]  # list of objects, each with (handle, transform)
         rom = self.get_rigid_object_manager()
         obj_counts: Dict[str, int] = defaultdict(int)
 
-        for i, (obj_handle, transform) in enumerate(ep_info["rigid_objs"]):
+        for i, (obj_handle, transform) in enumerate(ep_info.rigid_objs):
             if should_add_objects:
                 obj_attr_mgr = self.get_object_template_manager()
                 matching_templates = (
@@ -474,7 +471,7 @@ class RearrangeSim(HabitatSim):
                 ao.motion_type = habitat_sim.physics.MotionType.KINEMATIC
             self.art_objs.append(ao)
 
-    def _create_obj_viz(self, ep_info: "DictConfig"):
+    def _create_obj_viz(self):
         """
         Adds a visualization of the goal for each of the target objects in the
         scene. This is the same as the target object, but is a render only
@@ -682,7 +679,6 @@ class RearrangeSim(HabitatSim):
 
         if self.habitat_config.habitat_sim_v0.enable_gfx_replay_save:
             self.gfx_replay_manager.save_keyframe()
-        self.step_idx += 1
 
         if self.habitat_config.needs_markers:
             self._update_markers()
@@ -698,7 +694,7 @@ class RearrangeSim(HabitatSim):
                 )
 
             # Also render debug information
-            self._create_obj_viz(self.ep_info)
+            self._create_obj_viz()
 
             debug_obs = self.get_sensor_observations()
             obs["robot_third_rgb"] = debug_obs["robot_third_rgb"][:, :, :3]
@@ -777,7 +773,7 @@ class RearrangeSim(HabitatSim):
 
     def get_n_targets(self) -> int:
         """Get the number of rearrange targets."""
-        return len(self.ep_info["targets"])
+        return len(self.ep_info.targets)
 
     def get_target_objs_start(self) -> np.ndarray:
         """Get the initial positions of all objects targeted for rearrangement as a numpy array."""

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -36,10 +36,6 @@ class RearrangeTask(NavigationTask):
     _cur_episode_step: int
     _robot_pos_start: Dict[str, Tuple[np.ndarray, float]]
 
-    def overwrite_sim_config(self, sim_config, episode):
-        sim_config.ep_info = [episode.__dict__]
-        return sim_config
-
     def _duplicate_sensor_suite(self, sensor_suite: SensorSuite) -> None:
         """
         Modifies the sensor suite in place to duplicate robot specific sensors

--- a/habitat-lab/habitat/tasks/rearrange/sub_tasks/nav_to_obj_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/sub_tasks/nav_to_obj_task.py
@@ -110,15 +110,14 @@ class DynNavRLEnv(RearrangeTask):
         )
 
     def reset(self, episode: Episode):
-        sim = self._sim
         super().reset(episode, fetch_observations=False)
 
         self._nav_to_info = self._generate_nav_start_goal(
             episode, force_idx=self.force_obj_to_idx
         )
 
-        sim.robot.base_pos = self._nav_to_info.robot_start_pos
-        sim.robot.base_rot = self._nav_to_info.robot_start_angle
+        self._sim.robot.base_pos = self._nav_to_info.robot_start_pos
+        self._sim.robot.base_rot = self._nav_to_info.robot_start_angle
 
         if self._nav_to_info.start_hold_obj_idx is not None:
             if self._sim.grasp_mgr.is_grasped:
@@ -134,9 +133,9 @@ class DynNavRLEnv(RearrangeTask):
 
         if self._sim.habitat_config.debug_render:
             # Visualize the position the agent is navigating to.
-            sim.viz_ids["nav_targ_pos"] = sim.visualize_position(
+            self._sim.viz_ids["nav_targ_pos"] = self._sim.visualize_position(
                 self._nav_to_info.nav_goal_pos,
-                sim.viz_ids["nav_targ_pos"],
+                self._sim.viz_ids["nav_targ_pos"],
                 r=0.2,
             )
         self._sim.maybe_update_robot()


### PR DESCRIPTION
## Motivation and Context
On the Rearrangement tasks, speed was up to 10x slower than expected. The core issue was unnecessary copying of episode files and writing to Hydra configs. Speedscope profile below shows the performance impact these config modifications had on a single environment.


## How Has This Been Tested

Manually comparing training speeds.
