### PR TITLE
RearrangeGenerator cleanup and unstable object culling

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/configs/hab/rearrange.yaml
+++ b/habitat-lab/habitat/datasets/rearrange/configs/hab/rearrange.yaml
@@ -134,7 +134,7 @@ object_samplers:
     params:
       object_sets: ["hab2"]
       receptacle_sets: ["clutter"]
-      num_samples: [30, 30]
+      num_samples: [30, 40]
       orientation_sampling: "up"
   -
     name: "any_targets"

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -484,7 +484,8 @@ class RearrangeEpisodeGenerator:
                 new_receptacle = sampler.sample_receptacle(
                     self.sim, recep_tracker
                 )
-                if recep_tracker.update_receptacle_tracking(new_receptacle):
+                if recep_tracker.allocate_one_placement(new_receptacle):
+                    # used up new_receptacle, need to recompute the sampler's receptacle_candidates
                     sampler.receptacle_candidates = None
                 new_target_receptacles.append(new_receptacle)
 
@@ -504,7 +505,8 @@ class RearrangeEpisodeGenerator:
                 )
                 if isinstance(new_receptacle, OnTopOfReceptacle):
                     new_receptacle.set_episode_data(self.episode_data)
-                if recep_tracker.update_receptacle_tracking(new_receptacle):
+                if recep_tracker.allocate_one_placement(new_receptacle):
+                    # used up new_receptacle, need to recompute the sampler's receptacle_candidates
                     sampler.receptacle_candidates = None
 
                 new_goal_receptacles.append(new_receptacle)
@@ -512,6 +514,7 @@ class RearrangeEpisodeGenerator:
             goal_receptacles[sampler_name] = new_goal_receptacles
             all_goal_receptacles.extend(new_goal_receptacles)
 
+        # Goal and target receptacles are allowed 1 extra maximum object if a limit was defined
         for recep in [*all_goal_receptacles, *all_target_receptacles]:
             recep_tracker.inc_count(recep.name)
 

--- a/habitat-lab/habitat/datasets/rearrange/run_episode_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/run_episode_generator.py
@@ -51,8 +51,7 @@ class RearrangeEpisodeGeneratorConfig:
         default_factory=lambda: ["data/objects/ycb/"]
     )
     # optionally correct unstable states by removing extra unstable objects (within minimum samples limitations)
-    # TODO: This option is off by default for backwards compatibility and because it does not yet work with target sampling.
-    correct_unstable_results: bool = False
+    correct_unstable_results: bool = True
     # ----- resource set definitions ------
     # Define the sets of scenes, objects, and receptacles which can be sampled from.
     # The SceneDataset will be searched for resources of each type with handles containing ANY "included" substrings and NO "excluded" substrings.

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -374,16 +374,25 @@ class ObjectSampler:
         self,
         sim: habitat_sim.Simulator,
         recep_tracker: ReceptacleTracker,
-        target_receptacles,
+        target_receptacles: List[Receptacle],
         snap_down: bool = False,
         vdb: Optional[DebugVisualizer] = None,
-    ) -> List[habitat_sim.physics.ManagedRigidObject]:
+    ) -> List[Tuple[habitat_sim.physics.ManagedRigidObject, Receptacle]]:
         """
         Defaults to uniform sample: object -> receptacle -> volume w/ rejection -> repeat.
-        Optionally provide a debug visualizer (vdb)
+
+        :param sim: The active Simulator instance.
+        :param recep_tracker: The pre-initialized ReceptacleTracker instace containg active ReceptacleSets.
+        :param target_receptacles: A list of pre-selected Receptacles for target object placement. These will be sampled first.
+        :param snap_down: Whether or not to use the snap_down utility to place the objects.
+        :param vdb: Optionally provide a debug visualizer (vdb)
+
+        :return: The list of new (object,receptacle) pairs placed by the sampler.
         """
         num_pairing_tries = 0
