### PR TITLE
Changing gym registration to be faster

### DIFF
--- a/examples/tutorials/colabs/habitat2_gym_tutorial.ipynb
+++ b/examples/tutorials/colabs/habitat2_gym_tutorial.ipynb
@@ -123,7 +123,7 @@
     "    * `HabitatPrepareGroceries-v0`\n",
     "    * `HabitatSetTable-v0`\n",
     "\n",
-    "The Gym environments are automatically registered from the RL training configurations under [\"habitat-lab/habitat/config/benchmark/rearrange\"](https://github.com/facebookresearch/habitat-lab/tree/main/habitat-lab/habitat/config/benchmark/rearrange). The `habitat.gym.auto_name` key in the YAML file determines the `[Task Name]`. The observation keys in `habitat.gym.obs_keys` are what is returned in the observation space. If the the observations are a set of 1D arrays, then the observation space is automatically flattened. For example, in `HabitatReachState-v0` the observation space is `habitat.gym.obs_keys = ['joint', 'relative_resting_position']`. `joint` is a 7D array and `relative_resting_position` is a 3D array. These two arrays are concatenated automatically to give a `10D` observation space. On the other hand, in environments with image observations, the observation is returned as a dictionary.\n",
+    "The Gym environments are automatically registered from the RL training configurations under [\"habitat-lab/habitat/config/benchmark/rearrange\"](https://github.com/facebookresearch/habitat-lab/tree/main/habitat-lab/habitat/config/benchmark/rearrange). The observation keys in `habitat.gym.obs_keys` are what is returned in the observation space.\n",
     "\n",
     "An example of these different observation spaces is demonstrated below:"
    ]

--- a/examples/tutorials/nb_python/habitat2_gym_tutorial.py
+++ b/examples/tutorials/nb_python/habitat2_gym_tutorial.py
@@ -104,7 +104,7 @@ env.close()
 #     * `HabitatPrepareGroceries-v0`
 #     * `HabitatSetTable-v0`
 #
-# The Gym environments are automatically registered from the RL training configurations under ["habitat-lab/habitat/config/benchmark/rearrange"](https://github.com/facebookresearch/habitat-lab/tree/main/habitat-lab/habitat/config/benchmark/rearrange). The `habitat.gym.auto_name` key in the YAML file determines the `[Task Name]`. The observation keys in `habitat.gym.obs_keys` are what is returned in the observation space. If the the observations are a set of 1D arrays, then the observation space is automatically flattened. For example, in `HabitatReachState-v0` the observation space is `habitat.gym.obs_keys = ['joint', 'relative_resting_position']`. `joint` is a 7D array and `relative_resting_position` is a 3D array. These two arrays are concatenated automatically to give a `10D` observation space. On the other hand, in environments with image observations, the observation is returned as a dictionary.
+# The Gym environments are automatically registered from the RL training configurations under ["habitat-lab/habitat/config/benchmark/rearrange"](https://github.com/facebookresearch/habitat-lab/tree/main/habitat-lab/habitat/config/benchmark/rearrange). The observation keys in `habitat.gym.obs_keys` are what is returned in the observation space.
 #
 # An example of these different observation spaces is demonstrated below:
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/nn_skill.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/nn_skill.py
@@ -183,9 +183,7 @@ class NnSkillPolicy(SkillPolicy):
 
         for k in config.obs_skill_inputs:
             if k not in filtered_obs_space.spaces:
-                raise ValueError(
-                    f"Could not find {k} for skill {policy_cfg.habitat.gym.auto_name}"
-                )
+                raise ValueError(f"Could not find {k} for skill")
             space = filtered_obs_space.spaces[k]
             # There is always a 3D position
             filtered_obs_space.spaces[k] = truncate_obs_space(space, 3)

--- a/habitat-lab/habitat/config/README.md
+++ b/habitat-lab/habitat/config/README.md
@@ -284,7 +284,6 @@ habitat:
     - '*'
     data_path: data/datasets/pointnav/gibson/v1/{split}/{split}.json.gz
   gym:
-    auto_name: ''
     obs_keys: null
     action_keys: null
     achieved_goal_keys: []

--- a/habitat-lab/habitat/config/benchmark/rearrange/close_cab.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/close_cab.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: CloseCab
     obs_keys:
       - robot_head_depth
       - joint

--- a/habitat-lab/habitat/config/benchmark/rearrange/close_fridge.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/close_fridge.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: CloseFridge
     obs_keys:
       - robot_head_depth
       - joint

--- a/habitat-lab/habitat/config/benchmark/rearrange/nav_to_obj.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/nav_to_obj.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: NavToObj
     obs_keys:
       - robot_head_depth
       - goal_to_agent_gps_compass

