### PR TITLE
adding hydra launcher and single robot experiment config

### DIFF
--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/hab3_single_robot.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/hab3_single_robot.yaml
@@ -1,19 +1,19 @@
 # @package _global_
 
 defaults:
-  - rearrange/rl_hierarchical
+  - /rearrange/rl_hierarchical
   - override /habitat_baselines/rl/policy: hl_neural
   - override /habitat_baselines/rl/policy/hierarchical_policy/defined_skills: oracle_skills
-  - override hydra/output: path
-  - override hydra/launcher: submitit_habitat
+  - override /hydra/output: path
+  - override /hydra/launcher: submitit_habitat
   - _self_
 
 habitat_baselines:
-  video_dir: ${hydra:sweep.subdir}/video
-  tensorboard_dir: ${hydra:sweep.subdir}/tb
-  eval_ckpt_path_dir: ${hydra:sweep.subdir}/checkpoints
-  checkpoint_folder: ${hydra:sweep.subdir}/checkpoints
-  log_file: ${hydra:sweep.subdir}/train.log
+  video_dir: ${hydra:sweep.dir}/${hydra:sweep.subdir}/video
+  tensorboard_dir: ${hydra:sweep.dir}/${hydra:sweep.subdir}/tb
+  eval_ckpt_path_dir: ${hydra:sweep.dir}/${hydra:sweep.subdir}/checkpoints
+  checkpoint_folder: ${hydra:sweep.dir}/${hydra:sweep.subdir}/checkpoints
+  log_file: ${hydra:sweep.dir}/${hydra:sweep.subdir}/train.log
   evaluate: False
   writer_type: 'wb'
   wb:
@@ -37,7 +37,4 @@ habitat:
     kinematic_mode: True
     ac_freq_ratio: 1
     step_physics: False
-
-
-
 

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/hab3_single_robot.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/hab3_single_robot.yaml
@@ -37,4 +37,3 @@ habitat:
     kinematic_mode: True
     ac_freq_ratio: 1
     step_physics: False
-

--- a/habitat-baselines/habitat_baselines/config/hab3_single_robot.yaml
+++ b/habitat-baselines/habitat_baselines/config/hab3_single_robot.yaml
@@ -1,0 +1,43 @@
+# @package _global_
+
+defaults:
+  - rearrange/rl_hierarchical
+  - override /habitat_baselines/rl/policy: hl_neural
+  - override /habitat_baselines/rl/policy/hierarchical_policy/defined_skills: oracle_skills
+  - override hydra/output: path
+  - override hydra/launcher: submitit_habitat
+  - _self_
+
+habitat_baselines:
+  video_dir: ${hydra:sweep.subdir}/video
+  tensorboard_dir: ${hydra:sweep.subdir}/tb
+  eval_ckpt_path_dir: ${hydra:sweep.subdir}/checkpoints
+  checkpoint_folder: ${hydra:sweep.subdir}/checkpoints
+  log_file: ${hydra:sweep.subdir}/train.log
+  evaluate: False
+  writer_type: 'wb'
+  wb:
+    project_name: 'hab3'
+    entity: 'andrew-colab'
+  num_environments: 2
+
+habitat:
+  task:
+    measurements:
+      composite_success:
+        must_call_stop: False
+      force_terminate:
+        max_accum_force: -1.0
+        max_instant_force: -1.0
+
+  environment:
+    max_episode_steps: 30
+
+  simulator:
+    kinematic_mode: True
+    ac_freq_ratio: 1
+    step_physics: False
+
+
+
+

--- a/habitat-baselines/habitat_baselines/config/hydra/launcher/submitit_habitat.yaml
+++ b/habitat-baselines/habitat_baselines/config/hydra/launcher/submitit_habitat.yaml
@@ -1,0 +1,17 @@
+# @package hydra.launcher
+submitit_folder: ${hydra.sweep.dir}/.submitit/%j
+timeout_min: 2160
+nodes: 1
+cpus_per_task: 10
+mem_per_cpu: 5
+name: ${hydra.job.name}%j
+_target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher
+partition: devlab
+tasks_per_node: 2
+gres: gpu:2
+setup: 
+  - MAIN_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+  - export MAIN_ADDR
+  - export MASTER_ADDR=$(hostname -s)
+  - export MAGNUM_LOG=quiet
+  - export HABITAT_SIM_LOG=quiet

--- a/habitat-baselines/habitat_baselines/config/hydra/launcher/submitit_habitat.yaml
+++ b/habitat-baselines/habitat_baselines/config/hydra/launcher/submitit_habitat.yaml
@@ -4,14 +4,13 @@ timeout_min: 2160
 nodes: 1
 cpus_per_task: 10
 mem_per_cpu: 5
-name: ${hydra.job.name}%j
+name: ${hydra.job.name}
 _target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher
 partition: devlab
-tasks_per_node: 2
+tasks_per_node: 2 #make sure that tasks_per_node and gres are the same
 gres: gpu:2
 setup: 
-  - MAIN_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
-  - export MAIN_ADDR
+  - export MAIN_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
   - export MASTER_ADDR=$(hostname -s)
   - export MAGNUM_LOG=quiet
   - export HABITAT_SIM_LOG=quiet

--- a/habitat-baselines/habitat_baselines/config/hydra/launcher/submitit_habitat.yaml
+++ b/habitat-baselines/habitat_baselines/config/hydra/launcher/submitit_habitat.yaml
@@ -9,7 +9,7 @@ _target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher
 partition: devlab
 tasks_per_node: 2 #make sure that tasks_per_node and gres are the same
 gres: gpu:2
-setup: 
+setup:
   - export MAIN_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
   - export MASTER_ADDR=$(hostname -s)
   - export MAGNUM_LOG=quiet

--- a/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
+++ b/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
@@ -5,3 +5,4 @@ run:
 sweep:
   dir: /checkpoint/akshararai/hab3/${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
   subdir: ${hydra.job.num}_${hydra.job.override_dirname}
+  

--- a/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
+++ b/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
@@ -5,4 +5,3 @@ run:
 sweep:
   dir: /checkpoint/akshararai/hab3/${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
   subdir: ${hydra.job.num}_${hydra.job.override_dirname}
-  

--- a/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
+++ b/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
@@ -1,0 +1,7 @@
+# @package hydra
+run:
+  dir: /checkpoint/akshararai/hab3/${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  subdir: ${hydra.job.num}_${hydra.job.override_dirname}
+sweep:
+  dir: /checkpoint/akshararai/hab3/${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  subdir: ${hydra.job.num}_${hydra.job.override_dirname}


### PR DESCRIPTION
## Motivation and Context

1. Hydra config for launching slurm jobs on the cluster
2. Experiment config to standardize experiment parameters across all users
3. Path name standardization to easily collect data from multiple users


## How Has This Been Tested


## Types of changes


## Checklist

