### PR TITLE
Name-based rearrange: Using FP v0.2.0 receptacle categories

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/modify_episodes_for_object_rearrange.py
+++ b/habitat-lab/habitat/datasets/rearrange/modify_episodes_for_object_rearrange.py
@@ -20,6 +20,7 @@ def get_rec_category(rec_id, rec_category_mapping=None):
     """
     Retrieves the receptacle category from id
     """
+    rec_id = rec_id.rstrip("_")
     if rec_category_mapping is None:
         # for replicaCAD objects
         rec_id = rec_id.rstrip("_").replace("frl_apartment_", "")
@@ -103,8 +104,15 @@ def get_obj_rec_cat_in_eps(
 
 def read_obj_category_mapping(filename):
     df = pd.read_csv(filename)
-    df["category"] = df["clean_category"].apply(lambda x: x.replace(" ", "_"))
-    return dict(zip(df["name"], df["category"]))
+    name_key = "id" if "id" in df else "name"
+    category_key = "wnsynsetkey" if "wnsynsetkey" in df else "clean_category"
+
+    df["category"] = (
+        df[category_key]
+        .fillna("")
+        .apply(lambda x: x.replace(" ", "_").split(".")[0])
+    )
+    return dict(zip(df[name_key], df["category"]))
 
 
 def get_cats_list(
@@ -159,7 +167,8 @@ def collect_receptacle_goals(sim, rec_category_mapping=None):
                 "object_name": receptacle.name,
                 "object_id": str(object_id),
                 "object_category": get_rec_category(
-                    receptacle.name, rec_category_mapping=rec_category_mapping
+                    receptacle.parent_object_handle.split(":")[0],
+                    rec_category_mapping=rec_category_mapping,
                 ),
                 "view_points": [],
             }
@@ -218,6 +227,7 @@ def get_candidate_starts(
     obj_rearrange_easy=True,
     obj_category_mapping=None,
     rec_category_mapping=None,
+    rec_to_parent_obj=None,
 ):
     obj_goals = []
     for i, (obj, pos) in enumerate(objects):
@@ -238,7 +248,9 @@ def get_candidate_starts(
                 obj_goals.append(obj_goal)
             else:
                 recep_cat = get_rec_category(
-                    name_to_receptacle[obj_idx_to_name[i]],
+                    rec_to_parent_obj[
+                        name_to_receptacle[obj_idx_to_name[i]]
+                    ].split(":")[0],
                     rec_category_mapping=rec_category_mapping,
                 )
                 if recep_cat == start_rec_cat:
@@ -313,6 +325,8 @@ def add_cat_fields_to_episodes(
             episode["scene_dataset_config"],
             episode["additional_obj_config_paths"],
         )
+        rec = find_receptacles(sim)
+        rec_to_parent_obj = {r.name: r.parent_object_handle for r in rec}
         obj_idx_to_name = load_objects(sim, episode["rigid_objs"])
         all_rec_goals = collect_receptacle_goals(
             sim, rec_category_mapping=rec_category_mapping
@@ -334,6 +348,7 @@ def add_cat_fields_to_episodes(
             obj_rearrange_easy=obj_rearrange_easy,
             obj_category_mapping=obj_category_mapping,
             rec_category_mapping=rec_category_mapping,
+            rec_to_parent_obj=rec_to_parent_obj,
         )
         episode["candidate_start_receps"] = get_candidate_receptacles(
             all_rec_goals, start_rec_cat
@@ -417,6 +432,7 @@ if __name__ == "__main__":
             obj_category_mapping=obj_category_mapping,
             rec_category_mapping=rec_category_mapping,
         )
+
         episodes_json = DatasetFloatJSONEncoder().encode(episodes)
         os.makedirs(osp.join(target_data_dir, split), exist_ok=True)
         target_episodes_file = osp.join(

--- a/habitat-lab/habitat/datasets/rearrange/modify_episodes_for_object_rearrange.py
+++ b/habitat-lab/habitat/datasets/rearrange/modify_episodes_for_object_rearrange.py
@@ -161,13 +161,18 @@ def collect_receptacle_goals(sim, rec_category_mapping=None):
         else:
             object_id = -1
         pos = receptacle.get_surface_center(sim)
+        rec_name = receptacle.parent_object_handle
+        # if the handle name is None, try extracting category from receptacle name
+        rec_name = (
+            receptacle.name if rec_name is None else rec_name.split(":")[0]
+        )
         recep_goals.append(
             {
                 "position": [pos.x, pos.y, pos.z],
                 "object_name": receptacle.name,
                 "object_id": str(object_id),
                 "object_category": get_rec_category(
-                    receptacle.parent_object_handle.split(":")[0],
+                    rec_name,
                     rec_category_mapping=rec_category_mapping,
                 ),
                 "view_points": [],
@@ -247,10 +252,15 @@ def get_candidate_starts(
             if not obj_rearrange_easy:
                 obj_goals.append(obj_goal)
             else:
+                # use parent object name if it exists
+                rec_name = rec_to_parent_obj[
+                    name_to_receptacle[obj_idx_to_name[i]]
+                ]
+                # otherwise use receptacle name
+                if rec_name is None:
+                    rec_name = name_to_receptacle[obj_idx_to_name[i]]
                 recep_cat = get_rec_category(
-                    rec_to_parent_obj[
-                        name_to_receptacle[obj_idx_to_name[i]]
-                    ].split(":")[0],
+                    rec_name.split(":")[0],
                     rec_category_mapping=rec_category_mapping,
                 )
                 if recep_cat == start_rec_cat:


### PR DESCRIPTION
## Motivation and Context

Using `wnsynsetkey` field for granular receptacle categories.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
