### PR TITLE
Performance improvement on lab

### DIFF
--- a/habitat-baselines/habitat_baselines/config/default_structured_configs.py
+++ b/habitat-baselines/habitat_baselines/config/default_structured_configs.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple
 
+import attr
 from hydra.core.config_store import ConfigStore
 from omegaconf import MISSING
 
@@ -15,12 +15,12 @@ from habitat.config.default_structured_configs import SimulatorSensorConfig
 cs = ConfigStore.instance()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatBaselinesBaseConfig:
     pass
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class WBConfig(HabitatBaselinesBaseConfig):
     """Weights and Biases config"""
 
@@ -35,7 +35,7 @@ class WBConfig(HabitatBaselinesBaseConfig):
     run_name: str = ""
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EvalConfig(HabitatBaselinesBaseConfig):
     # The split to evaluate on
     split: str = "val"
@@ -44,16 +44,13 @@ class EvalConfig(HabitatBaselinesBaseConfig):
     # The number of time to run each episode through evaluation.
     # Only works when evaluating on all episodes.
     evals_per_ep: int = 1
-    video_option: List[str] = field(
-        # available options are "disk" and "tensorboard"
-        default_factory=list
-    )
-    extra_sim_sensors: Dict[str, SimulatorSensorConfig] = field(
-        default_factory=dict
-    )
+    video_option: List[
+        str
+    ] = []  # available options are "disk" and "tensorboard"
+    extra_sim_sensors: Dict[str, SimulatorSensorConfig] = dict()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PreemptionConfig(HabitatBaselinesBaseConfig):
     # Append the slurm job ID to the resume state filename if running
     # a slurm job. This is useful when you want to have things from a different
@@ -66,7 +63,7 @@ class PreemptionConfig(HabitatBaselinesBaseConfig):
     save_state_batch_only: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ActionDistributionConfig(HabitatBaselinesBaseConfig):
     use_log_std: bool = True
     use_softplus: bool = False
@@ -85,12 +82,12 @@ class ActionDistributionConfig(HabitatBaselinesBaseConfig):
     scheduled_std: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ObsTransformConfig(HabitatBaselinesBaseConfig):
     type: str = MISSING
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CenterCropperConfig(ObsTransformConfig):
     type: str = "CenterCropper"
     height: int = 256
@@ -111,7 +108,7 @@ cs.store(
 )
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ResizeShortestEdgeConfig(ObsTransformConfig):
     type: str = "ResizeShortestEdge"
     size: int = 256
@@ -132,21 +129,19 @@ cs.store(
 )
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class Cube2EqConfig(ObsTransformConfig):
     type: str = "CubeMap2Equirect"
     height: int = 256
     width: int = 512
