### PR TITLE
[Development] add new collision detection for Spot/Stretch robot

### DIFF
--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -28,8 +28,8 @@ habitat:
       base_velocity_spot:
         allow_dyn_slide: False
         cylinder_deviate: 0.3
-        lin_collision_threshold: 0.04
-        ang_collision_threshold: 0.01
+        lin_collision_threshold: 1e-5
+        ang_collision_threshold: 1e-5
   simulator:
     type: RearrangeSim-v0
     seed: 100

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -28,12 +28,10 @@ habitat:
       base_velocity_non_cylinder:
         allow_dyn_slide: False
         # There is a collision if the difference between the clamped NavMesh position and target position
-        # is more than than lin_collision_threshold/ang_collision_threshold for any point
-        lin_collision_threshold: 1e-5
-        ang_collision_threshold: 1e-5
+        # is more than than collision_threshold for any point
+        collision_threshold: 1e-5
         # The x and y locations of the clamped NavMesh position
-        x_offset: [0.3, -0.3]
-        y_offset: [0.0, 0.0]
+        navmesh_offset: [[0.3, 0], [-0.3, 0]]
         # If we allow the robot to move laterally
         enable_lateral_move: True
   simulator:
@@ -41,6 +39,8 @@ habitat:
     seed: 100
     additional_object_paths:
       - "data/objects/ycb/configs/"
+      # - "/Users/jimmytyyang/Downloads/test_scene_dataset/object_datasets/amazon_berkeley/configs/"
+      # - "/Users/jimmytyyang/Downloads/test_scene_dataset/object_datasets/google_object_dataset/configs/"
     agents:
       main_agent:
         radius: 0.3
@@ -59,3 +59,7 @@ habitat:
       enable_physics: True
   dataset:
     data_path: data/datasets/replica_cad/rearrange/v1/{split}/all_receptacles_10k_1k.json.gz
+    # data_path: /Users/jimmytyyang/floor_planner/habitat-lab/data/datasets/rearrange_floorplanner/train/rearrange_floorplanner_5_0303.json.gz
+    # data_path: /Users/jimmytyyang/habitat_lab_0301/habitat-lab/data/datasets/rearrange_floorplanner/train/rearrange_floorplanner_1_0303_102344307.json.gz
+    # data_path: /Users/jimmytyyang/habitat_lab_0301/habitat-lab/data/datasets/rearrange_floorplanner/train/rearrange_floorplanner_scene3_obj10_en10.json.gz
+    # data_path: /Users/jimmytyyang/habitat_lab_0301/habitat-lab/data/datasets/fp_episodes/rearrange/microtrain/rearrange_floorplanner.json.gz

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -34,7 +34,7 @@ habitat:
         # is more than than collision_threshold for any point
         collision_threshold: 1e-5
         # The x and y locations of the clamped NavMesh position
-        navmesh_offset: [[0.3, 0], [-0.3, 0]]
+        navmesh_offset: [[0.0, 0.0], [0.25, 0.0], [-0.25, 0.0]]
         # If we allow the robot to move laterally
         enable_lateral_move: True
   simulator:

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -3,7 +3,7 @@
 defaults:
   - /habitat: habitat_config_base
   - /habitat/task/actions:
-    - base_velocity_spot
+    - base_velocity_non_cylinder
   - /habitat/simulator/agents@habitat.simulator.agents.main_agent: rgbd_head_rgbd_arm_agent
   - /habitat/task/rearrange: play
   - /habitat/dataset/rearrangement: replica_cad
@@ -25,11 +25,13 @@ habitat:
         disable_grip: False
         delta_pos_limit: 0.0125
         ee_ctrl_lim: 0.015
-      base_velocity_spot:
+      base_velocity_non_cylinder:
         allow_dyn_slide: False
         cylinder_deviate: 0.3
         lin_collision_threshold: 1e-5
         ang_collision_threshold: 1e-5
