### PR TITLE
Fix pypi_deploy CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,38 +323,37 @@ jobs:
               python -c 'import habitat; print("habitat version:", habitat.__version__)'
               pip install habitat-baselines/
               python -c 'import habitat_baselines; print("habitat_baselines version:", habitat_baselines.__version__)'
-
-      - run:
-          name: Ensure build and intall work
+      - run: &build_sdist_and_bdist
+          name: Build sdist and bdist
           command: |
               cd habitat-lab
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-
               conda create -y -n build-env python=3.9
               . activate build-env
               pip install --upgrade build
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-lab/
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-baselines/
-
+      - run:
+          name: Ensure sdist and bdist intall work
+          command: |
+              cd habitat-lab
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               conda create -y -n bdist-install python=3.9
               . activate bdist-install
               conda install -y -c conda-forge -c aihabitat-nightly habitat-sim
               conda create -n sdist-install --clone bdist-install
-
               # install from built distribution:
               . activate bdist-install
               pip install habitat-lab/dist/habitat_lab*.whl
               python -c 'import habitat; print("habitat version:", habitat.__version__)'
               pip install habitat-baselines/dist/habitat_baselines*.whl
               python -c 'import habitat_baselines; print("habitat_baselines version:", habitat_baselines.__version__)'
-
               # install from source distribution:
               . activate sdist-install
               pip install habitat-lab/dist/habitat-lab*.tar.gz
               python -c 'import habitat; print("habitat version:", habitat.__version__)'
               pip install habitat-baselines/dist/habitat-baselines*.tar.gz
               python -c 'import habitat_baselines; print("habitat_baselines version:", habitat_baselines.__version__)'
-
       - store_artifacts:
           path: habitat-lab/data/profile  # This is the benchmark profile
   pypi_deploy:
@@ -376,7 +375,19 @@ jobs:
       - checkout:
           path: ./habitat-lab
       - run:
-          name: Deploy Habitat-Lab and Habitat-Baselines to PyPI
+          name: Install conda
+          no_output_timeout: 20m
+          command: |
+              if [ ! -d ~/miniconda ]
+              then
+                curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                chmod +x ~/miniconda.sh
+                bash ~/miniconda.sh -b -p $HOME/miniconda
+                rm ~/miniconda.sh
+              fi
+      - run: *build_sdist_and_bdist
+      - run:
+          name: Deploy Habitat-Lab and Habitat-Baselines distributions to PyPI
           command: |
               cd habitat-lab
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH


### PR DESCRIPTION
## Motivation and Context

This PR addresses the issue that the CI machine state is not shared between jobs ([failed nightly build](https://app.circleci.com/pipelines/github/facebookresearch/habitat-lab/4534/workflows/8ed4d914-97b3-4a42-ae05-7e7b5f2b3def)). 

In contrast to https://github.com/facebookresearch/habitat-lab/pull/1192, this PR executes following steps before calling twine to upload distributions:
1. installs conda  
2. builds habitat-lab and habitat-baselines sdist and bdist distributions

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
