### PR TITLE
sandbox tool habitat-sim built with bullet check

### DIFF
--- a/SIRO_README.md
+++ b/SIRO_README.md
@@ -9,7 +9,7 @@ Project-specific README for SIRo.
 1. Install Habitat-sim `main` branch.
     * [Build from source](https://github.com/facebookresearch/habitat-sim/blob/main/BUILD_FROM_SOURCE.md), or install the [conda nightly build](https://github.com/facebookresearch/habitat-sim#recommended-conda-packages).
         * Be sure to include Bullet physics, e.g. `python setup.py install --bullet`.
-    * Anecdotally, building from source is working more reliably (versus the conda nightly build).  
+    * Anecdotally, building from source is working more reliably (versus the conda nightly build).
     * If you build from source, configure `PYTHONPATH` and ensure that Python `import habitat_sim` imports your locally-built version of Habitat-sim.
     * Keep an eye on relevant [commits to main](https://github.com/facebookresearch/habitat-sim/commits/main) to help you decide when to update/rebuild Habitat-sim.
 1. Download humanoid data.
@@ -26,7 +26,7 @@ see [Sandbox Tool Readme](./examples/siro_sandbox/README.md)
 
 Fetch-Fetch in ReplicaCAD multi-agent training, single GPU. From `habitat-lab` directory:
 ```
-HABITAT_SIM_LOG=warning:physics,metadata=quiet MAGNUM_LOG=warning python habitat-baselines/habitat_baselines/run.py --config-name experiments_hab3/pop_play_kinematic_oracle.yaml 
+HABITAT_SIM_LOG=warning:physics,metadata=quiet MAGNUM_LOG=warning python habitat-baselines/habitat_baselines/run.py --config-name experiments_hab3/pop_play_kinematic_oracle.yaml
 ```
 
 # Eval

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -17,6 +17,7 @@ flags = sys.getdlopenflags()
 sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
 import argparse
+from functools import wraps
 from typing import Any
 
 import magnum as mn
@@ -42,6 +43,20 @@ DEFAULT_POSE_PATH = "data/humanoids/humanoid_data/walking_motion_processed.pkl"
 DEFAULT_CFG = "benchmark/rearrange/rearrange_easy_human_and_fetch.yaml"
 
 
+def requires_habitat_sim_with_bullet(callable_):
+    @wraps(callable_)
+    def wrapper(*args, **kwds):
+        import habitat_sim
+
+        assert (
+            habitat_sim.built_with_bullet
+        ), f"Habitat-sim is built without bullet, but {callable_.__name__} requires Habitat-sim with bullet."
+        return callable_(*args, **kwds)
+
+    return wrapper
+
+
+@requires_habitat_sim_with_bullet
 class SandboxDriver(GuiAppDriver):
     def __init__(self, args, config, gui_input):
         with habitat.config.read_write(config):


### PR DESCRIPTION
## Motivation and Context

Adds `requires_habitat_sim_with_bullet` decorator.

Decorates SandboxDriver with `requires_habitat_sim_with_bullet` to check if habitat-sim is built with bullet before instantiation SandboxDriver.

This seems to me a more informative / general check, but I can change to `sim.get_physics_simulation_library() != habitat_sim.physics.PhysicsSimulationLibrary.NoPhysics`. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