+        x_offset: [0.3, -0.3]
+        y_offset: [0.0, 0.0]
   simulator:
     type: RearrangeSim-v0
     seed: 100

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -28,7 +28,7 @@ habitat:
       base_velocity_non_cylinder:
         allow_dyn_slide: False
         # There is a collision if the difference between the clamped NavMesh position and target position
-        # is too great than lin_collision_threshold/ang_collision_threshold for any point
+        # is more than than lin_collision_threshold/ang_collision_threshold for any point
         lin_collision_threshold: 1e-5
         ang_collision_threshold: 1e-5
         # The x and y locations of the clamped NavMesh position

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -2,6 +2,8 @@
 
 defaults:
   - /habitat: habitat_config_base
+  - /habitat/task/actions:
+    - base_velocity_spot
   - /habitat/simulator/agents@habitat.simulator.agents.main_agent: rgbd_head_rgbd_arm_agent
   - /habitat/task/rearrange: play
   - /habitat/dataset/rearrangement: replica_cad
@@ -23,6 +25,11 @@ habitat:
         disable_grip: False
         delta_pos_limit: 0.0125
         ee_ctrl_lim: 0.015
+      base_velocity_spot:
+        allow_dyn_slide: False
+        cylinder_deviate: 0.3
+        lin_collision_threshold: 0.04
+        ang_collision_threshold: 0.01
   simulator:
     type: RearrangeSim-v0
     seed: 100

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -27,10 +27,15 @@ habitat:
         ee_ctrl_lim: 0.015
       base_velocity_non_cylinder:
         allow_dyn_slide: False
+        # There is a collision if the difference between the clamped NavMesh position and target position
+        # is too great than lin_collision_threshold/ang_collision_threshold for any point
         lin_collision_threshold: 1e-5
         ang_collision_threshold: 1e-5
+        # The x and y locations of the clamped NavMesh position
         x_offset: [0.3, -0.3]
         y_offset: [0.0, 0.0]
+        # If we allow the robot to move laterally
+        enable_lateral_move: True
   simulator:
     type: RearrangeSim-v0
     seed: 100
@@ -38,7 +43,7 @@ habitat:
       - "data/objects/ycb/configs/"
     agents:
       main_agent:
-        radius: 0.55
+        radius: 0.3
         articulated_agent_urdf: data/robots/hab_spot_arm/urdf/hab_spot_arm.urdf
         articulated_agent_type: "SpotRobot"
         sim_sensors:

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -27,7 +27,6 @@ habitat:
         ee_ctrl_lim: 0.015
       base_velocity_non_cylinder:
         allow_dyn_slide: False
-        cylinder_deviate: 0.3
         lin_collision_threshold: 1e-5
         ang_collision_threshold: 1e-5
         x_offset: [0.3, -0.3]

--- a/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_spot.yaml
@@ -39,8 +39,6 @@ habitat:
     seed: 100
     additional_object_paths:
       - "data/objects/ycb/configs/"
-      # - "/Users/jimmytyyang/Downloads/test_scene_dataset/object_datasets/amazon_berkeley/configs/"
-      # - "/Users/jimmytyyang/Downloads/test_scene_dataset/object_datasets/google_object_dataset/configs/"
     agents:
       main_agent:
         radius: 0.3
@@ -59,7 +57,3 @@ habitat:
       enable_physics: True
   dataset:
     data_path: data/datasets/replica_cad/rearrange/v1/{split}/all_receptacles_10k_1k.json.gz
-    # data_path: /Users/jimmytyyang/floor_planner/habitat-lab/data/datasets/rearrange_floorplanner/train/rearrange_floorplanner_5_0303.json.gz
-    # data_path: /Users/jimmytyyang/habitat_lab_0301/habitat-lab/data/datasets/rearrange_floorplanner/train/rearrange_floorplanner_1_0303_102344307.json.gz
-    # data_path: /Users/jimmytyyang/habitat_lab_0301/habitat-lab/data/datasets/rearrange_floorplanner/train/rearrange_floorplanner_scene3_obj10_en10.json.gz
-    # data_path: /Users/jimmytyyang/habitat_lab_0301/habitat-lab/data/datasets/fp_episodes/rearrange/microtrain/rearrange_floorplanner.json.gz

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -260,12 +260,10 @@ class BaseVelocityNonCylinderActionConfig(ActionConfig):
     # If we allow the robot to move back or not
     allow_back: bool = True
     # There is a collision if the difference between the clamped NavMesh position and target position
