### PR TITLE
Humanoid Rotation Fix

### DIFF
--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -279,8 +279,9 @@ def get_input_vel_ctlr(
             ) = env._sim.articulated_agent.get_joint_transform()
             # Divide joint_trans by 4 since joint_trans has flattened quaternions
             # and the dimension of each quaternion is 4
+            base_trans = env._sim.articulated_agent.base_transformation
             num_joints = len(joint_trans) // 4
-            root_trans = np.array(root_trans)
+            root_trans = np.array(base_trans)
             index_arms_start = 10
             joint_trans_quat = [
                 mn.Quaternion(
@@ -306,8 +307,9 @@ def get_input_vel_ctlr(
                     for quat in rotated_joints_quat
                 ]
             )
+            offset_trans = np.array(mn.Matrix4())
             base_action = np.concatenate(
-                [joint_trans.reshape(-1), root_trans.transpose().reshape(-1)]
+                [joint_trans.reshape(-1), offset_trans.transpose().reshape(-1), root_trans.transpose().reshape(-1)]
             )
         else:
             # Use the controller
@@ -470,7 +472,7 @@ def play_env(env, args, config):
     humanoid_controller = None
     if args.use_humanoid_controller:
         humanoid_controller = HumanoidRearrangeController(args.walk_pose_path)
-        humanoid_controller.reset(env._sim.articulated_agent.base_pos)
+        humanoid_controller.reset(env._sim.articulated_agent.base_transformation)
 
     while True:
         if (

--- a/examples/interactive_play.py
+++ b/examples/interactive_play.py
@@ -309,7 +309,11 @@ def get_input_vel_ctlr(
             )
             offset_trans = np.array(mn.Matrix4())
             base_action = np.concatenate(
-                [joint_trans.reshape(-1), offset_trans.transpose().reshape(-1), root_trans.transpose().reshape(-1)]
+                [
+                    joint_trans.reshape(-1),
+                    offset_trans.transpose().reshape(-1),
+                    root_trans.transpose().reshape(-1),
+                ]
             )
         else:
             # Use the controller
@@ -472,7 +476,9 @@ def play_env(env, args, config):
     humanoid_controller = None
     if args.use_humanoid_controller:
         humanoid_controller = HumanoidRearrangeController(args.walk_pose_path)
-        humanoid_controller.reset(env._sim.articulated_agent.base_transformation)
+        humanoid_controller.reset(
+            env._sim.articulated_agent.base_transformation
+        )
 
     while True:
         if (

--- a/examples/siro_sandbox/controllers.py
+++ b/examples/siro_sandbox/controllers.py
@@ -333,8 +333,8 @@ class GuiHumanoidController(Controller):
 
     def on_environment_reset(self):
         super().on_environment_reset()
-        base_pos = self.get_articulated_agent().base_pos
-        self._humanoid_controller.reset(base_pos)
+        base_trans = self.get_articulated_agent().base_transformation
+        self._humanoid_controller.reset(base_trans)
         self._hint_walk_dir = None
         self._hint_grasp_obj_idx = None
         self._hint_drop_pos = None

--- a/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
+++ b/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
@@ -53,7 +53,8 @@ TURNING_STEP_AMOUNT = (
     20  # The maximum angle we should be rotating at a given step
 )
 THRESHOLD_ROTATE_NOT_MOVE = 20  # The rotation angle above which we should only walk as if rotating in place
-EPS = 1e-5 # Distance at which we should stop
+EPS = 1e-5  # Distance at which we should stop
+
 
 class HumanoidRearrangeController:
     """
@@ -113,8 +114,10 @@ class HumanoidRearrangeController:
         """Reset the joints on the human. (Put in rest state)"""
         self.obj_transform_offset = mn.Matrix4()
         self.obj_transform_base = base_transformation
-        self.prev_orientation = base_transformation.transform_vector(mn.Vector3(1.0, 0., 0.))
-        
+        self.prev_orientation = base_transformation.transform_vector(
+            mn.Vector3(1.0, 0.0, 0.0)
+        )
+
     def calculate_stop_pose(self):
         """
         Calculates a stop, standing pose
@@ -154,13 +157,13 @@ class HumanoidRearrangeController:
                 np.arctan2(prev_orientation[2], prev_orientation[0])
                 * deg_per_rads
             )
-            # Update this...    
+            # Update this...
             forward_angle = new_angle - prev_angle
             if forward_angle >= 180:
                 forward_angle = 180 - forward_angle
             if forward_angle <= -180:
                 forward_angle = 360 + forward_angle
-            
+
             if np.abs(forward_angle) > self.min_angle_turn:
                 actual_angle_move = self.turning_step_amount
                 if abs(forward_angle) < actual_angle_move:
@@ -225,7 +228,9 @@ class HumanoidRearrangeController:
         joint_pose, obj_transform = new_pose.joints, new_pose.root_transform
 
         # We correct the object transform
-        forward_V_norm = mn.Vector3([forward_V[2], forward_V[1], -forward_V[0]])
+        forward_V_norm = mn.Vector3(
+            [forward_V[2], forward_V[1], -forward_V[0]]
+        )
         look_at_path_T = mn.Matrix4.look_at(
             self.obj_transform_base.translation,
             self.obj_transform_base.translation + forward_V_norm.normalized(),
@@ -233,9 +238,7 @@ class HumanoidRearrangeController:
         )
 
         # Remove the forward component, and orient according to forward_V
-        add_rot = mn.Matrix4.rotation(
-            mn.Rad(np.pi), mn.Vector3(0, 1.0, 0)
-        )
+        add_rot = mn.Matrix4.rotation(mn.Rad(np.pi), mn.Vector3(0, 1.0, 0))
         obj_transform = add_rot @ obj_transform
         obj_transform.translation *= mn.Vector3.x_axis() + mn.Vector3.y_axis()
 

--- a/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
+++ b/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
@@ -68,11 +68,12 @@ class HumanoidRearrangeController:
         self,
         walk_pose_path,
         draw_fps=30,
+        rotate_amount=20,
         base_offset=(0, 0.9, 0),
     ):
         self.min_angle_turn = MIN_ANGLE_TURN
-        self.turning_step_amount = TURNING_STEP_AMOUNT
-        self.threshold_rotate_not_move = THRESHOLD_ROTATE_NOT_MOVE
+        self.turning_step_amount = rotate_amount
+        self.threshold_rotate_not_move = rotate_amount
         self.base_offset = mn.Vector3(base_offset)
 
         if not os.path.isfile(walk_pose_path):
@@ -157,10 +158,9 @@ class HumanoidRearrangeController:
                 np.arctan2(prev_orientation[2], prev_orientation[0])
                 * deg_per_rads
             )
