### PR TITLE
[bug fix] change stretch mesh

### DIFF
--- a/habitat-lab/habitat/config/benchmark/rearrange/play_stretch.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/play_stretch.yaml
@@ -2,6 +2,8 @@
 
 defaults:
   - /habitat: habitat_config_base
+  - /habitat/task/actions:
+    - base_velocity_non_cylinder
   - /habitat/simulator/agents@habitat.simulator.agents.main_agent: rgbdp_head_rgbd_arm_agent
   - /habitat/task/rearrange: play
   - /habitat/dataset/rearrangement: replica_cad
@@ -26,6 +28,15 @@ habitat:
         gaze_distance_range: [0.1, 3.0]
         center_cone_angle_threshold: 20.0
         center_cone_vector: [0.0, 1.0, 0.0]
+      base_velocity_non_cylinder:
+        allow_dyn_slide: False
+        # There is a collision if the difference between the clamped NavMesh position and target position
+        # is more than than collision_threshold for any point
+        collision_threshold: 1e-5
+        # The x and y locations of the clamped NavMesh position
+        navmesh_offset: [[0.0, 0.0],[-0.035, 0.085],[-0.035, -0.085]]
+        # If we allow the robot to move laterally
+        enable_lateral_move: False
   simulator:
     type: RearrangeSim-v0
     seed: 100
@@ -33,7 +44,7 @@ habitat:
       - "data/objects/ycb/configs/"
     agents:
       main_agent:
-        radius: 0.3
+        radius: 0.085
         articulated_agent_urdf: data/robots/hab_stretch/urdf/hab_stretch.urdf
         articulated_agent_type: "StretchRobot"
         sim_sensors:


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? --> It changes the configuration of Stretch's mesh, so that we can use a smaller radius, which is important to navigate in the tight space 

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. --> Running interactive_play.py in FP and Replica_cad scenes. However, I found that the radius of Stretch-base a bit off. This needs further investigation.

## Types of changes

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