-    # is more than lin_collision_threshold/ang_collision_threshold for any point.
-    lin_collision_threshold: float = 1e-5
-    ang_collision_threshold: float = 1e-5
+    # is more than collision_threshold for any point.
+    collision_threshold: float = 1e-5
     # The x and y locations of the clamped NavMesh position
-    x_offset: Optional[List[float]] = None
-    y_offset: Optional[List[float]] = None
+    navmesh_offset: Optional[List[float]] = None
     # If we allow the robot to move laterally.
     enable_lateral_move: bool = False
 

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -245,6 +245,21 @@ class BaseVelocityActionConfig(ActionConfig):
 
 
 @dataclass
+class BaseVelocitySpotActionConfig(ActionConfig):
+    r"""
+    In Rearrangement only. Corresponds to the base velocity. Contains two continuous actions, the first one controls forward and backward motion, the second the rotation.
+    """
+    type: str = "BaseVelSpotAction"
+    lin_speed: float = 10.0
+    ang_speed: float = 10.0
+    allow_dyn_slide: bool = False
+    allow_back: bool = True
+    cylinder_deviate: float = 0.0
+    lin_collision_threshold: float = 0.0
+    ang_collision_threshold: float = 0.0
+
+
+@dataclass
 class HumanoidJointActionConfig(ActionConfig):
     r"""
     In Rearrangement only. Corresponds to actions to change the humanoid joints. Contains the parameter num_joints, indicating the joints that can be modified.
@@ -1536,6 +1551,12 @@ cs.store(
     group="habitat/task/actions",
     name="base_velocity",
     node=BaseVelocityActionConfig,
+)
+cs.store(
+    package="habitat.task.actions.base_velocity_spot",
+    group="habitat/task/actions",
+    name="base_velocity_spot",
+    node=BaseVelocitySpotActionConfig,
 )
 cs.store(
     package="habitat.task.actions.humanoidjoint_action",

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -255,8 +255,8 @@ class BaseVelocitySpotActionConfig(ActionConfig):
     allow_dyn_slide: bool = False
     allow_back: bool = True
     cylinder_deviate: float = 0.0
-    lin_collision_threshold: float = 0.0
-    ang_collision_threshold: float = 0.0
+    lin_collision_threshold: float = 1e-5
+    ang_collision_threshold: float = 1e-5
 
 
 @dataclass

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -247,17 +247,26 @@ class BaseVelocityActionConfig(ActionConfig):
 @dataclass
 class BaseVelocityNonCylinderActionConfig(ActionConfig):
     r"""
-    In Rearrangement only. Corresponds to the base velocity. Contains two continuous actions, the first one controls forward and backward motion, the second the rotation.
+    In Rearrangement only for the non cylinder shape of the robot. Corresponds to the base velocity. Contains two continuous actions, the first one controls forward and backward motion, the second the rotation.
     """
     type: str = "BaseVelNonCylinderAction"
+    # The max linear speed of the robot
     lin_speed: float = 10.0
+    # The max angular speed of the robot
     ang_speed: float = 10.0
+    # If we want to do sliding or not
     allow_dyn_slide: bool = False
+    # If we allow the robot to move back or not
     allow_back: bool = True
+    # There is a collision if the difference between the clamped NavMesh position and target position
+    # is too great than lin_collision_threshold/ang_collision_threshold for any point.
     lin_collision_threshold: float = 1e-5
     ang_collision_threshold: float = 1e-5
+    # The x and y locations of the clamped NavMesh position
     x_offset: Optional[List[float]] = None
     y_offset: Optional[List[float]] = None
+    # If we allow the robot to move laterally.
+    enable_lateral_move: bool = False
 
 
 @dataclass

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -250,8 +250,9 @@ class BaseVelocityNonCylinderActionConfig(ActionConfig):
     In Rearrangement only for the non cylinder shape of the robot. Corresponds to the base velocity. Contains two continuous actions, the first one controls forward and backward motion, the second the rotation.
     """
     type: str = "BaseVelNonCylinderAction"
