### PR TITLE
Update torch dependency version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
                 conda create -y -n habitat python=3.7
                 . activate habitat
-                conda install -q -y -c conda-forge ninja ccache numpy
+                conda install -q -y -c conda-forge ninja ccache
                 pip install pytest-sugar>=0.9.6 mock cython pygame flaky pytest pytest-mock pytest-cov psutil
               fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
               python -c 'import torch; print("Has cuda ? ",torch.cuda.is_available()); print("torch version : ",torch.__version__);'
       - restore_cache:
           keys:
-            - habitat-sim-{{ checksum "./hsim_sha" }}
+            - v1-habitat-sim-{{ checksum "./hsim_sha" }}
       - restore_cache:
           keys:
             - ccache-{{ arch }}-main
@@ -237,7 +237,7 @@ jobs:
               . activate habitat; cd habitat-sim
               python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
       - save_cache:
-          key: habitat-sim-{{ checksum "./hsim_sha" }}
+          key: v1-habitat-sim-{{ checksum "./hsim_sha" }}
           background: true
           paths:
             - ./habitat-sim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,7 @@
-
-
 version: 2.1
 gpu: &gpu
   machine:
-    image: ubuntu-1604-cuda-10.1:201909-23
+    image: ubuntu-2004-cuda-11.4:202110-01
   resource_class: gpu.nvidia.medium
   environment:
     FPS_THRESHOLD: 900
@@ -101,16 +99,18 @@ jobs:
                   curl \
                   vim \
                   ca-certificates \
-                  libbullet-dev \
                   libjpeg-dev \
                   libglm-dev \
                   libegl1-mesa-dev \
+                  ninja-build \
                   xorg-dev \
                   freeglut3-dev \
                   pkg-config \
                   wget \
                   zip \
+                  lcov\
                   libhdf5-dev \
+                  libomp-dev \
                   unzip || true
               sudo apt install --allow-change-held-packages \
                   texlive-base \
@@ -121,13 +121,7 @@ jobs:
           name: Check CUDA
           no_output_timeout: 20m
           background: true
-          command: |
-              # wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.44-1_amd64.deb
-              # sudo dpkg -i cuda-repo-ubuntu1604_8.0.44-1_amd64.deb
-              # sudo apt-get update || true
-              # sudo apt-get --yes --force-yes install cuda
-              # touch ./cuda_installed
-              nvidia-smi
+          command: nvidia-smi
       # Restore Conda cache
       - restore_cache:
           keys:
@@ -145,8 +139,6 @@ jobs:
                 export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
                 conda create -y -n habitat python=3.7
                 . activate habitat
-                pip install -U pip
-
                 conda install -q -y -c conda-forge ninja ccache numpy
                 pip install pytest-sugar>=0.9.6 mock cython pygame flaky pytest pytest-mock pytest-cov psutil
               fi
@@ -159,8 +151,10 @@ jobs:
               . activate habitat;
               if [ ! -f ~/miniconda/pytorch_installed ]
               then
+                # For whatever reason we have to install pytorch first. If it isn't
+                # it installs the 1.4 cpuonly version. Which is no good.
                 echo "Installing pytorch"
-                conda install -y pytorch==1.4.0 torchvision cudatoolkit=10.0 -c pytorch
+                conda install -y pytorch==1.12.1=py3.7_cuda11.3_cudnn8.3.2_0 torchvision==0.13.1=py37_cu113 cudatoolkit=11.3 -c pytorch -c nvidia
               fi
               touch ~/miniconda/pytorch_installed
               python -c 'import torch; print("Has cuda ? ",torch.cuda.is_available()); print("torch version : ",torch.__version__);'
@@ -188,12 +182,11 @@ jobs:
               then
                 git clone https://github.com/facebookresearch/habitat-sim.git --recursive
               fi
-              # while [ ! -f ./cuda_installed ]; do sleep 2; done # wait for CUDA
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat;
               cd habitat-sim
               pip install -r requirements.txt --progress-bar off
-              pip install pillow
+              pip install imageio imageio-ffmpeg
               python -u setup.py install --headless --with-cuda --bullet
       - run:
           name: Ccache stats
@@ -240,7 +233,6 @@ jobs:
       - run:
           name: Run sim benchmark
           command: |
-              # while [ ! -f ./cuda_installed ]; do sleep 2; done # wait for CUDA
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-sim
               python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD


### PR DESCRIPTION
## Motivation and Context

Currently, PyTorch is listed as a dependency in habitat_baselines/rl/requirements.txt as `torch>=1.3.1`. It means that during the lab/baselines installation pip will install the most recent version available (but not older than 1.3.1). However, before installing lab/baselines on CI side, we have **Install pytorch** step that installs `pytorch==1.4.0 cudatoolkit=10.0`. Though it satisfies the requirement, it is a very old version of PyTorch library (released on Jan 16, 2020!) that prevents us from using recent PyTorch APIs.

That's why, in scope of this PR we: 
- update CircleCI config: use the same machine image and cuda/pytorch installation instructions as in habitat-sim
- update habitat_baselines/rl PyTorch requirement >= 1.12.1 (to match version tested on CircleCI)
- do other things to make CI work
   - invalidate old cache by adding version to `v1-habitat-sim ...` (fixes [this](https://app.circleci.com/pipelines/github/facebookresearch/habitat-lab/4351/workflows/b045eb72-b46d-4345-966f-c684bc4bac3f/jobs/12074?invite=true#step-111-169))
   - change the step on which numpy is installed from  `Install conda and dependencies` to `Build and install habitat-sim` where all the other sim dependencies are installed (fixes [this](https://app.circleci.com/pipelines/github/facebookresearch/habitat-lab/4352/workflows/cb1ef757-fc27-4d0b-960e-93a7fe3e797c/jobs/12077?invite=true#step-111-1617))

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Dependency Upgrade\]** Upgrades one or several dependencies in habitat

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