-            # Update this...
             forward_angle = new_angle - prev_angle
             if forward_angle >= 180:
-                forward_angle = 180 - forward_angle
+                forward_angle = forward_angle - 360
             if forward_angle <= -180:
                 forward_angle = 360 + forward_angle
 

--- a/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
+++ b/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
@@ -53,7 +53,7 @@ TURNING_STEP_AMOUNT = (
     20  # The maximum angle we should be rotating at a given step
 )
 THRESHOLD_ROTATE_NOT_MOVE = 20  # The rotation angle above which we should only walk as if rotating in place
-
+EPS = 1e-5 # Distance at which we should stop
 
 class HumanoidRearrangeController:
     """
@@ -109,11 +109,12 @@ class HumanoidRearrangeController:
         self.prev_orientation = None
         self.walk_mocap_frame = 0
 
-    def reset(self, position) -> None:
+    def reset(self, base_transformation) -> None:
         """Reset the joints on the human. (Put in rest state)"""
         self.obj_transform_offset = mn.Matrix4()
-        self.obj_transform_base.translation = position + self.base_offset
-
+        self.obj_transform_base = base_transformation
+        self.prev_orientation = base_transformation.transform_vector(mn.Vector3(1.0, 0., 0.))
+        
     def calculate_stop_pose(self):
         """
         Calculates a stop, standing pose