-    # The max linear speed of the robot
-    lin_speed: float = 10.0
+    # The max longitudinal and lateral linear speeds of the robot
+    longitudinal_lin_speed: float = 10.0
+    lateral_lin_speed: float = 10.0
     # The max angular speed of the robot
     ang_speed: float = 10.0
     # If we want to do sliding or not
@@ -259,7 +260,7 @@ class BaseVelocityNonCylinderActionConfig(ActionConfig):
     # If we allow the robot to move back or not
     allow_back: bool = True
     # There is a collision if the difference between the clamped NavMesh position and target position
-    # is too great than lin_collision_threshold/ang_collision_threshold for any point.
+    # is more than lin_collision_threshold/ang_collision_threshold for any point.
     lin_collision_threshold: float = 1e-5
     ang_collision_threshold: float = 1e-5
     # The x and y locations of the clamped NavMesh position

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -245,18 +245,19 @@ class BaseVelocityActionConfig(ActionConfig):
 
 
 @dataclass
-class BaseVelocitySpotActionConfig(ActionConfig):
+class BaseVelocityNonCylinderActionConfig(ActionConfig):
     r"""
     In Rearrangement only. Corresponds to the base velocity. Contains two continuous actions, the first one controls forward and backward motion, the second the rotation.
     """
-    type: str = "BaseVelSpotAction"
+    type: str = "BaseVelNonCylinderAction"
     lin_speed: float = 10.0
     ang_speed: float = 10.0
     allow_dyn_slide: bool = False
     allow_back: bool = True
-    cylinder_deviate: float = 0.0
     lin_collision_threshold: float = 1e-5
     ang_collision_threshold: float = 1e-5
+    x_offset: Optional[List[float]] = None
+    y_offset: Optional[List[float]] = None
 
 
 @dataclass
