### PR TITLE
SIRo eval sweep

### DIFF
--- a/eval_sweep.sh
+++ b/eval_sweep.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+base_dir="/checkpoint/akshararai/hab3"
+read -p -r "Enter sweep directory name (example: pop_play/2023-04-17/16-19-04):" SWEEP_SUBDIR
+SWEEP_DIR="$base_dir/$SWEEP_SUBDIR"
+echo "$SWEEP_DIR"
+#SWEEP_DIR="/checkpoint/akshararai/hab3/pop_play/2023-04-17/16-19-04/"
+echo "Sweep directories:"
+for dir in "$SWEEP_DIR"/*/; do
+	subdir=$(basename "$dir")
+    echo "$subdir"
+    wandb_name="eval_$SWEEP_SUBDIR"
+    python habitat-baselines/habitat_baselines/run.py -m --config-name config.yaml --config-path "${dir}"/.hydra/ habitat_baselines.eval_ckpt_path_dir="${dir}"/checkpoints/latest.pth habitat_baselines.video_dir="${dir}"/video habitat_baselines.wb.run_name="${wandb_name}" habitat_baselines.evaluate=True habitat_baselines.test_episode_count=20 habitat_baselines.num_environments=16
+done

--- a/eval_sweep.sh
+++ b/eval_sweep.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 base_dir="/checkpoint/akshararai/hab3"
-read -p -r "Enter sweep directory name (example: pop_play/2023-04-17/16-19-04):" SWEEP_SUBDIR
+# shellcheck disable=SC2162
+read -p "Enter sweep directory name (example: pop_play/2023-04-17/16-19-04):" SWEEP_SUBDIR
 SWEEP_DIR="$base_dir/$SWEEP_SUBDIR"
 echo "$SWEEP_DIR"
 #SWEEP_DIR="/checkpoint/akshararai/hab3/pop_play/2023-04-17/16-19-04/"

--- a/eval_sweep.sh
+++ b/eval_sweep.sh
@@ -11,5 +11,5 @@ for dir in "$SWEEP_DIR"/*/; do
 	subdir=$(basename "$dir")
     echo "$subdir"
     wandb_name="eval_$SWEEP_SUBDIR"
-    python habitat-baselines/habitat_baselines/run.py -m --config-name config.yaml --config-path "${dir}"/.hydra/ habitat_baselines.eval_ckpt_path_dir="${dir}"/checkpoints/latest.pth habitat_baselines.video_dir="${dir}"/video habitat_baselines.wb.run_name="${wandb_name}" habitat_baselines.evaluate=True habitat_baselines.test_episode_count=20 habitat_baselines.num_environments=16
+    python habitat-baselines/habitat_baselines/run.py -m --config-name config.yaml --config-path "${dir}"/.hydra/ habitat_baselines.eval_ckpt_path_dir="${dir}"/checkpoints/latest.pth habitat_baselines.video_dir="${dir}"/video habitat_baselines.wb.run_name="${wandb_name}" habitat_baselines.evaluate=True habitat_baselines.test_episode_count=20 habitat_baselines.num_environments=16 habitat_baselines.eval.should_load_ckpt=True
 done

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
@@ -85,7 +85,7 @@ habitat_baselines:
     run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
 
   eval:
-    should_load_ckpt: False
+    should_load_ckpt: True
     video_option: ["disk"]
 
   rl:

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid.yaml
@@ -107,10 +107,10 @@ habitat_baselines:
   wb:
     project_name: 'hab3'
     entity: 'andrew-colab'
-    run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
+    run_name: ${hydra:job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
 
   eval:
-    should_load_ckpt: False
+    should_load_ckpt: True
     video_option: ["disk"]
 
   rl:


### PR DESCRIPTION
Added `eval_sweep.sh` which takes as input a training sweep folder like `pop_play/2023-04-17/16-19-04`.  It loops over all subdirectories in this folder and uses the training config `config.yaml` to set all eval parameters. This ensures that the train and eval parameters are the same.
It creates a new wandb run with the name `eval_<training_wandb_name>`, saves eval videos to the same training sweep folder. This way we have corresponding training and eval wand runs, as well as checkpoints and videos.