### PR TITLE
make min_envs configurable

### DIFF
--- a/habitat-baselines/habitat_baselines/config/default_structured_configs.py
+++ b/habitat-baselines/habitat_baselines/config/default_structured_configs.py
@@ -319,6 +319,7 @@ class VERConfig(HabitatBaselinesBaseConfig):
     variable_experience: bool = True
     num_inference_workers: int = 2
     overlap_rollouts_and_learn: bool = False
+    min_scenes_per_env: int = 16
 
 
 @dataclass

--- a/habitat-baselines/habitat_baselines/rl/ver/environment_worker.py
+++ b/habitat-baselines/habitat_baselines/rl/ver/environment_worker.py
@@ -48,8 +48,6 @@ if TYPE_CHECKING:
     from omegaconf import DictConfig
 
 
-MIN_SCENES_PER_ENV = 16
-
 T = TypeVar("T")
 
 
@@ -339,7 +337,8 @@ def _create_worker_configs(config: "DictConfig"):
 
     # We use a minimum number of scenes per environment to reduce bias
     scenes_per_env = max(
-        int(math.ceil(len(scenes) / num_environments)), MIN_SCENES_PER_ENV
+        int(math.ceil(len(scenes) / num_environments)),
+        config.habitat_baselines.min_scenes_per_env,
     )
     scene_splits: List[List[str]] = [[] for _ in range(num_environments)]
     for idx, scene in enumerate(infinite_shuffling_iterator(scenes)):


### PR DESCRIPTION
## Motivation and Context

VER consumes a substantial amount of RAM because unlike DDPPO, it requires every worker to load at least 16 environments' worth of datasets. This fix will allow the user to lower the minimum (can be set to 1 so that each scene is only loaded by 1 EnvironmentWorker)

## How Has This Been Tested

Training using ObjectNav HM3D

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
