### PR TITLE
Aks wandb job name

### DIFF
--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/multi_agent_kinematic_oracle_human_robot.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/multi_agent_kinematic_oracle_human_robot.yaml
@@ -113,6 +113,7 @@ habitat_baselines:
   wb:
     project_name: 'hab3'
     entity: 'andrew-colab'
+    run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
 
   eval:
     should_load_ckpt: False

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/multi_agent_kinematic_oracle_human_robot.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/multi_agent_kinematic_oracle_human_robot.yaml
@@ -180,12 +180,10 @@ habitat_baselines:
               apply_postconds: True
               force_end_on_timeout: False
               ignore_grip: True
-
             wait:
               skill_name: "WaitSkillPolicy"
               max_skill_steps: -1
               ignore_grip: True
-
             reset_arm:
               skill_name: "NoopSkillPolicy"
               max_skill_steps: 1

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
@@ -17,6 +17,10 @@ defaults:
     - composite_subgoal_reward
   - _self_
 
+hydra:
+  job:
+    name: 'pop_play'
+
 habitat:
   environment:
     max_episode_steps: 700

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
@@ -78,6 +78,7 @@ habitat_baselines:
   wb:
     project_name: 'hab3'
     entity: 'andrew-colab'
+    run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
 
   eval:
     should_load_ckpt: False

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid.yaml
@@ -107,6 +107,7 @@ habitat_baselines:
   wb:
     project_name: 'hab3'
     entity: 'andrew-colab'
+    run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
 
   eval:
     should_load_ckpt: False

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid.yaml
@@ -30,6 +30,10 @@ defaults:
   - override /habitat/task/rearrange: multi_agent_tidy_house_base
   - _self_
 
+hydra:
+  job:
+    name: 'pop_play_humanoid'
+
 habitat:
   task:
     actions:

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/single_agent_kinematic_oracle.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/single_agent_kinematic_oracle.yaml
@@ -6,6 +6,10 @@ defaults:
   - override /habitat_baselines/rl/policy/hierarchical_policy/defined_skills@habitat_baselines.rl.policy.main_agent.hierarchical_policy.defined_skills: oracle_skills
   - _self_
 
+hydra:
+  job:
+    name: 'single_oracle'
+
 habitat_baselines:
   log_interval: 1
   video_dir: ${hydra:sweep.dir}/${hydra:sweep.subdir}/video
@@ -18,6 +22,7 @@ habitat_baselines:
   wb:
     project_name: 'hab3'
     entity: 'andrew-colab'
+    run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
   num_environments: 2
 
 habitat:

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/single_agent_kinematic_teleport.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/single_agent_kinematic_teleport.yaml
@@ -6,6 +6,10 @@ defaults:
   - override /habitat_baselines/rl/policy/hierarchical_policy/defined_skills@habitat_baselines.rl.policy.main_agent.hierarchical_policy.defined_skills: oracle_skills
   - _self_
 
+hydra:
+  job:
+    name: 'single_teleport'
+
 habitat_baselines:
   video_dir: ${hydra:sweep.dir}/${hydra:sweep.subdir}/video
   tensorboard_dir: ${hydra:sweep.dir}/${hydra:sweep.subdir}/tb
@@ -17,6 +21,7 @@ habitat_baselines:
   wb:
     project_name: 'hab3'
     entity: 'andrew-colab'
+    run_name: ${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
   num_environments: 2
 
 habitat:

--- a/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
+++ b/habitat-baselines/habitat_baselines/config/hydra/output/path.yaml
@@ -1,6 +1,6 @@
 # @package hydra
 run:
-  dir: /checkpoint/akshararai/hab3/${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  dir: ./outputs/${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
   subdir: ${hydra.job.num}_${hydra.job.override_dirname}
 sweep:
   dir: /checkpoint/akshararai/hab3/${hydra.job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}


### PR DESCRIPTION
## Motivation and Context

Adding a job name to configs to make it easy to tell the different runs apart.
Adding wandb job names to correspond to checkpoint folders so that we can match runs with checkpoints.