-        new_objects: List[habitat_sim.physics.ManagedRigidObject] = []
+        new_objects: List[
+            Tuple[habitat_sim.physics.ManagedRigidObject, Receptacle]
+        ] = []
 
         logger.info(
             f"    Trying to sample {self.target_objects_number} from range {self.num_objects}"
@@ -397,7 +406,7 @@ class ObjectSampler:
         ):
             num_pairing_tries += 1
             if len(new_objects) < len(target_receptacles):
-                # no objects sampled yet
+                # sample objects explicitly from pre-designated target receptacles first
                 new_object, receptacle = self.single_sample(
                     sim,
                     recep_tracker,

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -413,8 +413,9 @@ class ObjectSampler:
                 )
                 if (
                     new_object is not None
-                    and recep_tracker.update_receptacle_tracking(receptacle)
+                    and recep_tracker.allocate_one_placement(receptacle)
                 ):
+                    # used up receptacle, need to recompute the sampler's receptacle_candidates
                     self.receptacle_candidates = None
 
             if new_object is not None:

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -27,7 +27,7 @@ from habitat.sims.habitat_simulator.debug_visualizer import DebugVisualizer
 
 class ObjectSampler:
     """
-    Sample an object from a set and try to place it in the scene from some receptacle set.
+    Sample an object from a set and try to place it in the scene on a Receptacles from some Receptacle set.
     """
 
     def __init__(
@@ -41,7 +41,13 @@ class ObjectSampler:
         recep_set_sample_probs: Optional[Dict[str, float]] = None,
     ) -> None:
         """
+        :param object_set: The set objects from which placements will be sampled.
+        :param allowed_recep_set_names:
+        :param num_objects: The [minimum, maximum] number of objects for this sampler. Actual target value for the sampler will be uniform random number in this range.
+        :param orientation_sample: Optionally choose to sample object orientation as well as position. Options are: None, "up" (1D), "all" (rand quat).
+        :param sample_region_ratio: Defines a XZ scaling of the sample region around its center. Default no scaling. Enables shrinking aabb receptacles away from edges.
         :param nav_to_min_distance: -1.0 means there will be no accessibility constraint. Positive values indicate minimum distance from sampled object to a navigable point.
+        :param recep_set_sample_probs: Optionally provide a non-uniform weighting for receptacle sampling.
         """
         self.object_set = object_set
         self._allowed_recep_set_names = allowed_recep_set_names
@@ -88,7 +94,13 @@ class ObjectSampler:
     ) -> Receptacle:
         """
         Sample a receptacle from the receptacle_set and return relevant information.
-        If cull_tilted_receptacles is True, receptacles are culled for objects with local "down" (-Y), not aligned with gravity (unit dot product compared to tilt_tolerance).
+
+        :param sim: The active Simulator instance.
+        :param recep_tracker: The pre-initialized ReceptacleTracker object defining available ReceptacleSets.
+        :param cull_tilted_receptacles: Whether or not to remove tilted Receptacles from the candidate set.
+        :param tilt_tolerance: If cull_tilted_receptacles is True, receptacles are culled for objects with local "down" (-Y), not aligned with gravity (unit dot product compared to tilt_tolerance).
+
+        :return: The sampled Receptacle. AssertionError if no valid Receptacle candidates are found.
         """
         if self.receptacle_instances is None:
             self.receptacle_instances = find_receptacles(sim)
@@ -211,6 +223,14 @@ class ObjectSampler:
     ) -> Optional[habitat_sim.physics.ManagedRigidObject]:
         """
         Attempt to sample a valid placement of the object in/on a receptacle given an object handle and receptacle information.
+
+        :param sim: The active Simulator instance.
+        :param object_handle: The handle of the object template for instantiation and attempted placement.
+        :param receptacle: The Receptacle instance on which to sample a placement position.
+        :param snap_down: Whether or not to use the snap_down utility to place the object.
+        :param vdb: Optionally provide a debug visualizer (vdb)
+
+        :return: The newly instanced rigid object or None if placement sampling failed.
         """
         num_placement_tries = 0
         new_object = None
