### PR TITLE
[BugFix] InstanceImageNav dist to viewpoint threshold

### DIFF
--- a/habitat-lab/habitat/config/habitat/task/instance_imagenav.yaml
+++ b/habitat-lab/habitat/config/habitat/task/instance_imagenav.yaml
@@ -29,3 +29,5 @@ goal_sensor_uuid: instance_imagegoal
 measurements:
   distance_to_goal:
     distance_to: VIEW_POINTS
+  success:
+    success_distance: 0.1


### PR DESCRIPTION
## Motivation and Context

This PR updates the success distance to viewpoint to 0.1m as mentioned in the [InstanceImageNav paper](https://arxiv.org/pdf/2211.15876.pdf). Current config is using the default distance to viewpoint which is 0.2m. See the attached screenshots

![Screenshot from 2023-02-10 12-35-06](https://user-images.githubusercontent.com/16323427/218158590-59563351-8e3f-4753-abce-5b90e81803b3.png)

![Screenshot from 2023-02-10 12-35-22](https://user-images.githubusercontent.com/16323427/218158611-7e1019c5-0d9b-4119-af64-560044de400b.png)

## How Has This Been Tested

Locally

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
