### PR TITLE
New Interactive Play Script

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -78,7 +78,7 @@ class EnvironmentConfig(HabitatBaseConfig):
 @attr.s(auto_attribs=True, slots=True)
 class ActionConfig(HabitatBaseConfig):
     type: str = MISSING
-    agent_index: int = 0
+    agent_index: Optional[int] = None
 
 
 @attr.s(auto_attribs=True, slots=True)

--- a/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
+++ b/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
@@ -40,10 +40,16 @@ actions:
   # Actions are defined per agent. Unlike the sensors, actions are not
   # automatically duplicated per agent.
   agent_0_arm_action:
+    agent_index : 0
     grip_controller: MagicGraspAction
+  agent_0_base_velocity:
+    agent_index : 0
+  agent_0_rearrange_stop:
+    agent_index : 0
+
   agent_1_arm_action:
-    grip_controller: MagicGraspAction
     agent_index : 1
+    grip_controller: MagicGraspAction
   agent_1_base_velocity:
     agent_index : 1
   agent_1_rearrange_stop:

--- a/habitat-lab/habitat/tasks/rearrange/actions/robot_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/robot_action.py
@@ -11,11 +11,11 @@ class RobotAction(SimulatorTaskAction):
 
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
-        if "agent" not in self._config or self._config.agent is None:
+        if self._config.agent_index is None:
             self._agent_index = 0
             self._multi_agent = False
         else:
-            self._agent_index = self._config.agent
+            self._agent_index = self._config.agent_index
             self._multi_agent = True
 
     @property


### PR DESCRIPTION

- Allow interacting with a Habitat Baselines policy in the interactive play script for multi-agent tasks.
- Refactored the interactive play script. 
- Remove saving arm actions and the manual 3rd PoV camera. The GFX replay functionality handles this and more.

To run: `python examples/interactive_play.py  --disable-inverse-kinematics --cfg habitat-lab/habitat/config/benchmark/rearrange/rearrange_easy_multi_agent.yaml --never-end habitat.dataset.split=minival`