### PR TITLE
Speed Upgrade to Rearrangement Tasks

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1071,6 +1071,7 @@ class SimulatorConfig(HabitatBaseConfig):
     create_renderer: bool = False
     requires_textures: bool = True
     auto_sleep: bool = False
+    sleep_dist: float = 3.0
     step_physics: bool = True
     concur_render: bool = False
     # If markers should be updated at every step:

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -143,6 +143,22 @@ class RearrangeSim(HabitatSim):
         if self.habitat_config.concur_render:
             self.renderer.acquire_gl_context()
 
+    def _auto_sleep(self):
+        all_robo_pos = [
+            robot.base_pos for robot in self.robots_mgr.robots_iter
+        ]
+        rom = self.get_rigid_object_manager()
+        for handle, ro in rom.get_objects_by_handle_substring().items():
+            is_far = any(
+                (robo_pos - ro.translation).length()
+                > self.habitat_config.sleep_dist
+                for robo_pos in all_robo_pos
+            )
+            if is_far:
+                ro.motion_type = habitat_sim.physics.MotionType.STATIC
+            else:
+                ro.motion_type = self._obj_orig_motion_types[handle]
+
     def sleep_all_objects(self):
         """
         De-activate (sleep) all rigid objects in the scene, assuming they are already in a dynamically stable state.
@@ -150,6 +166,7 @@ class RearrangeSim(HabitatSim):
         rom = self.get_rigid_object_manager()
         for _, ro in rom.get_objects_by_handle_substring().items():
             ro.awake = False
+
         aom = self.get_articulated_object_manager()
         for _, ao in aom.get_objects_by_handle_substring().items():
             ao.awake = False
@@ -241,6 +258,12 @@ class RearrangeSim(HabitatSim):
         # auto-sleep rigid objects as optimization
         if self.habitat_config.auto_sleep:
             self.sleep_all_objects()
+
+        rom = self.get_rigid_object_manager()
+        self._obj_orig_motion_types = {
+            handle: ro.motion_type
+            for handle, ro in rom.get_objects_by_handle_substring().items()
+        }
 
         if new_scene:
             self._load_navmesh(ep_info)
@@ -662,6 +685,8 @@ class RearrangeSim(HabitatSim):
             self.viz_ids = defaultdict(lambda: None)
 
         self.maybe_update_robot()
+        if self.habitat_config.sleep_dist > 0.0:
+            self._auto_sleep()
 
         if self.habitat_config.concur_render:
             self._prev_sim_obs = self.start_async_render()
@@ -751,7 +776,6 @@ class RearrangeSim(HabitatSim):
 
         Never call sim.step_world directly or miss updating the robot.
         """
-
         # optionally step physics and update the robot for benchmarking purposes
         if self.habitat_config.step_physics:
             self.step_world(dt)

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -96,6 +96,9 @@ class RearrangeTask(NavigationTask):
             # Duplicate sensors that handle robots. One for each robot.
             self._duplicate_sensor_suite(self.sensor_suite)
 
+    def overwrite_sim_config(self, config: Any, episode: Episode) -> Any:
+        return config
+
     @property
     def targ_idx(self):
         return self._targ_idx


### PR DESCRIPTION
## Motivation and Context

Small fix with big performance improvements. This sets objects outside a set radius of the agent to `MotionType.STATIC`. In manual tests with the interactive play script, this difference is unnoticable. The PR is not ready to merge until I confirm this has no impact on learning.

Sim speed test:
- Without this PR: 22.09266252303496 seconds
- With this PR: 11.722101256018505 seconds *(almost 2x improvement)*

Training speed test (20 environments, VER trainer, 1GPU, 16CPUs, 10 updates):
- Without this PR: 429 SPS
- With this PR: 633 SPS *(42% faster)*.

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
- Manual interactive play test.
