### PR TITLE
Velocity controller updates

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -136,6 +136,14 @@ class StopActionConfig(ActionConfig):
 
 
 @attr.s(auto_attribs=True, slots=True)
+class VelocityStopActionConfig(ActionConfig):
+    r"""
+    In Navigation tasks only, the velocity stop action is an action that takes continuous space input.
+    """
+    type: str = "VelocityStopAction"
+
+
+@attr.s(auto_attribs=True, slots=True)
 class EmptyActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, the pass action. The robot will do nothing.
@@ -204,7 +212,6 @@ class VelocityControlActionConfig(ActionConfig):
     time_step: float = 0.1  # seconds
     enable_scale_convert: bool = False
     # Stop criteria
-    use_stop_heuristic: bool = False
     min_abs_lin_speed: float = 0.025  # meters/sec
     min_abs_ang_speed: float = 0.018  # rad/sec (1 deg/sec)
 
@@ -1538,6 +1545,12 @@ cs.store(
     node=StopActionConfig,
 )
 cs.store(
+    package="habitat.task.actions.velocity_stop",
+    group="habitat/task/actions",
+    name="velocity_stop",
+    node=VelocityStopActionConfig,
+)
+cs.store(
     package="habitat.task.actions.move_forward",
     group="habitat/task/actions",
     name="move_forward",
@@ -1608,12 +1621,6 @@ cs.store(
     group="habitat/task/actions",
     name="base_velocity",
     node=BaseVelocityActionConfig,
-)
-cs.store(
-    package="habitat.task.actions.velocity_control",
-    group="habitat/task/actions",
-    name="velocity_control",
-    node=VelocityControlActionConfig,
 )
 cs.store(
     package="habitat.task.actions.empty",


### PR DESCRIPTION
## Motivation and Context

We need to have a continuous equivalent of the discrete STOP action that can be trained with the new ObjectNav policy.
I have added a new action called velocity_stop to refer to the continuous action space STOP. The new stop needs an input argument which should be +ve if the agent needs to stop. 

Other changes:
- Removed the old heuristic for stopping
- Removed the `cs.store` related to the VelocityControlActionConfig since it was being repeated twice.
- Changed ActionSpace to spaces.Dict() since ActionSpace is considered a discrete action space where you can choose between the different actions provided to it

## How Has This Been Tested

By starting the training of an agent.

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
