### PR TITLE
Roll back moving to attr.s in #1120

### DIFF
--- a/habitat-baselines/habitat_baselines/config/default_structured_configs.py
+++ b/habitat-baselines/habitat_baselines/config/default_structured_configs.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-import attr
 from hydra.core.config_store import ConfigStore
 from omegaconf import MISSING
 
@@ -15,12 +15,12 @@ from habitat.config.default_structured_configs import SimulatorSensorConfig
 cs = ConfigStore.instance()
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatBaselinesBaseConfig:
     pass
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class WBConfig(HabitatBaselinesBaseConfig):
     """Weights and Biases config"""
 
@@ -35,7 +35,7 @@ class WBConfig(HabitatBaselinesBaseConfig):
     run_name: str = ""
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EvalConfig(HabitatBaselinesBaseConfig):
     # The split to evaluate on
     split: str = "val"
@@ -44,13 +44,16 @@ class EvalConfig(HabitatBaselinesBaseConfig):
     # The number of time to run each episode through evaluation.
     # Only works when evaluating on all episodes.
     evals_per_ep: int = 1
-    video_option: List[
-        str
-    ] = []  # available options are "disk" and "tensorboard"
-    extra_sim_sensors: Dict[str, SimulatorSensorConfig] = dict()
+    video_option: List[str] = field(
+        # available options are "disk" and "tensorboard"
+        default_factory=list
+    )
+    extra_sim_sensors: Dict[str, SimulatorSensorConfig] = field(
+        default_factory=dict
+    )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PreemptionConfig(HabitatBaselinesBaseConfig):
     # Append the slurm job ID to the resume state filename if running
     # a slurm job. This is useful when you want to have things from a different
@@ -63,7 +66,7 @@ class PreemptionConfig(HabitatBaselinesBaseConfig):
     save_state_batch_only: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ActionDistributionConfig(HabitatBaselinesBaseConfig):
     use_log_std: bool = True
     use_softplus: bool = False
@@ -82,12 +85,12 @@ class ActionDistributionConfig(HabitatBaselinesBaseConfig):
     scheduled_std: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ObsTransformConfig(HabitatBaselinesBaseConfig):
     type: str = MISSING
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CenterCropperConfig(ObsTransformConfig):
     type: str = "CenterCropper"
     height: int = 256
@@ -108,7 +111,7 @@ cs.store(
 )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ResizeShortestEdgeConfig(ObsTransformConfig):
     type: str = "ResizeShortestEdge"
     size: int = 256
@@ -129,19 +132,21 @@ cs.store(
 )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class Cube2EqConfig(ObsTransformConfig):
     type: str = "CubeMap2Equirect"
     height: int = 256
     width: int = 512
