### PR TITLE
Change home-robot to optional dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ If you use the Habitat platform in your research, please cite the [Habitat 1.0](
       cd habitat-lab
       pip install -e habitat-lab  # install habitat_lab
       ```
+
+      Note: To enable continuous robot base action spaces, install habitat-lab with the "continuous_control" option
+      ```
+      pip install -e "habitat-lab[continuous_control]"
+      ```
+
 1. **Install habitat-baselines**.
 
     The command above will install only core of Habitat-Lab. To include habitat_baselines along with all additional requirements, use the command below after installing habitat-lab:

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ If you use the Habitat platform in your research, please cite the [Habitat 1.0](
       pip install -e habitat-lab  # install habitat_lab
       ```
 
-      Note: To enable continuous robot base action spaces, install habitat-lab with the "continuous_control" option
+      Note: To enable continuous robot base action spaces, install habitat-lab with the "home_robot" option
       ```
-      pip install -e "habitat-lab[continuous_control]"
+      pip install -e "habitat-lab[home_robot]"
       ```
 
 1. **Install habitat-baselines**.

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -35,7 +35,6 @@ from habitat.core.spaces import EmptySpace
 from habitat.core.utils import not_none_validator, try_cv2_import
 from habitat.sims.habitat_simulator.actions import HabitatSimActions
 from habitat.tasks.utils import cartesian_to_polar
-from habitat.utils.controller_wrapper import ContinuousController
 from habitat.utils.geometry_utils import (
     quaternion_from_coeff,
     quaternion_rotate_vector,
@@ -1537,7 +1536,16 @@ class WaypointAction(VelocityAction):
         super().__init__(*args, **kwargs)
 
         # Init goto velocity controller
-        self.w2v_controller = ContinuousController(self._config)
+        try:
+            from habitat.utils.controller_wrapper import ContinuousController
+
+            self.w2v_controller = ContinuousController(self._config)
+        except ModuleNotFoundError:
+            print(
+                "Missing dependencies for waypoint type actions. "
+                "Install habitat-lab with the 'continuous_control' option to enable this feature."
+            )
+            raise
 
         # Cache hydra configs
         self._waypoint_lin_range = self._config.waypoint_lin_range

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -1540,12 +1540,14 @@ class WaypointAction(VelocityAction):
             from habitat.utils.controller_wrapper import ContinuousController
 
             self.w2v_controller = ContinuousController(self._config)
-        except ModuleNotFoundError:
-            print(
-                "Missing dependencies for waypoint type actions. "
-                "Install habitat-lab with the 'continuous_control' option to enable this feature."
-            )
-            raise
+        except ModuleNotFoundError as exc:
+            additional_error_message = """
+            Missing dependencies for waypoint type actions. 
+            Install habitat-lab with the 'continuous_control' option to enable this feature.
+            pip install -e "habitat-lab[continuous_control]
+            """
+            exc.message += additional_error_message
+            raise exc
 
         # Cache hydra configs
         self._waypoint_lin_range = self._config.waypoint_lin_range

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -1537,12 +1537,14 @@ class WaypointAction(VelocityAction):
 
         # Init goto velocity controller
         try:
-            from habitat.utils.controller_wrapper import ContinuousController
+            from habitat.utils.controller_wrapper import (
+                DiffDriveVelocityController,
+            )
 
-            self.w2v_controller = ContinuousController(self._config)
+            self.w2v_controller = DiffDriveVelocityController(self._config)
         except ModuleNotFoundError as exc:
             additional_error_message = """
-            Missing dependencies for waypoint type actions. 
+            Missing dependencies for waypoint type actions.
             Install habitat-lab with the 'continuous_control' option to enable this feature.
             pip install -e "habitat-lab[continuous_control]
             """

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -1545,8 +1545,8 @@ class WaypointAction(VelocityAction):
         except ModuleNotFoundError as exc:
             additional_error_message = """
             Missing dependencies for waypoint type actions.
-            Install habitat-lab with the 'continuous_control' option to enable this feature.
-            pip install -e "habitat-lab[continuous_control]
+            Install habitat-lab with the 'home_robot' option to enable this feature.
+            pip install -e "habitat-lab[home_robot]
             """
             raise ModuleNotFoundError(additional_error_message) from exc
 

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -1548,8 +1548,7 @@ class WaypointAction(VelocityAction):
             Install habitat-lab with the 'continuous_control' option to enable this feature.
             pip install -e "habitat-lab[continuous_control]
             """
-            exc.message += additional_error_message
-            raise exc
+            raise ModuleNotFoundError(additional_error_message) from exc
 
         # Cache hydra configs
         self._waypoint_lin_range = self._config.waypoint_lin_range

--- a/habitat-lab/habitat/utils/controller_wrapper.py
+++ b/habitat-lab/habitat/utils/controller_wrapper.py
@@ -4,7 +4,7 @@ import numpy as np
 from home_robot.control.goto_controller import GotoVelocityController
 
 
-class ContinuousController:
+class DiffDriveVelocityController:
     """Wrapper around the velocity controller in home_robot"""
 
     def __init__(

--- a/habitat-lab/setup.py
+++ b/habitat-lab/setup.py
@@ -38,7 +38,7 @@ PROJECT_URLS = {
 
 EXTRA_DEPS = {
     # Home robot dependency for velocity controllers
-    "continuous_control": [
+    "home_robot": [
         "home-robot @ git+ssh://git@github.com/facebookresearch/home-robot.git@habitat-challenge-2023#subdirectory=src/home_robot",
     ]
 }

--- a/habitat-lab/setup.py
+++ b/habitat-lab/setup.py
@@ -36,6 +36,13 @@ PROJECT_URLS = {
     "Bug Tracker": "https://github.com/facebookresearch/habitat-lab/issues",
 }
 
+EXTRA_DEPS = {
+    # Home robot dependency for velocity controllers
+    "continuous_control": [
+        "home-robot @ git+ssh://git@github.com/facebookresearch/home-robot.git@habitat-challenge-2023#subdirectory=src/home_robot",
+    ]
+}
+
 if __name__ == "__main__":
     # package data are the files and configurations included in the package
     package_data = [
@@ -60,6 +67,7 @@ if __name__ == "__main__":
             "pybullet==3.0.4",
             "mock",
         ],
+        extras_require=EXTRA_DEPS,
         include_package_data=True,
         cmdclass={
             "install": DefaultInstallCommand,


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Change [home_robot](https://github.com/facebookresearch/home-robot/tree/main/src/home_robot) to be an optional dep.

TODO: Modify documentation and challenge description to inform users that continuous actions require installing with the "continuous control flag, as in
```
pip install -e "habitat-lab[continuous_control]"
```

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