@@ -311,7 +331,11 @@ class ObjectSampler:
 
         return None
 
-    def _is_accessible(self, sim, new_object) -> bool:
+    def _is_accessible(
+        self,
+        sim: habitat_sim.Simulator,
+        obj: habitat_sim.physics.ManagedRigidObject,
+    ) -> bool:
         """
         Return if the object is within a threshold distance of the nearest
         navigable point and that the nearest navigable point is on the same
@@ -323,12 +347,10 @@ class ObjectSampler:
         """
         if self.nav_to_min_distance == -1:
             return True
-        snapped = sim.pathfinder.snap_point(new_object.translation)
+        snapped = sim.pathfinder.snap_point(obj.translation)
         island_radius: float = sim.pathfinder.island_radius(snapped)
         dist = float(
-            np.linalg.norm(
-                np.array((snapped - new_object.translation))[[0, 2]]
-            )
+            np.linalg.norm(np.array((snapped - obj.translation))[[0, 2]])
         )
         return (
             dist < self.nav_to_min_distance
@@ -344,6 +366,18 @@ class ObjectSampler:
         fixed_target_receptacle=None,
         fixed_obj_handle: Optional[str] = None,
     ) -> Optional[habitat_sim.physics.ManagedRigidObject]:
+        """
+        Sample a single object placement by first sampling a Receptacle candidate, then an object, then attempting to place that object on the Receptacle.
+
+        :param sim: The active Simulator instance.
+        :param recep_tracker: The pre-initialized ReceptacleTracker instace containg active ReceptacleSets.
+        :param snap_down: Whether or not to use the snap_down utility to place the objects.
+        :param vdb: Optionally provide a debug visualizer (vdb)
+        :param fixed_target_receptacle: Optionally provide a pre-selected Receptacle instead of sampling. For example, when a target object's receptacle is selected in advance.
+        :param fixed_obj_handle: Optionally provide a pre-selected object instead of sampling. For example, when sampling the goal position for a known target object.
+
+        :return: The newly instanced rigid object or None if sampling failed.
+        """
         # draw a new pairing
         if fixed_obj_handle is None:
             object_handle = self.sample_object()
@@ -363,7 +397,10 @@ class ObjectSampler:
 
         return new_object, target_receptacle
 
-    def set_num_samples(self):
+    def set_num_samples(self) -> None:
+        """
+        Choose a target number of objects to sample from the configured range.
+        """
         self.target_objects_number = (
             random.randrange(self.num_objects[0], self.num_objects[1])
             if self.num_objects[1] > self.num_objects[0]


### PR DESCRIPTION
## Motivation and Context

This PR addresses the incompatibility between unstable object culling feature and target sampling. Additionally added a chunk of documentation, typing, and refactoring cleanup.

**Breaking: Unstable object culling is now turned on by default.**

_Note: To use this feature and leverage the speedup sampler num_objects range size should be non-zero (i.e. maximum objects sampled > minimum objects sampled) to allow room for correction._

## How Has This Been Tested

Locally generated 100 episodes with modified `rearrange.yaml` (30-40 clutter objects):
```
python habitat-lab/habitat/datasets/rearrange/run_episode_generator.py --run --config habitat-lab/habitat/datasets/rearrange/configs/hab/rearrange.yaml --num-episodes 100
```
Results:
```
Generated 100 episodes in 143 tries.
RearrangeEpisodeGenerator generated 100 episodes in 215.2370069026947 seconds.`
```

Without unstable object culling:
```
`Generated 100 episodes in 511 tries.
RearrangeEpisodeGenerator generated 100 episodes in 833.8440971374512 seconds.`
```

**~4x speedup at this scale, but only 43 failed episodes vs. 411 failed episodes.**

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