-    sensor_uuids: List[str] = field(
-        default_factory=lambda: [
-            "BACK",
-            "DOWN",
-            "FRONT",
-            "LEFT",
-            "RIGHT",
-            "UP",
-        ]
-    )
+    sensor_uuids: List[str] = [
+        "BACK",
+        "DOWN",
+        "FRONT",
+        "LEFT",
+        "RIGHT",
+        "UP",
+    ]
 
 
 cs.store(
@@ -157,23 +152,21 @@ cs.store(
 )
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class Cube2FishConfig(ObsTransformConfig):
     type: str = "CubeMap2Fisheye"
     height: int = 256
     width: int = 256
     fov: int = 180
     params: Tuple[float, ...] = (0.2, 0.2, 0.2)
-    sensor_uuids: List[str] = field(
-        default_factory=lambda: [
-            "BACK",
-            "DOWN",
-            "FRONT",
-            "LEFT",
-            "RIGHT",
-            "UP",
-        ]
-    )
+    sensor_uuids: List[str] = [
+        "BACK",
+        "DOWN",
+        "FRONT",
+        "LEFT",
+        "RIGHT",
+        "UP",
+    ]
 
 
 cs.store(
@@ -184,10 +177,10 @@ cs.store(
 )
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class AddVirtualKeysConfig(ObsTransformConfig):
     type: str = "AddVirtualKeys"
-    virtual_keys: Dict[str, int] = field(default_factory=dict)
+    virtual_keys: Dict[str, int] = dict()
 
 
 cs.store(
@@ -198,21 +191,19 @@ cs.store(
 )
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class Eq2CubeConfig(ObsTransformConfig):
     type: str = "Equirect2CubeMap"
     height: int = 256
     width: int = 256
-    sensor_uuids: List[str] = field(
-        default_factory=lambda: [
-            "BACK",
-            "DOWN",
-            "FRONT",
-            "LEFT",
-            "RIGHT",
-            "UP",
-        ]
-    )
+    sensor_uuids: List[str] = [
+        "BACK",
+        "DOWN",
+        "FRONT",
+        "LEFT",
+        "RIGHT",
+        "UP",
+    ]
 
 
 cs.store(
@@ -223,25 +214,25 @@ cs.store(
 )
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HierarchicalPolicy(HabitatBaselinesBaseConfig):
     high_level_policy: Dict[str, Any] = MISSING
-    defined_skills: Dict[str, Any] = field(default_factory=dict)
-    use_skills: Dict[str, str] = field(default_factory=dict)
+    defined_skills: Dict[str, Any] = dict()
+    use_skills: Dict[str, str] = dict()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PolicyConfig(HabitatBaselinesBaseConfig):
     name: str = "PointNavResNetPolicy"
     action_distribution_type: str = "categorical"  # or 'gaussian'
     # If the list is empty, all keys will be included.
     # For gaussian action distribution:
     action_dist: ActionDistributionConfig = ActionDistributionConfig()
-    obs_transforms: Dict[str, ObsTransformConfig] = field(default_factory=dict)
+    obs_transforms: Dict[str, ObsTransformConfig] = dict()
     hierarchical_policy: HierarchicalPolicy = MISSING
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PPOConfig(HabitatBaselinesBaseConfig):
     """Proximal policy optimization config"""
 
@@ -272,7 +263,7 @@ class PPOConfig(HabitatBaselinesBaseConfig):
     use_double_buffered_sampler: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class VERConfig(HabitatBaselinesBaseConfig):
     """Variable experience rollout config"""
 
@@ -281,12 +272,12 @@ class VERConfig(HabitatBaselinesBaseConfig):
     overlap_rollouts_and_learn: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class AuxLossConfig(HabitatBaselinesBaseConfig):
     pass
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CPCALossConfig(AuxLossConfig):
     """Action-conditional contrastive predictive coding loss"""
 
@@ -296,7 +287,7 @@ class CPCALossConfig(AuxLossConfig):
     loss_scale: float = 0.1
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DDPPOConfig(HabitatBaselinesBaseConfig):
     """Decentralized distributed proximal policy optimization config"""
 
@@ -319,7 +310,7 @@ class DDPPOConfig(HabitatBaselinesBaseConfig):
     force_distributed: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RLConfig(HabitatBaselinesBaseConfig):
     """Reinforcement learning config"""
 
@@ -328,22 +319,18 @@ class RLConfig(HabitatBaselinesBaseConfig):
     ppo: PPOConfig = PPOConfig()
     ddppo: DDPPOConfig = DDPPOConfig()
     ver: VERConfig = VERConfig()
-    auxiliary_losses: Dict[str, AuxLossConfig] = field(default_factory=dict)
+    auxiliary_losses: Dict[str, AuxLossConfig] = dict()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ProfilingConfig(HabitatBaselinesBaseConfig):
     capture_start_step: int = -1
     num_steps_to_capture: int = -1
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     # task config can be a list of configs like "A.yaml,B.yaml"
-    # base_task_config_path: str = (
-    #     "habitat-lab/habitat/config/task/pointnav.yaml"
-    # )
-    # cmd_trailing_opts: List[str] = field(default_factory=list)
     trainer_name: str = "ppo"
     torch_gpu_id: int = 0
     tensorboard_dir: str = "tb"
@@ -365,7 +352,7 @@ class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     log_file: str = "train.log"
     force_blind_policy: bool = False
     verbose: bool = True
-    eval_keys_to_include_in_name: List[str] = field(default_factory=list)
+    eval_keys_to_include_in_name: List[str] = []
     # For our use case, the CPU side things are mainly memory copies
     # and nothing of substantive compute. PyTorch has been making
     # more and more memory copies parallel, but that just ends up
@@ -384,17 +371,17 @@ class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     profiling: ProfilingConfig = ProfilingConfig()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatBaselinesRLConfig(HabitatBaselinesConfig):
     rl: RLConfig = RLConfig()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatBaselinesILConfig(HabitatBaselinesConfig):
-    il: Dict[str, Any] = field(default_factory=dict)
+    il: Dict[str, Any] = dict()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatBaselinesSPAConfig(HabitatBaselinesConfig):
     sense_plan_act: Any = MISSING
 

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -508,7 +508,9 @@ class FogOfWarConfig:
 @attr.s(auto_attribs=True, slots=True)
 class TopDownMapMeasurementConfig(MeasurementConfig):
     type: str = "TopDownMap"
-    max_episode_steps: int = II("habitat.environment.max_episode_steps")
+    max_episode_steps: int = (
+        EnvironmentConfig().max_episode_steps
+    )  # TODO : Use OmegaConf II()
     map_padding: int = 3
     map_resolution: int = 1024
     draw_source: bool = True
@@ -906,7 +908,7 @@ class SimulatorCameraSensorConfig(SimulatorSensorConfig):
 
 
 @attr.s(auto_attribs=True, slots=True)
-class SimulatorDepthSensorConfig(SimulatorCameraSensorConfig):
+class SimulatorDepthSensorConfig(SimulatorSensorConfig):
     min_depth: float = 0.0
     max_depth: float = 10.0
     normalize_depth: bool = True
@@ -918,8 +920,11 @@ class HabitatSimRGBSensorConfig(SimulatorCameraSensorConfig):
 
 
 @attr.s(auto_attribs=True, slots=True)
-class HabitatSimDepthSensorConfig(SimulatorDepthSensorConfig):
+class HabitatSimDepthSensorConfig(SimulatorCameraSensorConfig):
     type: str = "HabitatSimDepthSensor"
+    min_depth: float = 0.0
+    max_depth: float = 10.0
+    normalize_depth: bool = True
 
 
 @attr.s(auto_attribs=True, slots=True)
@@ -945,7 +950,7 @@ class HabitatSimEquirectangularSemanticSensorConfig(SimulatorSensorConfig):
 @attr.s(auto_attribs=True, slots=True)
 class SimulatorFisheyeSensorConfig(SimulatorSensorConfig):
     type: str = "HabitatSimFisheyeSensor"
-    height: int = SimulatorSensorConfig.width
+    height: int = SimulatorSensorConfig().width
     # The default value (alpha, xi) is set to match the lens  "GoPro" found in
     # Table 3 of this paper: Vladyslav Usenko, Nikolaus Demmel and
     # Daniel Cremers: The Double Sphere Camera Model,
@@ -970,9 +975,9 @@ class HabitatSimFisheyeRGBSensorConfig(SimulatorFisheyeSensorConfig):
 @attr.s(auto_attribs=True, slots=True)
 class SimulatorFisheyeDepthSensorConfig(SimulatorFisheyeSensorConfig):
     type: str = "HabitatSimFisheyeDepthSensor"
-    min_depth: float = SimulatorDepthSensorConfig.min_depth
-    max_depth: float = SimulatorDepthSensorConfig.max_depth
-    normalize_depth: bool = SimulatorDepthSensorConfig.normalize_depth
+    min_depth: float = SimulatorDepthSensorConfig().min_depth
+    max_depth: float = SimulatorDepthSensorConfig().max_depth
+    normalize_depth: bool = SimulatorDepthSensorConfig().normalize_depth
 
 
 @attr.s(auto_attribs=True, slots=True)

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+import attr
 from hydra.core.config_store import ConfigStore
 from omegaconf import II, MISSING
 
@@ -45,12 +45,12 @@ __all__ = [
 ]
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatBaseConfig:
     pass
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class IteratorOptionsConfig(HabitatBaseConfig):
     cycle: bool = True
     shuffle: bool = True
@@ -61,7 +61,7 @@ class IteratorOptionsConfig(HabitatBaseConfig):
     step_repetition_range: float = 0.2
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EnvironmentConfig(HabitatBaseConfig):
     r"""
     Some habitat environment configurations.
@@ -75,13 +75,13 @@ class EnvironmentConfig(HabitatBaseConfig):
 # -----------------------------------------------------------------------------
 # # Actions
 # -----------------------------------------------------------------------------
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ActionConfig(HabitatBaseConfig):
     type: str = MISSING
     agent_index: int = 0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class StopActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, the stop action is a discrete action. When called, the Agent
@@ -94,7 +94,7 @@ class StopActionConfig(ActionConfig):
     type: str = "StopAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EmptyActionConfig(ActionConfig):
     type: str = "EmptyAction"
 
@@ -102,7 +102,7 @@ class EmptyActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # NAVIGATION actions
 # -----------------------------------------------------------------------------
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class MoveForwardActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will move the robot forward by
@@ -111,7 +111,7 @@ class MoveForwardActionConfig(ActionConfig):
     type: str = "MoveForwardAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TurnLeftActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot to the left
@@ -120,7 +120,7 @@ class TurnLeftActionConfig(ActionConfig):
     type: str = "TurnLeftAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TurnRightActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot to the right
@@ -129,7 +129,7 @@ class TurnRightActionConfig(ActionConfig):
     type: str = "TurnRightAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class LookUpActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot's camera up
@@ -138,7 +138,7 @@ class LookUpActionConfig(ActionConfig):
     type: str = "LookUpAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class LookDownActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot's camera down
@@ -147,18 +147,18 @@ class LookDownActionConfig(ActionConfig):
     type: str = "LookDownAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TeleportActionConfig(ActionConfig):
     type: str = "TeleportAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class VelocityControlActionConfig(ActionConfig):
     type: str = "VelocityAction"
     # meters/sec
-    lin_vel_range: List[float] = field(default_factory=lambda: [0.0, 0.25])
+    lin_vel_range: List[float] = [0.0, 0.25]
     # deg/sec
-    ang_vel_range: List[float] = field(default_factory=lambda: [-10.0, 10.0])
+    ang_vel_range: List[float] = [-10.0, 10.0]
     min_abs_lin_speed: float = 0.025  # meters/sec
     min_abs_ang_speed: float = 1.0  # # deg/sec
     time_step: float = 1.0  # seconds
@@ -167,7 +167,7 @@ class VelocityControlActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # REARRANGE actions
 # -----------------------------------------------------------------------------
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArmActionConfig(ActionConfig):
     type: str = "ArmAction"
     arm_controller: str = "ArmRelPosAction"
@@ -182,7 +182,7 @@ class ArmActionConfig(ActionConfig):
     render_ee_target: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class BaseVelocityActionConfig(ActionConfig):
     type: str = "BaseVelAction"
     lin_speed: float = 10.0
@@ -191,12 +191,12 @@ class BaseVelocityActionConfig(ActionConfig):
     allow_back: bool = True
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RearrangeStopActionConfig(ActionConfig):
     type: str = "RearrangeStopAction"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class OracleNavActionConfig(ActionConfig):
     """
     Oracle navigation action.
@@ -219,7 +219,7 @@ class OracleNavActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # EQA actions
 # -----------------------------------------------------------------------------
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class AnswerActionConfig(ActionConfig):
     type: str = "AnswerAction"
 
@@ -227,24 +227,24 @@ class AnswerActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # TASK_SENSORS
 # -----------------------------------------------------------------------------
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class LabSensorConfig(HabitatBaseConfig):
     type: str = MISSING
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PointGoalSensorConfig(LabSensorConfig):
     type: str = "PointGoalSensor"
     goal_format: str = "POLAR"
     dimensionality: int = 2
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PointGoalWithGPSCompassSensorConfig(PointGoalSensorConfig):
     type: str = "PointGoalWithGPSCompassSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ObjectGoalSensorConfig(LabSensorConfig):
     r"""
     For Object Navigation tasks only. Generates a discrete observation containing
@@ -257,12 +257,12 @@ class ObjectGoalSensorConfig(LabSensorConfig):
     goal_spec_max_val: int = 50
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ImageGoalSensorConfig(LabSensorConfig):
     type: str = "ImageGoalSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class InstanceImageGoalSensorConfig(LabSensorConfig):
     r"""
     Used only by the InstanceImageGoal Navigation task. The observation is a rendered
@@ -271,7 +271,7 @@ class InstanceImageGoalSensorConfig(LabSensorConfig):
     type: str = "InstanceImageGoalSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class InstanceImageGoalHFOVSensorConfig(LabSensorConfig):
     r"""
     Used only by the InstanceImageGoal Navigation task. The observation is a single
@@ -281,12 +281,12 @@ class InstanceImageGoalHFOVSensorConfig(LabSensorConfig):
     type: str = "InstanceImageGoalHFOVSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HeadingSensorConfig(LabSensorConfig):
     type: str = "HeadingSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CompassSensorConfig(LabSensorConfig):
     r"""
     For Navigation tasks only. The observation of the
@@ -297,7 +297,7 @@ class CompassSensorConfig(LabSensorConfig):
     type: str = "CompassSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class GPSSensorConfig(LabSensorConfig):
     r"""
     For Navigation tasks only. The observation of the EpisodicGPSSensor are two float values
@@ -308,146 +308,146 @@ class GPSSensorConfig(LabSensorConfig):
     dimensionality: int = 2
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ProximitySensorConfig(LabSensorConfig):
     type: str = "ProximitySensor"
     max_detection_radius: float = 2.0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class JointSensorConfig(LabSensorConfig):
     type: str = "JointSensor"
     dimensionality: int = 7
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EEPositionSensorConfig(LabSensorConfig):
     type: str = "EEPositionSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class IsHoldingSensorConfig(LabSensorConfig):
     type: str = "IsHoldingSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RelativeRestingPositionSensorConfig(LabSensorConfig):
     type: str = "RelativeRestingPositionSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class JointVelocitySensorConfig(LabSensorConfig):
     type: str = "JointVelocitySensor"
     dimensionality: int = 7
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class OracleNavigationActionSensorConfig(LabSensorConfig):
     type: str = "OracleNavigationActionSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RestingPositionSensorConfig(LabSensorConfig):
     type: str = "RestingPositionSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArtJointSensorConfig(LabSensorConfig):
     type: str = "ArtJointSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class NavGoalSensorConfig(LabSensorConfig):
     type: str = "NavGoalSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArtJointSensorNoVelSensorConfig(LabSensorConfig):
     type: str = "ArtJointSensorNoVel"  # TODO: add "Sensor" suffix
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class MarkerRelPosSensorConfig(LabSensorConfig):
     type: str = "MarkerRelPosSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TargetStartSensorConfig(LabSensorConfig):
     type: str = "TargetStartSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TargetCurrentSensorConfig(LabSensorConfig):
     type: str = "TargetCurrentSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class GoalSensorConfig(LabSensorConfig):
     type: str = "GoalSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class NavGoalPointGoalSensorConfig(LabSensorConfig):
     type: str = "NavGoalPointGoalSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class GlobalPredicatesSensorConfig(LabSensorConfig):
     type: str = "GlobalPredicatesSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TargetStartGpsCompassSensorConfig(LabSensorConfig):
     type: str = "TargetStartGpsCompassSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TargetGoalGpsCompassSensorConfig(LabSensorConfig):
     type: str = "TargetGoalGpsCompassSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class NavToSkillSensorConfig(LabSensorConfig):
     type: str = "NavToSkillSensor"
     num_skills: int = 8
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class AbsTargetStartSensorConfig(LabSensorConfig):
     type: str = "AbsTargetStartSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class AbsGoalSensorConfig(LabSensorConfig):
     type: str = "AbsGoalSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DistToNavGoalSensorConfig(LabSensorConfig):
     type: str = "DistToNavGoalSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class LocalizationSensorConfig(LabSensorConfig):
     type: str = "LocalizationSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class QuestionSensorConfig(LabSensorConfig):
     type: str = "QuestionSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class InstructionSensorConfig(LabSensorConfig):
     type: str = "InstructionSensor"
     instruction_sensor_uuid: str = "instruction"
@@ -456,12 +456,12 @@ class InstructionSensorConfig(LabSensorConfig):
 # -----------------------------------------------------------------------------
 # Measurements
 # -----------------------------------------------------------------------------
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class MeasurementConfig(HabitatBaseConfig):
     type: str = MISSING
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SuccessMeasurementConfig(MeasurementConfig):
     r"""
     For Navigation tasks only, Measures 1.0 if the robot reached a success and 0 otherwise.
@@ -474,7 +474,7 @@ class SuccessMeasurementConfig(MeasurementConfig):
     success_distance: float = 0.2
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SPLMeasurementConfig(MeasurementConfig):
     r"""
     For Navigation tasks only, Measures the SPL (Success weighted by Path Length)
@@ -488,7 +488,7 @@ class SPLMeasurementConfig(MeasurementConfig):
     type: str = "SPL"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SoftSPLMeasurementConfig(MeasurementConfig):
     r"""
     For Navigation tasks only, Similar to SPL, but instead of a boolean,
@@ -498,19 +498,17 @@ class SoftSPLMeasurementConfig(MeasurementConfig):
     type: str = "SoftSPL"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class FogOfWarConfig:
     draw: bool = True
     visibility_dist: float = 5.0
     fov: int = 90
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TopDownMapMeasurementConfig(MeasurementConfig):
     type: str = "TopDownMap"
-    max_episode_steps: int = (
-        EnvironmentConfig.max_episode_steps
-    )  # TODO : Use OmegaConf II()
+    max_episode_steps: int = II("habitat.environment.max_episode_steps")
     map_padding: int = 3
     map_resolution: int = 1024
     draw_source: bool = True
@@ -523,79 +521,79 @@ class TopDownMapMeasurementConfig(MeasurementConfig):
     fog_of_war: FogOfWarConfig = FogOfWarConfig()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CollisionsMeasurementConfig(MeasurementConfig):
     type: str = "Collisions"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RobotForceMeasurementConfig(MeasurementConfig):
     type: str = "RobotForce"
     min_force: float = 20.0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ForceTerminateMeasurementConfig(MeasurementConfig):
     type: str = "ForceTerminate"
     max_accum_force: float = -1.0
     max_instant_force: float = -1.0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RobotCollisionsMeasurementConfig(MeasurementConfig):
     type: str = "RobotCollisions"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ObjectToGoalDistanceMeasurementConfig(MeasurementConfig):
     type: str = "ObjectToGoalDistance"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EndEffectorToObjectDistanceMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorToObjectDistance"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EndEffectorToRestDistanceMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorToRestDistance"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EndEffectorToGoalDistanceMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorToGoalDistance"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArtObjAtDesiredStateMeasurementConfig(MeasurementConfig):
     type: str = "ArtObjAtDesiredState"
     use_absolute_distance: bool = True
     success_dist_threshold: float = 0.05
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class GfxReplayMeasureMeasurementConfig(MeasurementConfig):
     type: str = "GfxReplayMeasure"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EndEffectorDistToMarkerMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorDistToMarker"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArtObjStateMeasurementConfig(MeasurementConfig):
     type: str = "ArtObjState"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArtObjSuccessMeasurementConfig(MeasurementConfig):
     type: str = "ArtObjSuccess"
     rest_dist_threshold: float = 0.15
     must_call_stop: bool = True
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArtObjRewardMeasurementConfig(MeasurementConfig):
     type: str = "ArtObjReward"
     dist_reward: float = 1.0
@@ -613,30 +611,30 @@ class ArtObjRewardMeasurementConfig(MeasurementConfig):
     force_end_pen: float = 10.0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RotDistToGoalMeasurementConfig(MeasurementConfig):
     type: str = "RotDistToGoal"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DistToGoalMeasurementConfig(MeasurementConfig):
     type: str = "DistToGoal"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class BadCalledTerminateMeasurementConfig(MeasurementConfig):
     type: str = "BadCalledTerminate"
     bad_term_pen: float = 0.0
     decay_bad_term: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class NavToPosSuccMeasurementConfig(MeasurementConfig):
     type: str = "NavToPosSucc"
     success_distance: float = 1.5
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class NavToObjRewardMeasurementConfig(MeasurementConfig):
     type: str = "NavToObjReward"
     # reward the agent for facing the object?
@@ -652,7 +650,7 @@ class NavToObjRewardMeasurementConfig(MeasurementConfig):
     force_end_pen: float = 1.0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class NavToObjSuccessMeasurementConfig(MeasurementConfig):
     type: str = "NavToObjSuccess"
     must_look_at_targ: bool = True
@@ -661,7 +659,7 @@ class NavToObjSuccessMeasurementConfig(MeasurementConfig):
     success_angle_dist: float = 0.261799
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RearrangeReachRewardMeasurementConfig(MeasurementConfig):
     type: str = "RearrangeReachReward"
     scale: float = 1.0
@@ -669,13 +667,13 @@ class RearrangeReachRewardMeasurementConfig(MeasurementConfig):
     sparse_reward: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RearrangeReachSuccessMeasurementConfig(MeasurementConfig):
     type: str = "RearrangeReachSuccess"
     succ_thresh: float = 0.2
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class NumStepsMeasurementConfig(MeasurementConfig):
     r"""
     In both Navigation and Rearrangement tasks, counts the number of steps since
@@ -684,17 +682,17 @@ class NumStepsMeasurementConfig(MeasurementConfig):
     type: str = "NumStepsMeasure"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DidPickObjectMeasurementConfig(MeasurementConfig):
     type: str = "DidPickObjectMeasure"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DidViolateHoldConstraintMeasurementConfig(MeasurementConfig):
     type: str = "DidViolateHoldConstraintMeasure"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class MoveObjectsRewardMeasurementConfig(MeasurementConfig):
     type: str = "MoveObjectsReward"
     pick_reward: float = 1.0
@@ -707,7 +705,7 @@ class MoveObjectsRewardMeasurementConfig(MeasurementConfig):
     force_end_pen: float = 10.0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RearrangePickRewardMeasurementConfig(MeasurementConfig):
     type: str = "RearrangePickReward"
     dist_reward: float = 2.0
@@ -723,19 +721,19 @@ class RearrangePickRewardMeasurementConfig(MeasurementConfig):
     wrong_pick_should_end: bool = True
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class RearrangePickSuccessMeasurementConfig(MeasurementConfig):
     type: str = "RearrangePickSuccess"
     ee_resting_success_threshold: float = 0.15
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ObjAtGoalMeasurementConfig(MeasurementConfig):
     type: str = "ObjAtGoal"
     succ_thresh: float = 0.15
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PlaceRewardMeasurementConfig(MeasurementConfig):
     type: str = "PlaceReward"
     dist_reward: float = 2.0
@@ -751,51 +749,51 @@ class PlaceRewardMeasurementConfig(MeasurementConfig):
     min_dist_to_goal: float = 0.15
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PlaceSuccessMeasurementConfig(MeasurementConfig):
     type: str = "PlaceSuccess"
     ee_resting_success_threshold: float = 0.15
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CompositeNodeIdxMeasurementConfig(MeasurementConfig):
     type: str = "CompositeNodeIdx"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CompositeStageGoalsMeasurementConfig(MeasurementConfig):
     type: str = "CompositeStageGoals"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CompositeSuccessMeasurementConfig(MeasurementConfig):
     type: str = "CompositeSuccess"
     must_call_stop: bool = True
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CompositeRewardMeasurementConfig(MeasurementConfig):
     type: str = "CompositeReward"
     must_call_stop: bool = True
     success_reward: float = 10.0
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DoesWantTerminateMeasurementConfig(MeasurementConfig):
     type: str = "DoesWantTerminate"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class CorrectAnswerMeasurementConfig(MeasurementConfig):
     type: str = "CorrectAnswer"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class EpisodeInfoMeasurementConfig(MeasurementConfig):
     type: str = "EpisodeInfo"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DistanceToGoalMeasurementConfig(MeasurementConfig):
     r"""
     In Navigation tasks only, measures the geodesic distance to the goal.
@@ -806,7 +804,7 @@ class DistanceToGoalMeasurementConfig(MeasurementConfig):
     distance_to: str = "POINT"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DistanceToGoalRewardMeasurementConfig(MeasurementConfig):
     r"""
     In Navigation tasks only, measures a reward based on the distance towards the goal.
@@ -816,12 +814,12 @@ class DistanceToGoalRewardMeasurementConfig(MeasurementConfig):
     type: str = "DistanceToGoalReward"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class AnswerAccuracyMeasurementConfig(MeasurementConfig):
     type: str = "AnswerAccuracy"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class TaskConfig(HabitatBaseConfig):
     r"""
     The definition of the task in Habitat.
@@ -838,8 +836,8 @@ class TaskConfig(HabitatBaseConfig):
     # NAVIGATION task
     type: str = "Nav-v0"
     # Temporary structure for sensors
-    lab_sensors: Dict[str, LabSensorConfig] = field(default_factory=dict)
-    measurements: Dict[str, MeasurementConfig] = field(default_factory=dict)
+    lab_sensors: Dict[str, LabSensorConfig] = dict()
+    measurements: Dict[str, MeasurementConfig] = dict()
     goal_sensor_uuid: str = "pointgoal"
     # REARRANGE task
     count_obj_collisions: bool = True
@@ -866,9 +864,7 @@ class TaskConfig(HabitatBaseConfig):
     base_noise: float = 0.05
     spawn_region_scale: float = 0.2
     joint_max_impulse: float = -1.0
-    desired_resting_position: List[float] = field(
-        default_factory=lambda: [0.5, 0.0, 1.0]
-    )
+    desired_resting_position: List[float] = [0.5, 0.0, 1.0]
     use_marker_t: bool = True
     cache_robot_init: bool = False
     success_state: float = 0.0
@@ -887,68 +883,66 @@ class TaskConfig(HabitatBaseConfig):
     enable_safe_drop: bool = False
     art_succ_thresh: float = 0.15
     robot_at_thresh: float = 2.0
-    filter_nav_to_tasks: List = field(default_factory=list)
+    filter_nav_to_tasks: List = []
     actions: Dict[str, ActionConfig] = MISSING
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SimulatorSensorConfig(HabitatBaseConfig):
     type: str = MISSING
     height: int = 480
     width: int = 640
-    position: List[float] = field(default_factory=lambda: [0.0, 1.25, 0.0])
+    position: List[float] = [0.0, 1.25, 0.0]
     # Euler's angles:
-    orientation: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    orientation: List[float] = [0.0, 0.0, 0.0]
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SimulatorCameraSensorConfig(SimulatorSensorConfig):
     hfov: int = 90  # horizontal field of view in degrees
     sensor_subtype: str = "PINHOLE"
     noise_model: str = "None"
-    noise_model_kwargs: Dict[str, Any] = field(default_factory=dict)
+    noise_model_kwargs: Dict[str, Any] = dict()
 
 
-@dataclass
-class SimulatorDepthSensorConfig(SimulatorSensorConfig):
+@attr.s(auto_attribs=True, slots=True)
+class SimulatorDepthSensorConfig(SimulatorCameraSensorConfig):
     min_depth: float = 0.0
     max_depth: float = 10.0
     normalize_depth: bool = True
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimRGBSensorConfig(SimulatorCameraSensorConfig):
     type: str = "HabitatSimRGBSensor"
 
 
-@dataclass
-class HabitatSimDepthSensorConfig(
-    SimulatorDepthSensorConfig, SimulatorCameraSensorConfig
-):
+@attr.s(auto_attribs=True, slots=True)
+class HabitatSimDepthSensorConfig(SimulatorDepthSensorConfig):
     type: str = "HabitatSimDepthSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimSemanticSensorConfig(SimulatorCameraSensorConfig):
     type: str = "HabitatSimSemanticSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimEquirectangularRGBSensorConfig(SimulatorSensorConfig):
     type: str = "HabitatSimEquirectangularRGBSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimEquirectangularDepthSensorConfig(SimulatorDepthSensorConfig):
     type: str = "HabitatSimEquirectangularDepthSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimEquirectangularSemanticSensorConfig(SimulatorSensorConfig):
     type: str = "HabitatSimEquirectangularSemanticSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SimulatorFisheyeSensorConfig(SimulatorSensorConfig):
     type: str = "HabitatSimFisheyeSensor"
     height: int = SimulatorSensorConfig.width
@@ -960,7 +954,7 @@ class SimulatorFisheyeSensorConfig(SimulatorSensorConfig):
     # in the same table as well.
     xi: float = -0.27
     alpha: float = 0.57
-    focal_length: List[float] = field(default_factory=lambda: [364.84, 364.86])
+    focal_length: List[float] = [364.84, 364.86]
     # Place camera at center of screen
     # Can be specified, otherwise is calculated automatically.
     # principal_point_offset defaults to (h/2,w/2)
@@ -968,12 +962,12 @@ class SimulatorFisheyeSensorConfig(SimulatorSensorConfig):
     sensor_model_type: str = "DOUBLE_SPHERE"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimFisheyeRGBSensorConfig(SimulatorFisheyeSensorConfig):
     type: str = "HabitatSimFisheyeRGBSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SimulatorFisheyeDepthSensorConfig(SimulatorFisheyeSensorConfig):
     type: str = "HabitatSimFisheyeDepthSensor"
     min_depth: float = SimulatorDepthSensorConfig.min_depth
@@ -981,67 +975,67 @@ class SimulatorFisheyeDepthSensorConfig(SimulatorFisheyeSensorConfig):
     normalize_depth: bool = SimulatorDepthSensorConfig.normalize_depth
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimFisheyeSemanticSensorConfig(SimulatorFisheyeSensorConfig):
     type: str = "HabitatSimFisheyeSemanticSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HeadRGBSensorConfig(HabitatSimRGBSensorConfig):
     uuid: str = "robot_head_rgb"
     width: int = 256
     height: int = 256
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HeadDepthSensorConfig(HabitatSimDepthSensorConfig):
     uuid: str = "robot_head_depth"
     width: int = 256
     height: int = 256
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArmRGBSensorConfig(HabitatSimRGBSensorConfig):
     uuid: str = "robot_arm_rgb"
     width: int = 256
     height: int = 256
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ArmDepthSensorConfig(HabitatSimDepthSensorConfig):
     uuid: str = "robot_arm_depth"
     width: int = 256
     height: int = 256
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ThirdRGBSensorConfig(HabitatSimRGBSensorConfig):
     uuid: str = "robot_third_rgb"
     width: int = 512
     height: int = 512
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class ThirdDepthSensorConfig(HabitatSimDepthSensorConfig):
     uuid: str = "robot_third_depth"  # TODO: robot_third_rgb on the main branch
     #  check if it won't cause any errors
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class AgentConfig(HabitatBaseConfig):
     height: float = 1.5
     radius: float = 0.1
-    sim_sensors: Dict[str, SimulatorSensorConfig] = field(default_factory=dict)
+    sim_sensors: Dict[str, SimulatorSensorConfig] = dict()
     is_set_start_state: bool = False
-    start_position: List[float] = field(default_factory=lambda: [0, 0, 0])
-    start_rotation: List[float] = field(default_factory=lambda: [0, 0, 0, 1])
+    start_position: List[float] = [0, 0, 0]
+    start_rotation: List[float] = [0, 0, 0, 1]
     joint_start_noise: float = 0.1
     robot_urdf: str = "data/robots/hab_fetch/robots/hab_fetch.urdf"
     robot_type: str = "FetchRobot"
     ik_arm_urdf: str = "data/robots/hab_fetch/robots/fetch_onlyarm.urdf"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatSimV0Config(HabitatBaseConfig):
     gpu_device_id: int = 0
     # Use Habitat-Sim's GPU->GPU copy mode to return rendering results in
@@ -1062,11 +1056,11 @@ class HabitatSimV0Config(HabitatBaseConfig):
     enable_gfx_replay_save: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class SimulatorConfig(HabitatBaseConfig):
     type: str = "Sim-v0"
     action_space_config: str = "v0"
-    action_space_config_arguments: Dict[str, Any] = field(default_factory=dict)
+    action_space_config_arguments: Dict[str, Any] = dict()
     forward_step_size: float = 0.25  # in metres
     create_renderer: bool = False
     requires_textures: bool = True
@@ -1083,7 +1077,7 @@ class SimulatorConfig(HabitatBaseConfig):
     scene_dataset: str = "default"
     # A list of directory or config paths to search in addition to the dataset
     # for object configs. should match the generated episodes for the task:
-    additional_object_paths: List[str] = field(default_factory=list)
+    additional_object_paths: List[str] = []
     # Use config.seed (can't reference Config.seed) or define via code
     # otherwise it leads to circular references:
     #
@@ -1120,25 +1114,25 @@ class SimulatorConfig(HabitatBaseConfig):
     ep_info: Optional[Any] = None
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PyrobotSensor(HabitatBaseConfig):
     pass
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PyrobotVisualSensorConfig(PyrobotSensor):
     type: str = MISSING
     height: int = 480
     width: int = 640
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PyrobotRGBSensorConfig(PyrobotVisualSensorConfig):
     type: str = "PyRobotRGBSensor"
     center_crop: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PyrobotDepthSensorConfig(PyrobotVisualSensorConfig):
     type: str = "PyRobotDepthSensor"
     min_depth: float = 0.0
@@ -1147,42 +1141,35 @@ class PyrobotDepthSensorConfig(PyrobotVisualSensorConfig):
     center_crop: bool = False
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PyrobotBumpSensorConfig(PyrobotSensor):
     type: str = "PyRobotBumpSensor"
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class LocobotConfig(HabitatBaseConfig):
-    actions: List[str] = field(
-        default_factory=lambda: ["base_actions", "camera_actions"]
-    )
-    base_actions: List[str] = field(
-        default_factory=lambda: ["go_to_relative", "go_to_absolute"]
-    )
-    camera_actions: List[str] = field(
-        default_factory=lambda: ["set_pan", "set_tilt", "set_pan_tilt"]
-    )
+    actions: List[str] = ["base_actions", "camera_actions"]
+    base_actions: List[str] = ["go_to_relative", "go_to_absolute"]
+
+    camera_actions: List[str] = ["set_pan", "set_tilt", "set_pan_tilt"]
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class PyrobotConfig(HabitatBaseConfig):
     # types of robots supported:
-    robots: List[str] = field(default_factory=lambda: ["locobot"])
+    robots: List[str] = ["locobot"]
     robot: str = "locobot"
-    sensors: Dict[str, PyrobotSensor] = field(
-        default_factory=lambda: {
-            "rgb_sensor": PyrobotRGBSensorConfig(),
-            "depth_sensor": PyrobotDepthSensorConfig(),
-            "bump_sensor": PyrobotBumpSensorConfig(),
-        }
-    )
+    sensors: Dict[str, PyrobotSensor] = {
+        "rgb_sensor": PyrobotRGBSensorConfig(),
+        "depth_sensor": PyrobotDepthSensorConfig(),
+        "bump_sensor": PyrobotBumpSensorConfig(),
+    }
     base_controller: str = "proportional"
     base_planner: str = "none"
     locobot: LocobotConfig = LocobotConfig()
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class DatasetConfig(HabitatBaseConfig):
     r"""Configuration for the dataset of the task.
 
@@ -1198,23 +1185,23 @@ class DatasetConfig(HabitatBaseConfig):
     type: str = "PointNav-v1"
     split: str = "train"
     scenes_dir: str = "data/scene_datasets"
-    content_scenes: List[str] = field(default_factory=lambda: ["*"])
+    content_scenes: List[str] = ["*"]
     data_path: str = (
         "data/datasets/pointnav/"
         "habitat-test-scenes/v1/{split}/{split}.json.gz"
     )
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class GymConfig(HabitatBaseConfig):
     auto_name: str = ""
     obs_keys: Optional[List[str]] = None
     action_keys: Optional[List[str]] = None
-    achieved_goal_keys: List = field(default_factory=list)
-    desired_goal_keys: List[str] = field(default_factory=list)
+    achieved_goal_keys: List = []
+    desired_goal_keys: List[str] = []
 
 
-@dataclass
+@attr.s(auto_attribs=True, slots=True)
 class HabitatConfig(HabitatBaseConfig):
     r"""
     The entry point for the configuration of Habitat. It holds the environment, simulator, task and dataset configurations.
@@ -1230,7 +1217,7 @@ class HabitatConfig(HabitatBaseConfig):
     # The dependencies for launching the GymRegistryEnv environments.
     # Modules listed here will be imported prior to making the environment with
     # gym.make()
-    env_task_gym_dependencies: List = field(default_factory=list)
+    env_task_gym_dependencies: List = []
     # The key of the gym environment in the registry to use in GymRegistryEnv
     # for example: `Cartpole-v0`
     env_task_gym_id: str = ""

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -173,7 +173,7 @@ class HabitatSimDepthSensor(DepthSensor, HabitatSimSensor):
                 obs, axis=2
             )  # make depth observation a 3D array
         else:
-            obs = obs.clamp(self.cmin_depth_value, self.max_depth_value)  # type: ignore[attr-defined, unreachable]
+            obs = obs.clamp(self.min_depth_value, self.max_depth_value)  # type: ignore[attr-defined, unreachable]
 
             obs = obs.unsqueeze(-1)  # type: ignore[attr-defined]
 

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -149,6 +149,7 @@ class HabitatSimDepthSensor(DepthSensor, HabitatSimSensor):
         else:
             self.min_depth_value = config.min_depth
             self.max_depth_value = config.max_depth
+        self.normalize_depth = config.normalize_depth
 
         super().__init__(config=config)
 
@@ -166,20 +167,20 @@ class HabitatSimDepthSensor(DepthSensor, HabitatSimSensor):
         obs = cast(Optional[VisualObservation], sim_obs.get(self.uuid, None))
         check_sim_obs(obs, self)
         if isinstance(obs, np.ndarray):
-            obs = np.clip(obs, self.config.min_depth, self.config.max_depth)
+            obs = np.clip(obs, self.min_depth_value, self.max_depth_value)
 
             obs = np.expand_dims(
                 obs, axis=2
             )  # make depth observation a 3D array
         else:
-            obs = obs.clamp(self.config.min_depth, self.config.max_depth)  # type: ignore[attr-defined, unreachable]
+            obs = obs.clamp(self.cmin_depth_value, self.max_depth_value)  # type: ignore[attr-defined, unreachable]
 
             obs = obs.unsqueeze(-1)  # type: ignore[attr-defined]
 
-        if self.config.normalize_depth:
+        if self.normalize_depth:
             # normalize depth observation to [0, 1]
-            obs = (obs - self.config.min_depth) / (
-                self.config.max_depth - self.config.min_depth
+            obs = (obs - self.min_depth_value) / (
+                self.max_depth_value - self.min_depth_value
             )
 
         return obs

--- a/habitat-lab/habitat/tasks/rearrange/actions/robot_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/robot_action.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-
 from habitat.core.embodied_task import SimulatorTaskAction
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
 
@@ -14,12 +9,21 @@ class RobotAction(SimulatorTaskAction):
 
     _sim: RearrangeSim
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)
+        if "agent" not in self._config or self._config.agent is None:
+            self._agent_index = 0
+            self._multi_agent = False
+        else:
+            self._agent_index = self._config.agent
+            self._multi_agent = True
+
     @property
     def _robot_mgr(self):
         """
         Underlying robot mananger for the robot instance the action is attached to.
         """
-        return self._sim.robots_mgr[self._config.agent_index]
+        return self._sim.robots_mgr[self._agent_index]
 
     @property
     def _ik_helper(self):
@@ -49,4 +53,6 @@ class RobotAction(SimulatorTaskAction):
         Returns the action prefix to go in front of sensor / action names if
         there are multiple agents.
         """
-        return f"agent_{self._config.agent_index}_"
+        if not self._multi_agent:
+            return ""
+        return f"agent_{self._agent_index}_"

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_grasp_manager.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_grasp_manager.py
@@ -42,6 +42,8 @@ class RearrangeGraspManager:
         self._config = config
         self._managed_robot = robot
 
+        self._kinematic_mode = self._sim.habitat_config.kinematic_mode
+
     def reconfigure(self) -> None:
         """Removes any existing constraints managed by this structure.
         Called from _sim.reconfigure().
@@ -101,10 +103,7 @@ class RearrangeGraspManager:
             if dist >= self._leave_info[1]:
                 rigid_obj.override_collision_group(CollisionGroups.Default)
                 self._leave_info = None
-        if (
-            self._sim.habitat_config.kinematic_mode
-            and self._snapped_obj_id is not None
-        ):
+        if self._kinematic_mode and self._snapped_obj_id is not None:
             self.update_object_to_grasp()
 
     def desnap(self, force=False) -> None:
@@ -186,7 +185,7 @@ class RearrangeGraspManager:
         marker = self._sim.get_marker(marker_name)
         self._snapped_marker_id = marker_name
         self._managed_robot.open_gripper()
-        if self._sim.habitat_config.kinematic_mode:
+        if self._kinematic_mode:
             return
 
         self._snap_constraints = [
@@ -311,7 +310,7 @@ class RearrangeGraspManager:
 
         self._managed_robot.open_gripper()
 
-        if self._sim.habitat_config.kinematic_mode:
+        if self._kinematic_mode:
             return
 
         # Set collision group to GraspedObject so that it doesn't collide

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
@@ -438,7 +438,9 @@ class GfxReplayMeasure(Measure):
 
     def __init__(self, sim, config, *args, **kwargs):
         self._sim = sim
-        self._config = config
+        self._enable_gfx_replay_save = (
+            self._sim.sim_config.sim_cfg.enable_gfx_replay_save
+        )
         super().__init__(**kwargs)
 
     @staticmethod
@@ -450,10 +452,7 @@ class GfxReplayMeasure(Measure):
         self.update_metric(*args, **kwargs)
 
     def update_metric(self, *args, task, **kwargs):
-        if (
-            not task._is_episode_active
-            and self._sim.sim_config.sim_cfg.enable_gfx_replay_save
-        ):
+        if not task._is_episode_active and self._enable_gfx_replay_save:
             self._metric = (
                 self._sim.gfx_replay_manager.write_saved_keyframes_to_string()
             )
@@ -461,7 +460,7 @@ class GfxReplayMeasure(Measure):
             self._metric = ""
 
     def get_metric(self, force_get=False):
-        if force_get and self._sim.sim_config.sim_cfg.enable_gfx_replay_save:
+        if force_get and self._enable_gfx_replay_save:
             return (
                 self._sim.gfx_replay_manager.write_saved_keyframes_to_string()
             )
@@ -479,6 +478,7 @@ class ObjAtGoal(Measure):
 
     def __init__(self, *args, sim, config, task, **kwargs):
         self._config = config
+        self._succ_thresh = self._config.succ_thresh
         super().__init__(*args, sim=sim, config=config, task=task, **kwargs)
 
     @staticmethod
@@ -506,7 +506,7 @@ class ObjAtGoal(Measure):
         ].get_metric()
 
         self._metric = {
-            str(idx): dist < self._config.succ_thresh
+            str(idx): dist < self._succ_thresh
             for idx, dist in obj_to_goal_dists.items()
         }
 
@@ -692,6 +692,8 @@ class RobotForce(UsesRobotInterface, Measure):
         self._sim = sim
         self._config = config
         self._task = task
+        self._count_obj_collisions = self._task._config.count_obj_collisions
+        self._min_force = self._config.min_force
         super().__init__(*args, sim=sim, config=config, task=task, **kwargs)
 
     @staticmethod
@@ -719,14 +721,14 @@ class RobotForce(UsesRobotInterface, Measure):
         robot_force, _, overall_force = self._task.get_coll_forces(
             self.robot_id
         )
-        if self._task._config.count_obj_collisions:
+        if self._count_obj_collisions:
             self._cur_force = overall_force
         else:
             self._cur_force = robot_force
 
         if self._prev_force is not None:
             self._add_force = self._cur_force - self._prev_force
-            if self._add_force > self._config.min_force:
+            if self._add_force > self._min_force:
                 self._accum_force += self._add_force
                 self._prev_force = self._cur_force
             elif self._add_force < 0.0:
@@ -773,6 +775,8 @@ class ForceTerminate(Measure):
     def __init__(self, *args, sim, config, task, **kwargs):
         self._sim = sim
         self._config = config
+        self._max_accum_force = self._config.max_accum_force
+        self._max_instant_force = self._config.max_instant_force
         self._task = task
         super().__init__(*args, sim=sim, config=config, task=task, **kwargs)
 
@@ -803,20 +807,20 @@ class ForceTerminate(Measure):
         accum_force = force_info["accum"]
         instant_force = force_info["instant"]
         if (
-            self._config.max_accum_force > 0
-            and accum_force > self._config.max_accum_force
+            self._max_instant_force > 0
+            and accum_force > self._max_instant_force
         ):
             rearrange_logger.debug(
-                f"Force threshold={self._config.max_accum_force} exceeded with {accum_force}, ending episode"
+                f"Force threshold={self._max_instant_force} exceeded with {accum_force}, ending episode"
             )
             self._task.should_end = True
             self._metric = True
         elif (
-            self._config.max_instant_force > 0
-            and instant_force > self._config.max_instant_force
+            self._max_instant_force > 0
+            and instant_force > self._max_instant_force
         ):
             rearrange_logger.debug(
-                f"Force instant threshold={self._config.max_instant_force} exceeded with {instant_force}, ending episode"
+                f"Force instant threshold={self._max_instant_force} exceeded with {instant_force}, ending episode"
             )
             self._task.should_end = True
             self._metric = True
@@ -862,7 +866,8 @@ class RearrangeReward(UsesRobotInterface, Measure):
         self._sim = sim
         self._config = config
         self._task = task
-
+        self._force_pen = self._config.force_pen
+        self._max_force_pen = self._config.max_force_pen
         super().__init__(*args, sim=sim, config=config, task=task, **kwargs)
 
     def reset_metric(self, *args, episode, task, observations, **kwargs):
@@ -909,8 +914,8 @@ class RearrangeReward(UsesRobotInterface, Measure):
         reward -= max(
             0,  # This penalty is always positive
             min(
-                self._config.force_pen * force_metric.add_force,
-                self._config.max_force_pen,
+                self._force_pen * force_metric.add_force,
+                self._max_force_pen,
             ),
         )
         return reward

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -110,6 +110,17 @@ class RearrangeSim(HabitatSim):
 
         self.robots_mgr = RobotManager(self.habitat_config, self)
 
+        self._debug_render_robot = self.habitat_config.debug_render_robot
+        self._debug_render_goal = self.habitat_config.debug_render_goal
+        self._debug_render = self.habitat_config.debug_render
+        self._concur_render = self.habitat_config.concur_render
+        self._enable_gfx_replay_save = (
+            self.habitat_config.habitat_sim_v0.enable_gfx_replay_save
+        )
+        self._needs_markers = self.habitat_config.needs_markers
+        self._update_robot = self.habitat_config.update_robot
+        self._step_physics = self.habitat_config.step_physics
+
     @property
     def robot(self):
         if len(self.robots_mgr) > 1:
@@ -140,7 +151,7 @@ class RearrangeSim(HabitatSim):
         return target_trans
 
     def _try_acquire_context(self):
-        if self.habitat_config.concur_render:
+        if self._concur_render:
             self.renderer.acquire_gl_context()
 
     def sleep_all_objects(self):
@@ -488,7 +499,7 @@ class RearrangeSim(HabitatSim):
         obj_attr_mgr = self.get_object_template_manager()
         for target_handle, transform in self._targets.items():
             # Visualize the goal of the object
-            if self.habitat_config.debug_render_goal:
+            if self._debug_render_goal:
                 new_target_handle = (
                     target_handle.split("_:")[0] + ".object_config.json"
                 )
@@ -632,8 +643,8 @@ class RearrangeSim(HabitatSim):
     def step(self, action: Union[str, int]) -> Observations:
         rom = self.get_rigid_object_manager()
 
-        if self.habitat_config.debug_render:
-            if self.habitat_config.debug_render_robot:
+        if self._debug_render:
+            if self._debug_render_robot:
                 self.robots_mgr.update_debug()
             rom = self.get_rigid_object_manager()
             self._try_acquire_context()
@@ -663,7 +674,7 @@ class RearrangeSim(HabitatSim):
 
         self.maybe_update_robot()
 
-        if self.habitat_config.concur_render:
+        if self._concur_render:
             self._prev_sim_obs = self.start_async_render()
 
             for _ in range(self.ac_freq_ratio):
@@ -677,14 +688,14 @@ class RearrangeSim(HabitatSim):
             self._prev_sim_obs = self.get_sensor_observations()
             obs = self._sensor_suite.get_observations(self._prev_sim_obs)
 
-        if self.habitat_config.habitat_sim_v0.enable_gfx_replay_save:
+        if self._enable_gfx_replay_save:
             self.gfx_replay_manager.save_keyframe()
 
-        if self.habitat_config.needs_markers:
+        if self._needs_markers:
             self._update_markers()
 
         # TODO: Make debug cameras more flexible
-        if "robot_third_rgb" in obs and self.habitat_config.debug_render:
+        if "robot_third_rgb" in obs and self._debug_render:
             self._try_acquire_context()
             for k, (pos, r) in add_back_viz_objs.items():
                 viz_id = self.viz_ids[k]
@@ -708,7 +719,7 @@ class RearrangeSim(HabitatSim):
         things, this will set the robot's sensors' positions to their new
         positions.
         """
-        if self.habitat_config.update_robot:
+        if self._update_robot:
             self.robots_mgr.update_robots()
 
     def visualize_position(
@@ -753,7 +764,7 @@ class RearrangeSim(HabitatSim):
         """
 
         # optionally step physics and update the robot for benchmarking purposes
-        if self.habitat_config.step_physics:
+        if self._step_physics:
             self.step_world(dt)
 
     def get_targets(self) -> Tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
## Motivation and Context

It seems checking if a key is in a Hydra DictConfig is rather slow. We cache the agent index to avoid having to recompute it every time.

Findings: If you have to access a configuration field several times per second, please store the value somewhere instead of accessing the configuration. The configuration will not change, I promise. 

1 process interact benchmark
Before regression of November 15 2022 : 168.11183922196446
After regression of November 15 2022 : 134.35855893433697
After first commit of this PR : 158.04943632647434
After second commit of this PR : 163.95664144856636

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