@@ -1553,10 +1554,10 @@ cs.store(
     node=BaseVelocityActionConfig,
 )
 cs.store(
-    package="habitat.task.actions.base_velocity_spot",
+    package="habitat.task.actions.base_velocity_non_cylinder",
     group="habitat/task/actions",
-    name="base_velocity_spot",
-    node=BaseVelocitySpotActionConfig,
+    name="base_velocity_non_cylinder",
+    node=BaseVelocityNonCylinderActionConfig,
 )
 cs.store(
     package="habitat.task.actions.humanoidjoint_action",

--- a/habitat-lab/habitat/tasks/rearrange/actions/actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/actions.py
@@ -538,20 +538,19 @@ class BaseVelSpotAction(ArticulatedAgentAction):
         front_goal_pos[1] = front_cur_pos[1]
         # For step filter of the rear pos
         end_rear_pos = self._sim.step_filter(rear_cur_pos, rear_goal_pos)
-        end_rear_pos[1] = front_cur_pos[1]
-        rear_goal_pos[1] = front_cur_pos[1]
+        end_rear_pos[1] = rear_cur_pos[1]
+        rear_goal_pos[1] = rear_cur_pos[1]
         # For step filter of the center pos
         end_pos[1] = trans.translation[1]
 
-        # Robot moving distance
+        # Planar move distance clamped by NavMesh
         front_move = (end_front_pos - front_goal_pos).length()
         rear_move = (end_rear_pos - rear_goal_pos).length()
 
         # For detection of linear or angualr velocity
         center_move = (end_pos - trans.translation).length()
 
-        # If the acutal target and the resulting moving position
-        # is too samll, then there is a collision
+        # There is a collision if the difference between the clamped NavMesh position and target position is too great for any point.
         if (
             front_move > self._lin_collision_threshold
             or rear_move > self._lin_collision_threshold
@@ -567,8 +566,6 @@ class BaseVelSpotAction(ArticulatedAgentAction):
 
     def update_base(self):
         ctrl_freq = self._sim.ctrl_freq
-
-        # before_trans_state = self._capture_articulated_agent_state()
 
         trans = self.cur_articulated_agent.sim_obj.transformation
         rigid_state = habitat_sim.RigidState(
@@ -591,9 +588,6 @@ class BaseVelSpotAction(ArticulatedAgentAction):
         did_coll = self.spot_collison_check(trans, target_trans, end_pos)
 
         if not self._allow_dyn_slide:
-            # Check if in the new articulated_agent state the arm collides with anything.
-            # If so we have to revert back to the previous transform
-            self._sim.internal_step(-1)
             if did_coll:
                 self.cur_articulated_agent.sim_obj.transformation = trans
         if self.cur_grasp_mgr.snap_idx is not None:

--- a/habitat-lab/habitat/tasks/rearrange/actions/actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/actions.py
@@ -470,7 +470,7 @@ class BaseVelAction(ArticulatedAgentAction):
 
 
 @registry.register_task_action
-class BaseVelNonCylinderAction(BaseVelAction):
+class BaseVelNonCylinderAction(ArticulatedAgentAction):
     """
     The articulated agent base motion is constrained to the NavMesh and controlled with velocity commands integrated with the VelocityControl interface.
 
@@ -479,10 +479,19 @@ class BaseVelNonCylinderAction(BaseVelAction):
 
     def __init__(self, *args, config, sim: RearrangeSim, **kwargs):
         super().__init__(*args, config=config, sim=sim, **kwargs)
+        self._sim: RearrangeSim = sim
+        self.base_vel_ctrl = habitat_sim.physics.VelocityControl()
+        self.base_vel_ctrl.controlling_lin_vel = True
+        self.base_vel_ctrl.lin_vel_is_local = True
+        self.base_vel_ctrl.controlling_ang_vel = True
+        self.base_vel_ctrl.ang_vel_is_local = True
+        self._allow_dyn_slide = self._config.get("allow_dyn_slide", True)
+        self._allow_back = self._config.allow_back
         self._lin_collision_threshold = self._config.lin_collision_threshold
         self._ang_collision_threshold = self._config.ang_collision_threshold
         self._longitudinal_lin_speed = self._config.longitudinal_lin_speed
         self._lateral_lin_speed = self._config.lateral_lin_speed
+        self._ang_speed = self._config.ang_speed
         self._x_offset = self._config.x_offset
         self._y_offset = self._config.y_offset
         self._enable_lateral_move = self._config.enable_lateral_move


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? --> The Spot robot from Boston Dynamics has an oblong shape. This is problematic since we assume the agent's shape is a cylinder, which prevents us from getting a correct mesh for Spot and makes it easy to collide with the obstacles. Our solution is to have multiple cylinders aligned to approximate an oblong shape. See an illustration figure below. 

<img width="728" alt="Screenshot 2023-03-20 at 4 35 36 PM" src="https://user-images.githubusercontent.com/55121504/226459906-9d204248-987e-494e-b3fe-99d1cb46ee8b.png">

In addition, we also benchmark the Spot training speed and found that the new collision shape introduces a 10% of speed decrease (from 1257 to 1112 FPS), which is acceptable given that we still get 1k FPS.

Moreover, we design a new class of action space, called `BaseVelSpotAction`, instead of refactoring the original `BaseVelAction`. This is to prevent changing the behavior (training speed) of the original codebase.
 
This is a joint work with @aclegg3 !

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. --> Ran the VER training on the fair cluster to benchmark the speed, and `interactive_play.py`

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
