### PR TITLE
Add support for glTF multi-receptacle assets

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -535,25 +535,25 @@ def import_tri_mesh(mesh_file: str) -> List[mn.trade.MeshData]:
 
     :param mesh_file: The input meshes file. NOTE: must contain only triangles.
     """
-    _importer = _manager.load_and_instantiate("AnySceneImporter")
-    _importer.open_file(mesh_file)
+    importer = _manager.load_and_instantiate("AnySceneImporter")
+    importer.open_file(mesh_file)
 
     mesh_data: List[mn.trade.MeshData] = []
 
     # import mesh data and pre-process
     mesh_data = [
-        filter_interleave_mesh(_importer.mesh(mesh_ix))
-        for mesh_ix in range(_importer.mesh_count)
+        filter_interleave_mesh(importer.mesh(mesh_ix))
+        for mesh_ix in range(importer.mesh_count)
     ]
 
     # if there is a scene defined, apply any transformations
-    if _importer.scene_count > 0:
-        scene_id = _importer.default_scene
+    if importer.scene_count > 0:
+        scene_id = importer.default_scene
         # If there's no default scene, load the first one
         if scene_id == -1:
             scene_id = 0
 
-        scene = _importer.scene(scene_id)
+        scene = importer.scene(scene_id)
 
         # Mesh referenced by mesh_assignments[i] has a corresponding transform in
         # mesh_transformations[i]. Association to a particular node ID is stored in

--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -575,6 +575,8 @@ def import_tri_mesh(mesh_file: str) -> List[mn.trade.MeshData]:
             )
         ]
 
+    _importer.close()
+
     return mesh_data
 
 

--- a/test/test_rearrange_task.py
+++ b/test/test_rearrange_task.py
@@ -284,13 +284,13 @@ def test_receptacle_parsing():
             # check for contents and correct type parsing
             if receptacle.name == "receptacle_aabb_chair_test":
                 assert type(receptacle) is hab_receptacle.AABBReceptacle
-            elif receptacle.name == "receptacle_mesh_chair_test":
+            elif receptacle.name == "receptacle_mesh_chair_test.0000":
                 assert (
                     type(receptacle) is hab_receptacle.TriangleMeshReceptacle
                 )
             elif receptacle.name == "receptacle_aabb_simpleroom_test":
                 assert type(receptacle) is hab_receptacle.AABBReceptacle
-            elif receptacle.name == "receptacle_mesh_simpleroom_test":
+            elif receptacle.name == "receptacle_mesh_simpleroom_test.0000":
                 assert (
                     type(receptacle) is hab_receptacle.TriangleMeshReceptacle
                 )


### PR DESCRIPTION
## Motivation and Context

Current `TriangleMeshReceptacle` parsing supports only single mesh PLY files. This PR adds support for multi-mesh glTF files.

In the multi-mesh case, a unique `TriangleMeshReceptacle` instance is created for each sub-mesh.

For example, if 3 sub-meshes exist in the `1234.glb` file referenced from receptacle metadata like:
```
"receptacle_mesh_1234": {
      "name": "receptacle_mesh_1234",
      "mesh_filepath": "my_rec_meshes/1234.glb"
  }
```
The parser will produce 3 TriangleMeshReceptacles named:
```
"receptacle_mesh_1234.0000"
"receptacle_mesh_1234.0001"
"receptacle_mesh_1234.0002"
```

NOTE some un-quiet-able logging is expected from receptacle loading and import initialization.
This will be fixed soon in a follow-up change to Magnum APIs introducing log quieting functionality.
E.g.:
```
Trade::GltfImporter::scene(): node 0 extras modelObb property is Utility::JsonToken::Type::Object, skipping
...
PluginManager::Manager: duplicate static plugin AnySceneImporter, ignoring
```
## How Has This Been Tested

Locally with .glb and .ply files.
Should update test_assets in habitat-sim to include new .glb receptacles.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