@@ -138,22 +139,28 @@ class HumanoidRearrangeController:
         """
         deg_per_rads = 180.0 / np.pi
         forward_V = target_position
-        if forward_V.length() == 0.0:
+        if forward_V.length() < EPS:
             self.calculate_stop_pose()
             return
         distance_to_walk = np.linalg.norm(forward_V)
         did_rotate = False
 
         # The angle we initially want to go to
-        new_angle = np.arctan2(forward_V[0], forward_V[2]) * deg_per_rads
+        new_angle = np.arctan2(forward_V[2], forward_V[0]) * deg_per_rads
         if self.prev_orientation is not None:
             # If prev orrientation is None, transition to this position directly
             prev_orientation = self.prev_orientation
             prev_angle = (
-                np.arctan2(prev_orientation[0], prev_orientation[2])
+                np.arctan2(prev_orientation[2], prev_orientation[0])
                 * deg_per_rads
             )
+            # Update this...    
             forward_angle = new_angle - prev_angle
+            if forward_angle >= 180:
+                forward_angle = 180 - forward_angle
+            if forward_angle <= -180:
+                forward_angle = 360 + forward_angle
+            
             if np.abs(forward_angle) > self.min_angle_turn:
                 actual_angle_move = self.turning_step_amount
                 if abs(forward_angle) < actual_angle_move:
@@ -165,8 +172,7 @@ class HumanoidRearrangeController:
                 did_rotate = True
             else:
                 new_angle = new_angle / deg_per_rads
-
-            forward_V = mn.Vector3(np.sin(new_angle), 0, np.cos(new_angle))
+            forward_V = mn.Vector3(np.cos(new_angle), 0, np.sin(new_angle))
 
         forward_V = mn.Vector3(forward_V)
         forward_V = forward_V.normalized()
@@ -219,13 +225,18 @@ class HumanoidRearrangeController:
         joint_pose, obj_transform = new_pose.joints, new_pose.root_transform
 
         # We correct the object transform
+        forward_V_norm = mn.Vector3([forward_V[2], forward_V[1], -forward_V[0]])
         look_at_path_T = mn.Matrix4.look_at(
             self.obj_transform_base.translation,
-            self.obj_transform_base.translation + forward_V.normalized(),
+            self.obj_transform_base.translation + forward_V_norm.normalized(),
             mn.Vector3.y_axis(),
         )
 
         # Remove the forward component, and orient according to forward_V
+        add_rot = mn.Matrix4.rotation(
+            mn.Rad(np.pi), mn.Vector3(0, 1.0, 0)
+        )
+        obj_transform = add_rot @ obj_transform
         obj_transform.translation *= mn.Vector3.x_axis() + mn.Vector3.y_axis()
 
         # This is the rotation and translation caused by the current motion pose

--- a/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
+++ b/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
@@ -13,6 +13,7 @@ from habitat.articulated_agents.mobile_manipulator import (
     MobileManipulator,
     MobileManipulatorParams,
 )
+from habitat_sim.utils.common import orthonormalize_rotation_shear
 
 
 class KinematicHumanoid(MobileManipulator):
@@ -34,14 +35,14 @@ class KinematicHumanoid(MobileManipulator):
             ee_constraint=np.zeros((2, 2, 3)),
             cameras={
                 "head": ArticulatedAgentCameraParams(
-                    cam_offset_pos=mn.Vector3(0.0, 0.5, 0.25),
-                    cam_look_at_pos=mn.Vector3(0.0, 0.5, 0.75),
+                    cam_offset_pos=mn.Vector3(0., 0.5, 0.25),
+                    cam_look_at_pos=mn.Vector3(0., 0.5, 0.75),
                     attached_link_id=-1,
                 ),
                 "third": ArticulatedAgentCameraParams(
                     cam_offset_pos=mn.Vector3(-1.2, 2.0, -1.2),
                     cam_look_at_pos=mn.Vector3(1, 0.0, 0.75),
-                    attached_link_id=-1,
+                    attached_link_id=-2,
                 ),
             },
             arm_mtr_pos_gain=0.3,
@@ -72,6 +73,7 @@ class KinematicHumanoid(MobileManipulator):
         # Base transform will move linearly when the character follows
         # a path, whereas the offset transform will be changing the position
         # to simulate different gaits
+        self.sim = sim
         self.offset_transform = mn.Matrix4()
 
         # TODO: make this part of reset skill
@@ -155,6 +157,8 @@ class KinematicHumanoid(MobileManipulator):
                 ]
             )
         )
+        self.offset_rot = -np.pi / 2
+
 
     @property
     def inverse_offset_transform(self):
@@ -164,7 +168,11 @@ class KinematicHumanoid(MobileManipulator):
 
     @property
     def base_transformation(self):
-        return self.sim_obj.transformation @ self.inverse_offset_transform
+        angle_rot = self.offset_rot
+        add_rot = mn.Matrix4.rotation(
+            mn.Rad(angle_rot), mn.Vector3(0, 1.0, 0)
+        )
+        return self.sim_obj.transformation @ self.inverse_offset_transform @ add_rot
 
     @property
     def base_pos(self):
@@ -194,13 +202,14 @@ class KinematicHumanoid(MobileManipulator):
 
     @property
     def base_rot(self) -> float:
-        return self.base_transformation.rotation.angle()
+        return self.sim_obj.rotation.angle() + mn.Rad(self.offset_rot)
 
     @base_rot.setter
     def base_rot(self, rotation_y_rad: float):
         if self._base_type == "mobile" or self._base_type == "leg":
+            angle_rot = -self.offset_rot
             self.sim_obj.rotation = mn.Quaternion.rotation(
-                mn.Rad(rotation_y_rad), mn.Vector3(0, 1, 0)
+                mn.Rad(rotation_y_rad+angle_rot), mn.Vector3(0, 1, 0)
             )
         else:
             raise NotImplementedError("The base type is not implemented.")
@@ -208,7 +217,8 @@ class KinematicHumanoid(MobileManipulator):
     def set_rest_position(self) -> None:
         """Sets the agents in a resting position"""
         joint_list = self.rest_joints
-        offset_transform = self.rest_matrix
+        offset_transform = mn.Matrix4() # self.rest_matrix
+        self.sim_obj.joint_positions = joint_list
         self.set_joint_transform(
             joint_list, offset_transform, self.base_transformation
         )
@@ -219,6 +229,60 @@ class KinematicHumanoid(MobileManipulator):
         self.sim_obj.motion_type = habitat_sim.physics.MotionType.KINEMATIC
         self.update()
         self.set_rest_position()
+
+
+    def update(self) -> None:
+        """Updates the camera transformations and performs necessary checks on
+        joint limits and sleep states.
+        """
+        if self._cameras is not None:
+            # get the transformation
+            agent_node = self._sim._default_agent.scene_node
+            inv_T = agent_node.transformation.inverted()
+            # update the cameras
+            for cam_prefix, sensor_names in self._cameras.items():
+                for sensor_name in sensor_names:
+                    sens_obj = self._sim._sensors[sensor_name]._sensor_object
+                    cam_info = self.params.cameras[cam_prefix]
+
+                    if cam_info.attached_link_id == -1:
+                        link_trans = self.sim_obj.transformation
+                    elif cam_info.attached_link_id == -2:
+                        link_trans = self.base_transformation
+                    else:
+                        link_trans = self.sim_obj.get_link_scene_node(
+                            cam_info.attached_link_id
+                        ).transformation
+
+                    if cam_info.cam_look_at_pos == mn.Vector3(0, 0, 0):
+                        pos = cam_info.cam_offset_pos
+                        ori = cam_info.cam_orientation
+                        Mt = mn.Matrix4.translation(pos)
+                        Mz = mn.Matrix4.rotation_z(mn.Rad(ori[2]))
+                        My = mn.Matrix4.rotation_y(mn.Rad(ori[1]))
+                        Mx = mn.Matrix4.rotation_x(mn.Rad(ori[0]))
+                        cam_transform = Mt @ Mz @ My @ Mx
+                    else:
+                        cam_transform = mn.Matrix4.look_at(
+                            cam_info.cam_offset_pos,
+                            cam_info.cam_look_at_pos,
+                            mn.Vector3(0, 1, 0),
+                        )
+                    cam_transform = (
+                        link_trans
+                        @ cam_transform
+                        @ cam_info.relative_transform
+                    )
+                    cam_transform = inv_T @ cam_transform
+
+                    sens_obj.node.transformation = (
+                        orthonormalize_rotation_shear(cam_transform)
+                    )
+
+        if self._fix_joint_values is not None:
+            self.arm_joint_pos = self._fix_joint_values
+
+        self.sim_obj.awake = True
 
     def reset(self) -> None:
         super().reset()
@@ -235,9 +299,13 @@ class KinematicHumanoid(MobileManipulator):
         # TODO: should this go into articulated agent?
         self.sim_obj.joint_positions = joint_list
         self.offset_transform = offset_transform
-        final_transform = base_transform @ offset_transform
+        add_rot = mn.Matrix4.rotation(
+            mn.Rad(-self.offset_rot), mn.Vector3(0, 1.0, 0)
+        )
+        final_transform = (base_transform @ add_rot) @ offset_transform
 
         self.sim_obj.transformation = final_transform
+
 
     def get_joint_transform(self):
         """Returns the joints and base transform of the humanoid"""

--- a/habitat-lab/habitat/articulated_agents/mobile_manipulator.py
+++ b/habitat-lab/habitat/articulated_agents/mobile_manipulator.py
@@ -19,7 +19,7 @@ from habitat_sim.simulator import Simulator
 class ArticulatedAgentCameraParams:
     """Data to configure a camera placement on the articulated agent.
     :property attached_link_id: Which link ID this camera is attached to, -1