-    sensor_uuids: List[str] = [
-        "BACK",
-        "DOWN",
-        "FRONT",
-        "LEFT",
-        "RIGHT",
-        "UP",
-    ]
+    sensor_uuids: List[str] = field(
+        default_factory=lambda: [
+            "BACK",
+            "DOWN",
+            "FRONT",
+            "LEFT",
+            "RIGHT",
+            "UP",
+        ]
+    )
 
 
 cs.store(
@@ -152,21 +157,23 @@ cs.store(
 )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class Cube2FishConfig(ObsTransformConfig):
     type: str = "CubeMap2Fisheye"
     height: int = 256
     width: int = 256
     fov: int = 180
     params: Tuple[float, ...] = (0.2, 0.2, 0.2)
-    sensor_uuids: List[str] = [
-        "BACK",
-        "DOWN",
-        "FRONT",
-        "LEFT",
-        "RIGHT",
-        "UP",
-    ]
+    sensor_uuids: List[str] = field(
+        default_factory=lambda: [
+            "BACK",
+            "DOWN",
+            "FRONT",
+            "LEFT",
+            "RIGHT",
+            "UP",
+        ]
+    )
 
 
 cs.store(
@@ -177,10 +184,10 @@ cs.store(
 )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class AddVirtualKeysConfig(ObsTransformConfig):
     type: str = "AddVirtualKeys"
-    virtual_keys: Dict[str, int] = dict()
+    virtual_keys: Dict[str, int] = field(default_factory=dict)
 
 
 cs.store(
@@ -191,19 +198,21 @@ cs.store(
 )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class Eq2CubeConfig(ObsTransformConfig):
     type: str = "Equirect2CubeMap"
     height: int = 256
     width: int = 256
-    sensor_uuids: List[str] = [
-        "BACK",
-        "DOWN",
-        "FRONT",
-        "LEFT",
-        "RIGHT",
-        "UP",
-    ]
+    sensor_uuids: List[str] = field(
+        default_factory=lambda: [
+            "BACK",
+            "DOWN",
+            "FRONT",
+            "LEFT",
+            "RIGHT",
+            "UP",
+        ]
+    )
 
 
 cs.store(
@@ -214,7 +223,7 @@ cs.store(
 )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HrlDefinedSkillConfig(HabitatBaselinesBaseConfig):
     """
     Defines a low-level skill to be used in the hierarchical policy.
@@ -234,7 +243,7 @@ class HrlDefinedSkillConfig(HabitatBaselinesBaseConfig):
     # If true, this willapply the post-conditions of the skill after it
     # terminates.
     apply_postconds: bool = False
-    obs_skill_inputs: List[str] = list()
+    obs_skill_inputs: List[str] = field(default_factory=list)
     obs_skill_input_dim: int = 3
     start_zone_radius: float = 0.3
     # For the oracle navigation skill
@@ -248,25 +257,27 @@ class HrlDefinedSkillConfig(HabitatBaselinesBaseConfig):
     pddl_action_names: Optional[List[str]] = None
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HierarchicalPolicyConfig(HabitatBaselinesBaseConfig):
     high_level_policy: Dict[str, Any] = MISSING
-    defined_skills: Dict[str, HrlDefinedSkillConfig] = dict()
-    use_skills: Dict[str, str] = dict()
+    defined_skills: Dict[str, HrlDefinedSkillConfig] = field(
+        default_factory=dict
+    )
+    use_skills: Dict[str, str] = field(default_factory=dict)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PolicyConfig(HabitatBaselinesBaseConfig):
     name: str = "PointNavResNetPolicy"
     action_distribution_type: str = "categorical"  # or 'gaussian'
     # If the list is empty, all keys will be included.
     # For gaussian action distribution:
     action_dist: ActionDistributionConfig = ActionDistributionConfig()
-    obs_transforms: Dict[str, ObsTransformConfig] = dict()
+    obs_transforms: Dict[str, ObsTransformConfig] = field(default_factory=dict)
     hierarchical_policy: HierarchicalPolicyConfig = MISSING
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PPOConfig(HabitatBaselinesBaseConfig):
     """Proximal policy optimization config"""
 
@@ -297,7 +308,7 @@ class PPOConfig(HabitatBaselinesBaseConfig):
     use_double_buffered_sampler: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class VERConfig(HabitatBaselinesBaseConfig):
     """Variable experience rollout config"""
 
@@ -306,12 +317,12 @@ class VERConfig(HabitatBaselinesBaseConfig):
     overlap_rollouts_and_learn: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class AuxLossConfig(HabitatBaselinesBaseConfig):
     pass
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CPCALossConfig(AuxLossConfig):
     """Action-conditional contrastive predictive coding loss"""
 
@@ -321,7 +332,7 @@ class CPCALossConfig(AuxLossConfig):
     loss_scale: float = 0.1
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DDPPOConfig(HabitatBaselinesBaseConfig):
     """Decentralized distributed proximal policy optimization config"""
 
@@ -344,7 +355,7 @@ class DDPPOConfig(HabitatBaselinesBaseConfig):
     force_distributed: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RLConfig(HabitatBaselinesBaseConfig):
     """Reinforcement learning config"""
 
@@ -353,16 +364,16 @@ class RLConfig(HabitatBaselinesBaseConfig):
     ppo: PPOConfig = PPOConfig()
     ddppo: DDPPOConfig = DDPPOConfig()
     ver: VERConfig = VERConfig()
-    auxiliary_losses: Dict[str, AuxLossConfig] = dict()
+    auxiliary_losses: Dict[str, AuxLossConfig] = field(default_factory=dict)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ProfilingConfig(HabitatBaselinesBaseConfig):
     capture_start_step: int = -1
     num_steps_to_capture: int = -1
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     # task config can be a list of configs like "A.yaml,B.yaml"
     # If habitat_baselines.evaluate is true, the run will be in evaluation mode
@@ -392,7 +403,7 @@ class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     log_file: str = "train.log"
     force_blind_policy: bool = False
     verbose: bool = True
-    eval_keys_to_include_in_name: List[str] = []
+    eval_keys_to_include_in_name: List[str] = field(default_factory=list)
     # For our use case, the CPU side things are mainly memory copies
     # and nothing of substantive compute. PyTorch has been making
     # more and more memory copies parallel, but that just ends up
@@ -411,17 +422,17 @@ class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     profiling: ProfilingConfig = ProfilingConfig()
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatBaselinesRLConfig(HabitatBaselinesConfig):
     rl: RLConfig = RLConfig()
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatBaselinesILConfig(HabitatBaselinesConfig):
-    il: Dict[str, Any] = dict()
+    il: Dict[str, Any] = field(default_factory=dict)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatBaselinesSPAConfig(HabitatBaselinesConfig):
     sense_plan_act: Any = MISSING
 

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-import attr
 from hydra.core.config_store import ConfigStore
 from omegaconf import II, MISSING
 
@@ -83,12 +83,12 @@ __all__ = [
 ]
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatBaseConfig:
     pass
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class IteratorOptionsConfig(HabitatBaseConfig):
     cycle: bool = True
     shuffle: bool = True
@@ -99,7 +99,7 @@ class IteratorOptionsConfig(HabitatBaseConfig):
     step_repetition_range: float = 0.2
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EnvironmentConfig(HabitatBaseConfig):
     r"""
     Some habitat environment configurations.
@@ -115,13 +115,13 @@ class EnvironmentConfig(HabitatBaseConfig):
 # -----------------------------------------------------------------------------
 # # Actions
 # -----------------------------------------------------------------------------
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ActionConfig(HabitatBaseConfig):
     type: str = MISSING
     agent_index: int = 0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class StopActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, the stop action is a discrete action. When called, the Agent
@@ -134,7 +134,7 @@ class StopActionConfig(ActionConfig):
     type: str = "StopAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EmptyActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, the pass action. The robot will do nothing.
@@ -145,7 +145,7 @@ class EmptyActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # NAVIGATION actions
 # -----------------------------------------------------------------------------
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class MoveForwardActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will move the robot forward by
@@ -154,7 +154,7 @@ class MoveForwardActionConfig(ActionConfig):
     type: str = "MoveForwardAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TurnLeftActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot to the left
@@ -163,7 +163,7 @@ class TurnLeftActionConfig(ActionConfig):
     type: str = "TurnLeftAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TurnRightActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot to the right
@@ -172,7 +172,7 @@ class TurnRightActionConfig(ActionConfig):
     type: str = "TurnRightAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class LookUpActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot's camera up
@@ -181,7 +181,7 @@ class LookUpActionConfig(ActionConfig):
     type: str = "LookUpAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class LookDownActionConfig(ActionConfig):
     r"""
     In Navigation tasks only, this discrete action will rotate the robot's camera down
@@ -190,18 +190,18 @@ class LookDownActionConfig(ActionConfig):
     type: str = "LookDownAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TeleportActionConfig(ActionConfig):
     type: str = "TeleportAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class VelocityControlActionConfig(ActionConfig):
     type: str = "VelocityAction"
     # meters/sec
-    lin_vel_range: List[float] = [0.0, 0.25]
+    lin_vel_range: List[float] = field(default_factory=lambda: [0.0, 0.25])
     # deg/sec
-    ang_vel_range: List[float] = [-10.0, 10.0]
+    ang_vel_range: List[float] = field(default_factory=lambda: [-10.0, 10.0])
     min_abs_lin_speed: float = 0.025  # meters/sec
     min_abs_ang_speed: float = 1.0  # # deg/sec
     time_step: float = 1.0  # seconds
@@ -210,7 +210,7 @@ class VelocityControlActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # REARRANGE actions
 # -----------------------------------------------------------------------------
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArmActionConfig(ActionConfig):
     r"""
     In Rearrangement tasks only, the action that will move the robot arm around. The action represents to delta angle (in radians) of each joint.
@@ -231,7 +231,7 @@ class ArmActionConfig(ActionConfig):
     render_ee_target: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class BaseVelocityActionConfig(ActionConfig):
     r"""
     In Rearrangement only. Corresponds to the base velocity. Contains two continuous actions, the first one controls forward and backward motion, the second the rotation.
@@ -243,7 +243,7 @@ class BaseVelocityActionConfig(ActionConfig):
     allow_back: bool = True
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RearrangeStopActionConfig(ActionConfig):
     r"""
     In rearrangement tasks only, if the robot calls this action, the task will end.
@@ -251,12 +251,12 @@ class RearrangeStopActionConfig(ActionConfig):
     type: str = "RearrangeStopAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PddlApplyActionConfig(ActionConfig):
     type: str = "PddlApplyAction"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class OracleNavActionConfig(ActionConfig):
     """
     Rearrangement Only, Oracle navigation action.
@@ -281,7 +281,7 @@ class OracleNavActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # EQA actions
 # -----------------------------------------------------------------------------
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class AnswerActionConfig(ActionConfig):
     type: str = "AnswerAction"
 
@@ -289,19 +289,19 @@ class AnswerActionConfig(ActionConfig):
 # -----------------------------------------------------------------------------
 # # TASK_SENSORS
 # -----------------------------------------------------------------------------
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class LabSensorConfig(HabitatBaseConfig):
     type: str = MISSING
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PointGoalSensorConfig(LabSensorConfig):
     type: str = "PointGoalSensor"
     goal_format: str = "POLAR"
     dimensionality: int = 2
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PointGoalWithGPSCompassSensorConfig(PointGoalSensorConfig):
     """
     Indicates the position of the point goal in the frame of reference of the robot.
@@ -310,7 +310,7 @@ class PointGoalWithGPSCompassSensorConfig(PointGoalSensorConfig):
     type: str = "PointGoalWithGPSCompassSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ObjectGoalSensorConfig(LabSensorConfig):
     r"""
     For Object Navigation tasks only. Generates a discrete observation containing
@@ -324,12 +324,12 @@ class ObjectGoalSensorConfig(LabSensorConfig):
     goal_spec_max_val: int = 50
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ImageGoalSensorConfig(LabSensorConfig):
     type: str = "ImageGoalSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class InstanceImageGoalSensorConfig(LabSensorConfig):
     r"""
     Used only by the InstanceImageGoal Navigation task. The observation is a rendered
@@ -338,7 +338,7 @@ class InstanceImageGoalSensorConfig(LabSensorConfig):
     type: str = "InstanceImageGoalSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class InstanceImageGoalHFOVSensorConfig(LabSensorConfig):
     r"""
     Used only by the InstanceImageGoal Navigation task. The observation is a single
@@ -348,12 +348,12 @@ class InstanceImageGoalHFOVSensorConfig(LabSensorConfig):
     type: str = "InstanceImageGoalHFOVSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HeadingSensorConfig(LabSensorConfig):
     type: str = "HeadingSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CompassSensorConfig(LabSensorConfig):
     r"""
     For Navigation tasks only. The observation of the
@@ -364,7 +364,7 @@ class CompassSensorConfig(LabSensorConfig):
     type: str = "CompassSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class GPSSensorConfig(LabSensorConfig):
     r"""
     For Navigation tasks only. The observation of the EpisodicGPSSensor are two float values
@@ -375,13 +375,13 @@ class GPSSensorConfig(LabSensorConfig):
     dimensionality: int = 2
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ProximitySensorConfig(LabSensorConfig):
     type: str = "ProximitySensor"
     max_detection_radius: float = 2.0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class JointSensorConfig(LabSensorConfig):
     r"""
     Rearrangement only. Returns the joint positions of the robot.
@@ -390,7 +390,7 @@ class JointSensorConfig(LabSensorConfig):
     dimensionality: int = 7
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EEPositionSensorConfig(LabSensorConfig):
     r"""
     Rearrangement only. the cartesian coordinates (3 floats) of the arm's end effector in the frame of reference of the robot's base.
@@ -398,7 +398,7 @@ class EEPositionSensorConfig(LabSensorConfig):
     type: str = "EEPositionSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class IsHoldingSensorConfig(LabSensorConfig):
     r"""
     Rearrangement only. A single float sensor with value 1.0 if the robot is grasping any object and 0.0 otherwise.
@@ -406,7 +406,7 @@ class IsHoldingSensorConfig(LabSensorConfig):
     type: str = "IsHoldingSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RelativeRestingPositionSensorConfig(LabSensorConfig):
     r"""
     Rearrangement only. Sensor for the relative position of the end-effector's resting position, relative to the end-effector's current position.
@@ -417,43 +417,43 @@ class RelativeRestingPositionSensorConfig(LabSensorConfig):
     type: str = "RelativeRestingPositionSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class JointVelocitySensorConfig(LabSensorConfig):
     type: str = "JointVelocitySensor"
     dimensionality: int = 7
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class OracleNavigationActionSensorConfig(LabSensorConfig):
     type: str = "OracleNavigationActionSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RestingPositionSensorConfig(LabSensorConfig):
     type: str = "RestingPositionSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArtJointSensorConfig(LabSensorConfig):
     type: str = "ArtJointSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class NavGoalSensorConfig(LabSensorConfig):
     type: str = "NavGoalSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArtJointSensorNoVelSensorConfig(LabSensorConfig):
     type: str = "ArtJointSensorNoVel"  # TODO: add "Sensor" suffix
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class MarkerRelPosSensorConfig(LabSensorConfig):
     type: str = "MarkerRelPosSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TargetStartSensorConfig(LabSensorConfig):
     r"""
     Rearrangement only. Returns the relative position from end effector to a target object that needs to be picked up.
@@ -463,14 +463,14 @@ class TargetStartSensorConfig(LabSensorConfig):
     dimensionality: int = 3
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TargetCurrentSensorConfig(LabSensorConfig):
     type: str = "TargetCurrentSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class GoalSensorConfig(LabSensorConfig):
     """
     Rearrangement only. Returns the relative position from end effector to a goal position in which the agent needs to place an object.
@@ -481,17 +481,17 @@ class GoalSensorConfig(LabSensorConfig):
     dimensionality: int = 3
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class NavGoalPointGoalSensorConfig(LabSensorConfig):
     type: str = "NavGoalPointGoalSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class GlobalPredicatesSensorConfig(LabSensorConfig):
     type: str = "GlobalPredicatesSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TargetStartGpsCompassSensorConfig(LabSensorConfig):
     r"""
     Rearrangement only. Returns the initial position of every object that needs to be rearranged in composite tasks, in 2D polar coordinates.
@@ -499,7 +499,7 @@ class TargetStartGpsCompassSensorConfig(LabSensorConfig):
     type: str = "TargetStartGpsCompassSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TargetGoalGpsCompassSensorConfig(LabSensorConfig):
     r"""
     Rearrangement only. Returns the desired goal position of every object that needs to be rearranged in composite tasks, in 2D polar coordinates.
@@ -507,42 +507,42 @@ class TargetGoalGpsCompassSensorConfig(LabSensorConfig):
     type: str = "TargetGoalGpsCompassSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class NavToSkillSensorConfig(LabSensorConfig):
     type: str = "NavToSkillSensor"
     num_skills: int = 8
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class AbsTargetStartSensorConfig(LabSensorConfig):
     type: str = "AbsTargetStartSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class AbsGoalSensorConfig(LabSensorConfig):
     type: str = "AbsGoalSensor"
     goal_format: str = "CARTESIAN"
     dimensionality: int = 3
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DistToNavGoalSensorConfig(LabSensorConfig):
     type: str = "DistToNavGoalSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class LocalizationSensorConfig(LabSensorConfig):
     type: str = "LocalizationSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class QuestionSensorConfig(LabSensorConfig):
     type: str = "QuestionSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class InstructionSensorConfig(LabSensorConfig):
     type: str = "InstructionSensor"
     instruction_sensor_uuid: str = "instruction"
@@ -551,12 +551,12 @@ class InstructionSensorConfig(LabSensorConfig):
 # -----------------------------------------------------------------------------
 # Measurements
 # -----------------------------------------------------------------------------
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class MeasurementConfig(HabitatBaseConfig):
     type: str = MISSING
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SuccessMeasurementConfig(MeasurementConfig):
     r"""
     For Navigation tasks only, Measures 1.0 if the robot reached a success and 0 otherwise.
@@ -569,7 +569,7 @@ class SuccessMeasurementConfig(MeasurementConfig):
     success_distance: float = 0.2
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SPLMeasurementConfig(MeasurementConfig):
     r"""
     For Navigation tasks only, Measures the SPL (Success weighted by Path Length)
@@ -583,7 +583,7 @@ class SPLMeasurementConfig(MeasurementConfig):
     type: str = "SPL"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SoftSPLMeasurementConfig(MeasurementConfig):
     r"""
     For Navigation tasks only, Similar to SPL, but instead of a boolean,
@@ -593,14 +593,14 @@ class SoftSPLMeasurementConfig(MeasurementConfig):
     type: str = "SoftSPL"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class FogOfWarConfig:
     draw: bool = True
     visibility_dist: float = 5.0
     fov: int = 90
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TopDownMapMeasurementConfig(MeasurementConfig):
     type: str = "TopDownMap"
     max_episode_steps: int = (
@@ -618,12 +618,12 @@ class TopDownMapMeasurementConfig(MeasurementConfig):
     fog_of_war: FogOfWarConfig = FogOfWarConfig()
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CollisionsMeasurementConfig(MeasurementConfig):
     type: str = "Collisions"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RobotForceMeasurementConfig(MeasurementConfig):
     r"""
     The amount of force in newton's applied by the robot. It computes both the instant and accumulated.
@@ -632,7 +632,7 @@ class RobotForceMeasurementConfig(MeasurementConfig):
     min_force: float = 20.0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ForceTerminateMeasurementConfig(MeasurementConfig):
     r"""
     If the force is greater than a certain threshold, this measure will be 1.0 and 0.0 otherwise.
@@ -646,12 +646,12 @@ class ForceTerminateMeasurementConfig(MeasurementConfig):
     max_instant_force: float = -1.0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RobotCollisionsMeasurementConfig(MeasurementConfig):
     type: str = "RobotCollisions"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ObjectToGoalDistanceMeasurementConfig(MeasurementConfig):
     r"""
     In rearrangement only. The distance between the target object and the goal position for the object.
@@ -659,12 +659,12 @@ class ObjectToGoalDistanceMeasurementConfig(MeasurementConfig):
     type: str = "ObjectToGoalDistance"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EndEffectorToObjectDistanceMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorToObjectDistance"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EndEffectorToRestDistanceMeasurementConfig(MeasurementConfig):
     """
     Rearrangement only. Distance between current end effector position
@@ -675,12 +675,12 @@ class EndEffectorToRestDistanceMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorToRestDistance"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EndEffectorToGoalDistanceMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorToGoalDistance"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArtObjAtDesiredStateMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement open/close container tasks only. Whether the articulated object (fridge or cabinet door) towards a desired state (open or closed) as defined by the task.
@@ -690,22 +690,22 @@ class ArtObjAtDesiredStateMeasurementConfig(MeasurementConfig):
     success_dist_threshold: float = 0.05
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class GfxReplayMeasureMeasurementConfig(MeasurementConfig):
     type: str = "GfxReplayMeasure"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EndEffectorDistToMarkerMeasurementConfig(MeasurementConfig):
     type: str = "EndEffectorDistToMarker"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArtObjStateMeasurementConfig(MeasurementConfig):
     type: str = "ArtObjState"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArtObjSuccessMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement open/close container tasks only. Requires art_obj_at_desired_state. Is 1.0 if the articulated object is in desired state and the end effector is within rest_dist_threshold of the resting position. If must_call_stop is True, the robot must also call the rearrange_stop action.
@@ -715,7 +715,7 @@ class ArtObjSuccessMeasurementConfig(MeasurementConfig):
     must_call_stop: bool = True
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArtObjRewardMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement open/close container tasks only. Requires art_obj_at_desired_state.
@@ -743,7 +743,7 @@ class ArtObjRewardMeasurementConfig(MeasurementConfig):
     force_end_pen: float = 10.0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RotDistToGoalMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Navigation task only. The angle between the forward direction of the agent and the direction to the goal location.
@@ -751,19 +751,19 @@ class RotDistToGoalMeasurementConfig(MeasurementConfig):
     type: str = "RotDistToGoal"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DistToGoalMeasurementConfig(MeasurementConfig):
     type: str = "DistToGoal"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class BadCalledTerminateMeasurementConfig(MeasurementConfig):
     type: str = "BadCalledTerminate"
     bad_term_pen: float = 0.0
     decay_bad_term: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class NavToPosSuccMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Navigation task only. The value is 1.0 if the robot is within success_distance of the goal position.
@@ -772,7 +772,7 @@ class NavToPosSuccMeasurementConfig(MeasurementConfig):
     success_distance: float = 1.5
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class NavToObjRewardMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Navigation task only. The reward for rearrangement navigation.
@@ -795,7 +795,7 @@ class NavToObjRewardMeasurementConfig(MeasurementConfig):
     force_end_pen: float = 1.0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class NavToObjSuccessMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Navigation only. Takes the value 1.0 when the Robot successfully navigated to the target object. Depends on nav_to_pos_succ.
@@ -811,7 +811,7 @@ class NavToObjSuccessMeasurementConfig(MeasurementConfig):
     success_angle_dist: float = 0.261799
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RearrangeReachRewardMeasurementConfig(MeasurementConfig):
     type: str = "RearrangeReachReward"
     scale: float = 1.0
@@ -819,13 +819,13 @@ class RearrangeReachRewardMeasurementConfig(MeasurementConfig):
     sparse_reward: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RearrangeReachSuccessMeasurementConfig(MeasurementConfig):
     type: str = "RearrangeReachSuccess"
     succ_thresh: float = 0.2
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class NumStepsMeasurementConfig(MeasurementConfig):
     r"""
     In both Navigation and Rearrangement tasks, counts the number of steps since
@@ -834,17 +834,17 @@ class NumStepsMeasurementConfig(MeasurementConfig):
     type: str = "NumStepsMeasure"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DidPickObjectMeasurementConfig(MeasurementConfig):
     type: str = "DidPickObjectMeasure"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DidViolateHoldConstraintMeasurementConfig(MeasurementConfig):
     type: str = "DidViolateHoldConstraintMeasure"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class MoveObjectsRewardMeasurementConfig(MeasurementConfig):
     type: str = "MoveObjectsReward"
     pick_reward: float = 1.0
@@ -857,7 +857,7 @@ class MoveObjectsRewardMeasurementConfig(MeasurementConfig):
     force_end_pen: float = 10.0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RearrangePickRewardMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Only. Requires the end_effector_sensor lab sensor. The reward for the pick task.
@@ -884,7 +884,7 @@ class RearrangePickRewardMeasurementConfig(MeasurementConfig):
     wrong_pick_should_end: bool = True
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class RearrangePickSuccessMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Only. Requires the end_effector_sensor lab sensor. 1.0 if the robot picked the target object.
@@ -893,7 +893,7 @@ class RearrangePickSuccessMeasurementConfig(MeasurementConfig):
     ee_resting_success_threshold: float = 0.15
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ObjAtGoalMeasurementConfig(MeasurementConfig):
     r"""
     The measure is a dictionary of target indexes to float. The values are 1 if the object is within succ_thresh of the goal position for that object.
@@ -904,7 +904,7 @@ class ObjAtGoalMeasurementConfig(MeasurementConfig):
     succ_thresh: float = 0.15
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PlaceRewardMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Only. Requires the end_effector_sensor lab sensor. The reward for the place task.
@@ -929,7 +929,7 @@ class PlaceRewardMeasurementConfig(MeasurementConfig):
     min_dist_to_goal: float = 0.15
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PlaceSuccessMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Only. Requires the end_effector_sensor lab sensor. 1.0 if the robot placed the target object on the goal position and has its end effector within ee_resting_success_threshold of its resting position.
@@ -938,12 +938,12 @@ class PlaceSuccessMeasurementConfig(MeasurementConfig):
     ee_resting_success_threshold: float = 0.15
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CompositeNodeIdxMeasurementConfig(MeasurementConfig):
     type: str = "CompositeNodeIdx"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CompositeStageGoalsMeasurementConfig(MeasurementConfig):
     r"""
     Composite Rearrangement only. 1.0 if the agent complete a particular stage defined in `stage_goals` and 0.0 otherwise. Stage goals are specified in the `pddl` task description.
@@ -951,7 +951,7 @@ class CompositeStageGoalsMeasurementConfig(MeasurementConfig):
     type: str = "CompositeStageGoals"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CompositeSuccessMeasurementConfig(MeasurementConfig):
     r"""
     Composite rearrangement tasks only (rearrange, set_table, tidy_house). It uses a goal pddl expression to validate the success.
@@ -962,14 +962,14 @@ class CompositeSuccessMeasurementConfig(MeasurementConfig):
     must_call_stop: bool = True
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CompositeRewardMeasurementConfig(MeasurementConfig):
     type: str = "CompositeReward"
     must_call_stop: bool = True
     success_reward: float = 10.0
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DoesWantTerminateMeasurementConfig(MeasurementConfig):
     r"""
     Rearrangement Only. Measures 1 if the agent has called the stop action and 0 otherwise.
@@ -977,17 +977,17 @@ class DoesWantTerminateMeasurementConfig(MeasurementConfig):
     type: str = "DoesWantTerminate"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class CorrectAnswerMeasurementConfig(MeasurementConfig):
     type: str = "CorrectAnswer"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class EpisodeInfoMeasurementConfig(MeasurementConfig):
     type: str = "EpisodeInfo"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DistanceToGoalMeasurementConfig(MeasurementConfig):
     r"""
     In Navigation tasks only, measures the geodesic distance to the goal.
@@ -998,7 +998,7 @@ class DistanceToGoalMeasurementConfig(MeasurementConfig):
     distance_to: str = "POINT"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DistanceToGoalRewardMeasurementConfig(MeasurementConfig):
     r"""
     In Navigation tasks only, measures a reward based on the distance towards the goal.
@@ -1008,12 +1008,12 @@ class DistanceToGoalRewardMeasurementConfig(MeasurementConfig):
     type: str = "DistanceToGoalReward"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class AnswerAccuracyMeasurementConfig(MeasurementConfig):
     type: str = "AnswerAccuracy"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class TaskConfig(HabitatBaseConfig):
     r"""
     The definition of the task in Habitat.
@@ -1053,8 +1053,8 @@ class TaskConfig(HabitatBaseConfig):
     # NAVIGATION task
     type: str = "Nav-v0"
     # Temporary structure for sensors
-    lab_sensors: Dict[str, LabSensorConfig] = dict()
-    measurements: Dict[str, MeasurementConfig] = dict()
+    lab_sensors: Dict[str, LabSensorConfig] = field(default_factory=dict)
+    measurements: Dict[str, MeasurementConfig] = field(default_factory=dict)
     goal_sensor_uuid: str = "pointgoal"
     # REARRANGE task
     count_obj_collisions: bool = True
@@ -1080,7 +1080,9 @@ class TaskConfig(HabitatBaseConfig):
     base_noise: float = 0.05
     spawn_region_scale: float = 0.2
     joint_max_impulse: float = -1.0
-    desired_resting_position: List[float] = [0.5, 0.0, 1.0]
+    desired_resting_position: List[float] = field(
+        default_factory=lambda: [0.5, 0.0, 1.0]
+    )
     use_marker_t: bool = True
     cache_robot_init: bool = False
     success_state: float = 0.0
@@ -1096,41 +1098,41 @@ class TaskConfig(HabitatBaseConfig):
     enable_safe_drop: bool = False
     art_succ_thresh: float = 0.15
     robot_at_thresh: float = 2.0
-    filter_nav_to_tasks: List = []
+    filter_nav_to_tasks: List = field(default_factory=list)
     actions: Dict[str, ActionConfig] = MISSING
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SimulatorSensorConfig(HabitatBaseConfig):
     type: str = MISSING
     height: int = 480
     width: int = 640
-    position: List[float] = [0.0, 1.25, 0.0]
+    position: List[float] = field(default_factory=lambda: [0.0, 1.25, 0.0])
     # Euler's angles:
-    orientation: List[float] = [0.0, 0.0, 0.0]
+    orientation: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SimulatorCameraSensorConfig(SimulatorSensorConfig):
     hfov: int = 90  # horizontal field of view in degrees
     sensor_subtype: str = "PINHOLE"
     noise_model: str = "None"
-    noise_model_kwargs: Dict[str, Any] = dict()
+    noise_model_kwargs: Dict[str, Any] = field(default_factory=dict)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SimulatorDepthSensorConfig(SimulatorSensorConfig):
     min_depth: float = 0.0
     max_depth: float = 10.0
     normalize_depth: bool = True
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimRGBSensorConfig(SimulatorCameraSensorConfig):
     type: str = "HabitatSimRGBSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimDepthSensorConfig(SimulatorCameraSensorConfig):
     type: str = "HabitatSimDepthSensor"
     min_depth: float = 0.0
@@ -1138,27 +1140,27 @@ class HabitatSimDepthSensorConfig(SimulatorCameraSensorConfig):
     normalize_depth: bool = True
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimSemanticSensorConfig(SimulatorCameraSensorConfig):
     type: str = "HabitatSimSemanticSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimEquirectangularRGBSensorConfig(SimulatorSensorConfig):
     type: str = "HabitatSimEquirectangularRGBSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimEquirectangularDepthSensorConfig(SimulatorDepthSensorConfig):
     type: str = "HabitatSimEquirectangularDepthSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimEquirectangularSemanticSensorConfig(SimulatorSensorConfig):
     type: str = "HabitatSimEquirectangularSemanticSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SimulatorFisheyeSensorConfig(SimulatorSensorConfig):
     type: str = "HabitatSimFisheyeSensor"
     height: int = SimulatorSensorConfig().width
@@ -1170,7 +1172,7 @@ class SimulatorFisheyeSensorConfig(SimulatorSensorConfig):
     # in the same table as well.
     xi: float = -0.27
     alpha: float = 0.57
-    focal_length: List[float] = [364.84, 364.86]
+    focal_length: List[float] = field(default_factory=lambda: [364.84, 364.86])
     # Place camera at center of screen
     # Can be specified, otherwise is calculated automatically.
     # principal_point_offset defaults to (h/2,w/2)
@@ -1178,12 +1180,12 @@ class SimulatorFisheyeSensorConfig(SimulatorSensorConfig):
     sensor_model_type: str = "DOUBLE_SPHERE"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimFisheyeRGBSensorConfig(SimulatorFisheyeSensorConfig):
     type: str = "HabitatSimFisheyeRGBSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SimulatorFisheyeDepthSensorConfig(SimulatorFisheyeSensorConfig):
     type: str = "HabitatSimFisheyeDepthSensor"
     min_depth: float = SimulatorDepthSensorConfig().min_depth
@@ -1191,68 +1193,68 @@ class SimulatorFisheyeDepthSensorConfig(SimulatorFisheyeSensorConfig):
     normalize_depth: bool = SimulatorDepthSensorConfig().normalize_depth
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimFisheyeSemanticSensorConfig(SimulatorFisheyeSensorConfig):
     type: str = "HabitatSimFisheyeSemanticSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HeadRGBSensorConfig(HabitatSimRGBSensorConfig):
     uuid: str = "head_rgb"
     width: int = 256
     height: int = 256
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HeadDepthSensorConfig(HabitatSimDepthSensorConfig):
     uuid: str = "head_depth"
     width: int = 256
     height: int = 256
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArmRGBSensorConfig(HabitatSimRGBSensorConfig):
     uuid: str = "articulated_agent_arm_rgb"
     width: int = 256
     height: int = 256
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ArmDepthSensorConfig(HabitatSimDepthSensorConfig):
     uuid: str = "articulated_agent_arm_depth"
     width: int = 256
     height: int = 256
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ThirdRGBSensorConfig(HabitatSimRGBSensorConfig):
     uuid: str = "third_rgb"
     width: int = 512
     height: int = 512
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ThirdDepthSensorConfig(HabitatSimDepthSensorConfig):
     uuid: str = "third_depth"  # TODO: third_rgb on the main branch
     #  check if it won't cause any errors
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class AgentConfig(HabitatBaseConfig):
     height: float = 1.5
     radius: float = 0.1
     grasp_managers: int = 1
-    sim_sensors: Dict[str, SimulatorSensorConfig] = dict()
+    sim_sensors: Dict[str, SimulatorSensorConfig] = field(default_factory=dict)
     is_set_start_state: bool = False
-    start_position: List[float] = [0, 0, 0]
-    start_rotation: List[float] = [0, 0, 0, 1]
+    start_position: List[float] = field(default_factory=lambda: [0, 0, 0])
+    start_rotation: List[float] = field(default_factory=lambda: [0, 0, 0, 1])
     joint_start_noise: float = 0.1
     articulated_agent_urdf: str = "data/robots/hab_fetch/robots/hab_fetch.urdf"
     articulated_agent_type: str = "FetchRobot"
     ik_arm_urdf: str = "data/robots/hab_fetch/robots/fetch_onlyarm.urdf"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatSimV0Config(HabitatBaseConfig):
     gpu_device_id: int = 0
     # Use Habitat-Sim's GPU->GPU copy mode to return rendering results in
@@ -1273,11 +1275,11 @@ class HabitatSimV0Config(HabitatBaseConfig):
     enable_gfx_replay_save: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SimulatorConfig(HabitatBaseConfig):
     type: str = "Sim-v0"
     action_space_config: str = "v0"
-    action_space_config_arguments: Dict[str, Any] = dict()
+    action_space_config_arguments: Dict[str, Any] = field(default_factory=dict)
     forward_step_size: float = 0.25  # in metres
     create_renderer: bool = False
     requires_textures: bool = True
@@ -1294,7 +1296,7 @@ class SimulatorConfig(HabitatBaseConfig):
     scene_dataset: str = "default"
     # A list of directory or config paths to search in addition to the dataset
     # for object configs. should match the generated episodes for the task:
-    additional_object_paths: List[str] = []
+    additional_object_paths: List[str] = field(default_factory=list)
     # Use config.seed (can't reference Config.seed) or define via code
     # otherwise it leads to circular references:
     #
@@ -1331,25 +1333,25 @@ class SimulatorConfig(HabitatBaseConfig):
     ep_info: Optional[Any] = None
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PyrobotSensor(HabitatBaseConfig):
     pass
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PyrobotVisualSensorConfig(PyrobotSensor):
     type: str = MISSING
     height: int = 480
     width: int = 640
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PyrobotRGBSensorConfig(PyrobotVisualSensorConfig):
     type: str = "PyRobotRGBSensor"
     center_crop: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PyrobotDepthSensorConfig(PyrobotVisualSensorConfig):
     type: str = "PyRobotDepthSensor"
     min_depth: float = 0.0
@@ -1358,35 +1360,42 @@ class PyrobotDepthSensorConfig(PyrobotVisualSensorConfig):
     center_crop: bool = False
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PyrobotBumpSensorConfig(PyrobotSensor):
     type: str = "PyRobotBumpSensor"
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class LocobotConfig(HabitatBaseConfig):
-    actions: List[str] = ["base_actions", "camera_actions"]
-    base_actions: List[str] = ["go_to_relative", "go_to_absolute"]
+    actions: List[str] = field(
+        default_factory=lambda: ["base_actions", "camera_actions"]
+    )
+    base_actions: List[str] = field(
+        default_factory=lambda: ["go_to_relative", "go_to_absolute"]
+    )
+    camera_actions: List[str] = field(
+        default_factory=lambda: ["set_pan", "set_tilt", "set_pan_tilt"]
+    )
 
-    camera_actions: List[str] = ["set_pan", "set_tilt", "set_pan_tilt"]
 
-
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class PyrobotConfig(HabitatBaseConfig):
     # types of robots supported:
-    robots: List[str] = ["locobot"]
+    robots: List[str] = field(default_factory=lambda: ["locobot"])
     robot: str = "locobot"
-    sensors: Dict[str, PyrobotSensor] = {
-        "rgb_sensor": PyrobotRGBSensorConfig(),
-        "depth_sensor": PyrobotDepthSensorConfig(),
-        "bump_sensor": PyrobotBumpSensorConfig(),
-    }
+    sensors: Dict[str, PyrobotSensor] = field(
+        default_factory=lambda: {
+            "rgb_sensor": PyrobotRGBSensorConfig(),
+            "depth_sensor": PyrobotDepthSensorConfig(),
+            "bump_sensor": PyrobotBumpSensorConfig(),
+        }
+    )
     base_controller: str = "proportional"
     base_planner: str = "none"
     locobot: LocobotConfig = LocobotConfig()
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class DatasetConfig(HabitatBaseConfig):
     r"""Configuration for the dataset of the task.
 
@@ -1402,22 +1411,22 @@ class DatasetConfig(HabitatBaseConfig):
     type: str = "PointNav-v1"
     split: str = "train"
     scenes_dir: str = "data/scene_datasets"
-    content_scenes: List[str] = ["*"]
+    content_scenes: List[str] = field(default_factory=lambda: ["*"])
     data_path: str = (
         "data/datasets/pointnav/"
         "habitat-test-scenes/v1/{split}/{split}.json.gz"
     )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class GymConfig(HabitatBaseConfig):
     obs_keys: Optional[List[str]] = None
     action_keys: Optional[List[str]] = None
-    achieved_goal_keys: List = []
-    desired_goal_keys: List[str] = []
+    achieved_goal_keys: List = field(default_factory=list)
+    desired_goal_keys: List[str] = field(default_factory=list)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class HabitatConfig(HabitatBaseConfig):
     r"""
     The entry point for the configuration of Habitat. It holds the environment, simulator, task and dataset configurations.
@@ -1434,7 +1443,7 @@ class HabitatConfig(HabitatBaseConfig):
     # The dependencies for launching the GymRegistryEnv environments.
     # Modules listed here will be imported prior to making the environment with
     # gym.make()
-    env_task_gym_dependencies: List = []
+    env_task_gym_dependencies: List = field(default_factory=list)
     # The key of the gym environment in the registry to use in GymRegistryEnv
     # for example: `Cartpole-v0`
     env_task_gym_id: str = ""


### PR DESCRIPTION
## Motivation and Context

Rolled back moving to attr.s in  https://github.com/facebookresearch/habitat-lab/pull/1120.
Agreed on `@dataclass` style of defining structured configs in https://github.com/facebookresearch/habitat-lab/pull/1172.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
