### PR TITLE
[CI Fix] Bump isort version.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     # TODO: Add blanket type ignore check as well
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
     -   id: isort
         exclude: docs/|examples/tutorials/(colabs|nb_python)/(.*\.py|.*\.ipynb)$


### PR DESCRIPTION
## Motivation and Context

This bumps `isort` to `5.11.5` to fix an ongoing CI issue. See: https://github.com/PyCQA/isort/releases/tag/5.11.5
Note that version `5.12` dropped python 3.7 support.

## How Has This Been Tested

Tested on CI.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
