### PR TITLE
[WIP] Lab interactive viewer extending sim viewer

### DIFF
--- a/scripts/viewer/viewer.py
+++ b/scripts/viewer/viewer.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import ctypes
+import os
+import sys
+from typing import Any, Dict
+
+import git
+
+flags = sys.getdlopenflags()
+sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
+
+from habitat_sim.utils.settings import default_sim_settings
+from habitat_sim.viewer import viewer as sim_viewer
+
+repo = git.Repo(".", search_parent_directories=True)
+dir_path = repo.working_tree_dir
+# %cd $dir_path
+data_path = os.path.join(dir_path, "data")
+
+
+class HabitatLabInteractiveViewer(sim_viewer.HabitatSimInteractiveViewer):
+    def __init__(self, sim_settings: Dict[str, Any]) -> None:
+        sim_viewer.HabitatSimInteractiveViewer.__init__(self, sim_settings)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+
+    # optional arguments
+    parser.add_argument(
+        "--scene",
+        default="./data/test_assets/scenes/simple_room.glb",
+        type=str,
+        help='scene/stage file to load (default: "./data/test_assets/scenes/simple_room.glb")',
+    )
+    parser.add_argument(
+        "--dataset",
+        default="./data/objects/ycb/ycb.scene_dataset_config.json",
+        type=str,
+        metavar="DATASET",
+        help='dataset configuration file to use (default: "./data/objects/ycb/ycb.scene_dataset_config.json")',
+    )
+    parser.add_argument(
+        "--disable-physics",
+        action="store_true",
+        help="disable physics simulation (default: False)",
+    )
+    parser.add_argument(
+        "--stage-requires-lighting",
+        action="store_true",
+        help="Override configured lighting to use synthetic lighting for the stage.",
+    )
+    parser.add_argument(
+        "--enable-batch-renderer",
+        action="store_true",
+        help="Enable batch rendering mode. The number of concurrent environments is specified with the num-environments parameter.",
+    )
+    parser.add_argument(
+        "--num-environments",
+        default=1,
+        type=int,
+        help="Number of concurrent environments to batch render. Note that only the first environment simulates physics and can be controlled.",
+    )
+    parser.add_argument(
+        "--composite-files",
+        type=str,
+        nargs="*",
+        help="Composite files that the batch renderer will use in-place of simulation assets to improve memory usage and performance. If none is specified, the original scene files will be loaded from disk.",
+    )
+    parser.add_argument(
+        "--width",
+        default=800,
+        type=int,
+        help="Horizontal resolution of the window.",
+    )
+    parser.add_argument(
+        "--height",
+        default=600,
+        type=int,
+        help="Vertical resolution of the window.",
+    )
+
+    args = parser.parse_args()
+
+    if args.num_environments < 1:
+        parser.error("num-environments must be a positive non-zero integer.")
+    if args.width < 1:
+        parser.error("width must be a positive non-zero integer.")
+    if args.height < 1:
+        parser.error("height must be a positive non-zero integer.")
+
+    # Setting up sim_settings
+    sim_settings: Dict[str, Any] = default_sim_settings.copy()
+    sim_settings["scene"] = args.scene
+    sim_settings["scene_dataset_config_file"] = args.dataset
+    sim_settings["enable_physics"] = not args.disable_physics
+    sim_settings["stage_requires_lighting"] = args.stage_requires_lighting
+    sim_settings["enable_batch_renderer"] = args.enable_batch_renderer
+    sim_settings["num_environments"] = args.num_environments
+    sim_settings["composite_files"] = args.composite_files
+    sim_settings["window_width"] = args.width
+    sim_settings["window_height"] = args.height
+    # setup the font path relative to the current file
+    sim_settings["font_path"] = os.path.join(
+        data_path, "fonts/ProggyClean.ttf"
+    )
+
+    # start the application
+    HabitatLabInteractiveViewer(sim_settings).exec()


### PR DESCRIPTION
## Motivation and Context

This PR script demonstrates extending the Habitat-sim interactive viewer.py application in Habitat-lab. This is a PoC for testing, not intended for merge.

This approach should replace `interactive_play.py` in future iterations.

**Intended to be tested against** [Habitat-sim PR 1990](https://github.com/facebookresearch/habitat-sim/pull/1990).

## How Has This Been Tested

Example use:
```
python scripts/viewer/viewer.py --dataset data/scene_datasets/mp3d_example/mp3d.scene_dataset_config.json --scene 17DRP5sb8fy
```

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
