### PR TITLE
[bugfix] - revert erroneous snap-down "fix" for stage mesh margin

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -205,6 +205,7 @@ def bb_ray_prescreen(
     )
 
     # account for the affects of stage mesh margin
+    # Warning: Bullet raycast on stage triangle mesh does NOT consider the margin, so explicitly consider this here.
     margin_offset = (
         0
         if not highest_support_impact_with_stage

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -219,10 +219,6 @@ def bb_ray_prescreen(
         + gravity_dir * (base_rel_height - margin_offset)
     )
 
-    print(f"base_rel_height = {base_rel_height}")
-    print(f"surface_snap_point = {surface_snap_point}")
-    print(f"lowest_key_point_height = {lowest_key_point_height}")
-
     # return list of relative base height, object position for surface snapped point, and ray results details
     return {
         "base_rel_height": base_rel_height,
@@ -284,16 +280,8 @@ def snap_down(
                 )
             ):
                 obj.translation = cached_position
-                print(
-                    f" Failure: contact in final position w/ distance = {cp.contact_distance}."
-                )
-                if not (
-                    cp.object_id_a in support_obj_ids
-                    or cp.object_id_b in support_obj_ids
-                ):
-                    print(
-                        f" Failure: contact in final position with non support object {cp.object_id_a} or {cp.object_id_b}."
-                    )
+                # print(f" Failure: contact in final position w/ distance = {cp.contact_distance}.")
+                # print(f" Failure: contact in final position with non support object {cp.object_id_a} or {cp.object_id_b}.")
                 return False
         return True
     else:

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -181,7 +181,6 @@ def bb_ray_prescreen(
                 if hit.object_id == obj.object_id:
                     continue
                 elif hit.object_id in support_obj_ids:
-                    print(f"hit.ray_distance = {hit.ray_distance}")
                     hit_point = ray.origin + ray.direction * hit.ray_distance
                     support_impacts[ix] = hit_point
                     support_impact_height = mn.math.dot(

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -42,16 +42,19 @@ def test_snap_down(support_margin, obj_margin, stage_support):
 
     otm = mm.object_template_manager
     stm = mm.stage_template_manager
-    # setup a cube ground plane object config
+
+    # prepare the support object depending on 'stage_support' mode. Either a STATIC object or a stage mesh.
     cube_template_handle = otm.get_template_handles("cubeSolid")[0]
     cube_stage_template_handle = "cube_stage_object"
     plane_stage_template_handle = "plane_stage"
     if not stage_support:
+        # setup a cube ground plane object config
         cube_template = otm.get_template_by_handle(cube_template_handle)
         cube_template.scale = mn.Vector3(10, 0.05, 10)
         cube_template.margin = support_margin
         otm.register_template(cube_template, cube_stage_template_handle)
     else:
+        # setup a stage using the plane.glb test asset
         new_stage_template = stm.create_new_template(
             handle=plane_stage_template_handle
         )
@@ -98,7 +101,9 @@ def test_snap_down(support_margin, obj_margin, stage_support):
             cube_stage_obj = rom.add_object_by_template_handle(
                 cube_stage_template_handle
             )
-            assert cube_stage_obj.is_alive
+            assert (
+                cube_stage_obj.is_alive
+            ), "Failure to add object may indicate configuration issue or no 'cube_stage_template_handle'."
             support_obj_ids = [cube_stage_obj.object_id]
         cube_obj = rom.add_object_by_template_handle(cube_template_handle)
         assert cube_obj.is_alive


### PR DESCRIPTION
## Motivation and Context

Reverts a change in my previous PR #1220 removing stage margin consideration. 

I had trusted that Bullet raycast would take margin into account. Upon further investigation, it does so for object convex shapes, but NOT for stage concave collision meshes. Therefore, while the previous change to consider object collision aabb is correct, the removal of stage margin correction was erroneous and is replaced here.

Note that the result of #1220 is that snapping to a stage is likely to fail (due to default margin), but snapping to objects (e.g. furniture receptacles) should be better.
This fix should allow best performance for both cases.

## How Has This Been Tested

I have added an explicit test for stage assets with a variable margin. This test failed until I reverted the previous changes and now passes, validating this correction.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