--- a/habitat-lab/habitat/config/benchmark/rearrange/open_cab.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/open_cab.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: OpenCab
     obs_keys:
       - robot_head_depth
       - joint

--- a/habitat-lab/habitat/config/benchmark/rearrange/open_fridge.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/open_fridge.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: OpenFridge
     obs_keys:
       - robot_head_depth
       - joint

--- a/habitat-lab/habitat/config/benchmark/rearrange/pick.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/pick.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: Pick
     obs_keys:
       - robot_head_depth
       - obj_start_sensor

--- a/habitat-lab/habitat/config/benchmark/rearrange/place.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/place.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: Place
     obs_keys:
       - robot_head_depth
       - obj_goal_sensor

--- a/habitat-lab/habitat/config/benchmark/rearrange/prepare_groceries.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/prepare_groceries.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: PrepareGroceries
     obs_keys:
       - robot_head_depth
       - relative_resting_position

--- a/habitat-lab/habitat/config/benchmark/rearrange/reach_state.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/reach_state.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: ReachState
     obs_keys:
       - joint
       - relative_resting_position

--- a/habitat-lab/habitat/config/benchmark/rearrange/rearrange.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/rearrange.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: Rearrange
     obs_keys:
       - robot_head_depth
       - relative_resting_position

--- a/habitat-lab/habitat/config/benchmark/rearrange/rearrange_easy.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/rearrange_easy.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: RearrangeEasy
     obs_keys:
       - robot_head_depth
       - relative_resting_position

--- a/habitat-lab/habitat/config/benchmark/rearrange/rearrange_easy_multi_agent.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/rearrange_easy_multi_agent.yaml
@@ -10,7 +10,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: RearrangeEasyMultiAgent
     obs_keys:
       - agent_0_robot_head_depth
       - agent_1_robot_head_depth

--- a/habitat-lab/habitat/config/benchmark/rearrange/set_table.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/set_table.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: SetTable
     obs_keys:
       - robot_head_depth
       - relative_resting_position

--- a/habitat-lab/habitat/config/benchmark/rearrange/tidy_house.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/tidy_house.yaml
@@ -9,7 +9,6 @@ defaults:
 
 habitat:
   gym:
-    auto_name: TidyHouse
     obs_keys:
     - robot_head_depth
     - relative_resting_position

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1208,7 +1208,6 @@ class DatasetConfig(HabitatBaseConfig):
 
 @attr.s(auto_attribs=True, slots=True)
 class GymConfig(HabitatBaseConfig):
-    auto_name: str = ""
     obs_keys: Optional[List[str]] = None
     action_keys: Optional[List[str]] = None
     achieved_goal_keys: List = []

--- a/test/test_gym_wrapper.py
+++ b/test/test_gym_wrapper.py
@@ -6,7 +6,6 @@
 
 import importlib
 import sys
-from glob import glob
 
 import gym
 import gym.spaces as spaces
@@ -17,7 +16,7 @@ import pytest
 import habitat.gym
 import habitat.utils.env_utils
 from habitat.core.environments import get_env_class
-from habitat.gym.gym_definitions import _get_env_name
+from habitat.gym.gym_definitions import PRE_REGISTERED_GYM_TASKS, _get_env_name
 
 # using mock for pygame to avoid having a pygame windows
 sys.modules["pygame"] = mock.MagicMock()
@@ -164,21 +163,16 @@ def test_full_gym_wrapper(config_file, override_options):
 
 
 @pytest.mark.parametrize(
-    "test_cfg_path",
-    list(
-        glob("habitat-lab/habitat/config/benchmark/**/*.yaml", recursive=True),
-    ),
+    "env_name",
+    list(PRE_REGISTERED_GYM_TASKS.keys()),
 )
-def test_auto_gym_wrapper(test_cfg_path):
+def test_auto_gym_wrapper(env_name):
     """
     Test all defined automatic Gym wrappers work
     """
-    config = habitat.get_config(test_cfg_path)
-    if "gym" not in config.habitat or config.habitat.gym.auto_name == "":
-        pytest.skip(f"Gym environment name isn't set for {test_cfg_path}.")
     pytest.importorskip("pygame")
     for prefix in ["", "Render"]:
-        full_gym_name = f"Habitat{prefix}{config.habitat.gym.auto_name}-v0"
+        full_gym_name = f"Habitat{prefix}{env_name}-v0"
 
         hab_gym = gym.make(
             full_gym_name,


### PR DESCRIPTION
## Motivation and Context
Using gym.auto_name forces us to parse all files, load them and check the auto_name value. This is very slow. This change makes it such that the auto_gym environments are defined in a dictionary `PRE_REGISTERED_GYM_TASKS` in gym_definitions.py


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