-        for the base link.
+        for the root transformation, -2 for the base transformation.
     :property cam_offset_pos: The 3D position of the camera relative to the
         transformation of the attached link.
     :property cam_look_at_pos: The 3D of where the camera should face relative

--- a/habitat-lab/habitat/tasks/rearrange/actions/oracle_nav_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/oracle_nav_action.py
@@ -120,7 +120,7 @@ class OracleNavAction(BaseVelAction, HumanoidJointAction):
 
             if self.motion_type == "human_joints":
                 self.humanoid_controller.reset(
-                    self.cur_articulated_agent.base_pos
+                    self.cur_articulated_agent.base_transformation
                 )
             self._targets[nav_to_target_idx] = (start_pos, np.array(obj_pos))
         return self._targets[nav_to_target_idx]

--- a/test/test_humanoid.py
+++ b/test/test_humanoid.py
@@ -223,10 +223,11 @@ def test_humanoid_controller():
         )
         humanoid_controller = HumanoidRearrangeController(walk_pose_path)
 
-        init_pos = kin_humanoid.base_pos
+        init_trans = kin_humanoid.base_transformation
+        init_pos = init_trans.transformation
         target_pos = init_pos + mn.Vector3(1.5, 0, 0)
         step_count = 0
-        humanoid_controller.reset(init_pos)
+        humanoid_controller.reset(init_trans)
         while step_count < num_steps:
             pose_diff = target_pos - kin_humanoid.base_pos
             humanoid_controller.calculate_walk_pose(pose_diff)


### PR DESCRIPTION
## Motivation and Context
The humanoid was pointing to the -Z direction, as a result PDDL actions that should end with the humanoid looking at the object oriented the humanoid badly. This PR corrects this. It also adds the option to visualize a static camera for the humanoid, to better identify foot-sliding. 

## How Has This Been Tested

Interactive Play with PDDL and Smooth actions

## Types of changes
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Experiment\]** A pull request that add new features to the [habitat-baselines](/habitat-baselines/) training codebase. Experiments Pull Requests can be any size, must have smoke/integration tests and be isolated from the rest of the code. Your code additions should not rely on other habitat-baselines code. This is to avoid dependencies between different parts of habitat-baselines. You must also include a README that will document how to use your new feature or trainer. **You** will be the maintainer of this code, if the code becomes stale or is not supported often enough, we will eventually remove it.

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
