### PR TITLE
add PerfLogger and runtime perf stats

### DIFF
--- a/habitat-baselines/habitat_baselines/common/construct_vector_env.py
+++ b/habitat-baselines/habitat_baselines/common/construct_vector_env.py
@@ -18,7 +18,7 @@ def construct_envs(
     config: "DictConfig",
     workers_ignore_signals: bool = False,
     enforce_scenes_greater_eq_environments: bool = False,
-) -> VectorEnv:
+):
     r"""Create VectorEnv object with specified config and env class type.
     To allow better performance, dataset are split into small ones for
     each individual env, grouped by scenes.
@@ -96,4 +96,5 @@ def construct_envs(
         env_fn_args=tuple((c,) for c in configs),
         workers_ignore_signals=workers_ignore_signals,
     )
-    return envs
+
+    return envs, len(scenes)

--- a/habitat-baselines/habitat_baselines/config/default_structured_configs.py
+++ b/habitat-baselines/habitat_baselines/config/default_structured_configs.py
@@ -391,6 +391,23 @@ class RLConfig(HabitatBaselinesBaseConfig):
 
 @dataclass
 class ProfilingConfig(HabitatBaselinesBaseConfig):
+    # The PerfLogger logs runtime perf stats as name/value pairs on two rows, like so:
+    #
+    # 2023-04-19 19:17:41,331 PerfLogger
+    # statName1,statName2,statName3
+    # 1.23,4,anotherStatValue
+    #
+    # The comma-separated lines can be pasted into a spreadsheet as CSV data. Runtime
+    # perf stats include timings and measures of scene complexity like object count and
+    # triangle count. These can be compared across experiments to understand changes
+    # in training throughput (steps per second, aka SPS).
+    enable_perf_logger: bool = False
+    # PerfLogger is verbose so we may not want to log it as often as other logging. Set
+    # to 1 to print at the same interval as habitat_baselines.log_interval, or
+    # set to a larger number to log less often.
+    perf_logger_skip_interval: int = 10
+
+    # Used with Nsight Systems profiling. See also profiling_wrapper.py.
     capture_start_step: int = -1
     num_steps_to_capture: int = -1
 

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle.yaml
@@ -15,6 +15,7 @@ defaults:
   - /habitat_baselines/rl/policy/hierarchical_policy/defined_skills@habitat_baselines.rl.policy.agent_1.hierarchical_policy.defined_skills: oracle_skills_ma
   - /habitat/task/measurements:
     - composite_subgoal_reward
+    - runtime_perf_stats
   - _self_
 
 hydra:
@@ -83,6 +84,10 @@ habitat_baselines:
     project_name: 'hab3'
     entity: 'andrew-colab'
     run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
+
+  profiling:
+    enable_perf_logger: True
+    perf_logger_skip_interval: 20
 
   eval:
     should_load_ckpt: True

--- a/habitat-baselines/habitat_baselines/utils/info_dict.py
+++ b/habitat-baselines/habitat_baselines/utils/info_dict.py
@@ -4,8 +4,13 @@ from typing import Any, Dict, List
 import numpy as np
 
 # These metrics are not scalars and cannot be easily reported
-# (unless using videos)
+# (unless using videos).
 NON_SCALAR_METRICS = {"top_down_map", "collisions.is_collision"}
+
+# These metrics are arbitrary data we're communicating from env workers
+# to the main rollout-collection process; not relevant to learning the task; like
+# runtime_perf_stats and other debug data.
+NON_TASK_METRICS = {"runtime_perf_stats"}
 
 
 def extract_scalars_from_info(info: Dict[str, Any]) -> Dict[str, float]:
@@ -21,7 +26,11 @@ def extract_scalars_from_info(info: Dict[str, Any]) -> Dict[str, float]:
     """
     result = {}
     for k, v in info.items():
-        if not isinstance(k, str) or k in NON_SCALAR_METRICS:
+        if (
+            not isinstance(k, str)
+            or k in NON_SCALAR_METRICS
+            or k in NON_TASK_METRICS
+        ):
             continue
 
         if isinstance(v, dict):

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -81,6 +81,8 @@ __all__ = [
     "NavToObjSuccessMeasurementConfig",
     "NavToObjRewardMeasurementConfig",
     "CompositeSuccessMeasurementConfig",
+    # DEBUG MEASURES
+    "RuntimePerfStatsMeasurementConfig",
 ]
 
 
@@ -674,6 +676,11 @@ class TopDownMapMeasurementConfig(MeasurementConfig):
 @dataclass
 class CollisionsMeasurementConfig(MeasurementConfig):
     type: str = "Collisions"
+
+
+@dataclass
+class RuntimePerfStatsMeasurementConfig(MeasurementConfig):
+    type: str = "RuntimePerfStats"
 
 
 @dataclass
@@ -2191,7 +2198,12 @@ cs.store(
     name="rearrange_reach_success",
     node=RearrangeReachSuccessMeasurementConfig,
 )
-
+cs.store(
+    package="habitat.task.measurements.runtime_perf_stats",
+    group="habitat/task/measurements",
+    name="runtime_perf_stats",
+    node=RuntimePerfStatsMeasurementConfig,
+)
 
 from hydra.core.config_search_path import ConfigSearchPath
 from hydra.core.plugins import Plugins

--- a/habitat-lab/habitat/core/env.py
+++ b/habitat-lab/habitat/core/env.py
@@ -469,11 +469,17 @@ class RLEnv(gym.Env):
 
         :return: :py:`(observations, reward, done, info)`
         """
+        t_start = time.time()
 
         observations = self._env.step(*args, **kwargs)
         reward = self.get_reward(observations)
         done = self.get_done(observations)
         info = self.get_info(observations)
+
+        if "runtime_perf_stats" in info:
+            info["runtime_perf_stats"]["RLEnv.step (ms)"] = (
+                time.time() - t_start
+            ) * 1000
 
         return observations, reward, done, info
 

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os.path as osp
+import time
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
@@ -123,6 +124,11 @@ class RearrangeSim(HabitatSim):
         )
         self._step_physics = self.habitat_config.step_physics
         self._kinematic_mode = self.habitat_config.kinematic_mode
+
+        self._backend_runtime_perf_stat_names = (
+            super().get_runtime_perf_stat_names()
+        )
+        self._extra_runtime_perf_stats: Dict[str, Any] = {}
 
     @property
     def receptacles(self) -> Dict[str, AABBReceptacle]:
@@ -246,6 +252,8 @@ class RearrangeSim(HabitatSim):
     def reconfigure(self, config: "DictConfig", ep_info: RearrangeEpisode):
         self._handle_to_goal_name = ep_info.info["object_labels"]
 
+        t_start = time.time()
+
         with read_write(config):
             config["scene"] = ep_info.scene_id
 
@@ -335,6 +343,7 @@ class RearrangeSim(HabitatSim):
                 node.semantic_id = (
                     obj.object_id + self.habitat_config.object_ids_start
                 )
+        self.add_perf_timing("reconfigure", t_start)
 
     def get_agent_data(self, agent_idx: Optional[int]):
         if agent_idx is None:
@@ -757,12 +766,21 @@ class RearrangeSim(HabitatSim):
             for _ in range(self.ac_freq_ratio):
                 self.internal_step(-1, update_articulated_agent=False)
 
+            t_start = time.time()
             self._prev_sim_obs = self.get_sensor_observations_async_finish()
+            self.add_perf_timing(
+                "get_sensor_observations_async_finish", t_start
+            )
+
             obs = self._sensor_suite.get_observations(self._prev_sim_obs)
         else:
             for _ in range(self.ac_freq_ratio):
                 self.internal_step(-1, update_articulated_agent=False)
+
+            t_start = time.time()
             self._prev_sim_obs = self.get_sensor_observations()
+            self.add_perf_timing("get_sensor_observations", t_start)
+
             obs = self._sensor_suite.get_observations(self._prev_sim_obs)
 
         if self._enable_gfx_replay_save:
@@ -841,7 +859,9 @@ class RearrangeSim(HabitatSim):
         """
         # Optionally step physics and update the articulated_agent for benchmarking purposes
         if self._step_physics:
+            t_start = time.time()
             self.step_world(dt)
+            self.add_perf_timing("step_world", t_start)
 
     def get_targets(self) -> Tuple[np.ndarray, np.ndarray]:
         """Get a mapping of object ids to goal positions for rearrange targets.
@@ -878,3 +898,20 @@ class RearrangeSim(HabitatSim):
                 for idx in self._scene_obj_ids
             ]
         )
+
+    def add_perf_timing(self, desc, t_start):
+        t_curr = time.time()
+        full_desc = desc + " (ms)"
+        self._extra_runtime_perf_stats[full_desc] = (t_curr - t_start) * 1000
+
+    def get_runtime_perf_stats(self):
+        names = self._backend_runtime_perf_stat_names
+        values = super().get_runtime_perf_stat_values()
+        stats_dict = dict(zip(names, values))
+
+        for name, value in self._extra_runtime_perf_stats.items():
+            stats_dict[name] = value
+        # clear this dict so we don't accidentally collect these twice
+        self._extra_runtime_perf_stats = {}
+
+        return stats_dict

--- a/habitat-lab/habitat/utils/perf_logger.py
+++ b/habitat-lab/habitat/utils/perf_logger.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import os
+import random
+import subprocess
+import time
+from collections import OrderedDict
+
+import torch
+
+from habitat import logger
+from habitat.core.embodied_task import Measure
+from habitat.core.registry import registry
+from habitat.tasks.nav.nav import ImageGoalSensor
+
+
+class PerfLogger:
+    """
+    The PerfLogger logs runtime perf stats as name/value pairs on two rows, like so:
+
+    2023-04-19 19:17:41,331 PerfLogger
+    statName1,statName2,statName3
+    1.23,4,anotherStatValue
+
+    The comma-separated lines can be pasted into a spreadsheet as CSV data. Runtime
+    perf stats include timings and measures of scene complexity like object count and
+    triangle count. These can be compared across experiments to understand changes
+    in training throughput (steps per second, aka SPS).
+
+    To enable in PPO training:
+    * set config.habitat_baselines.profiling.enable_perf_logger
+    * add "runtime_perf_stats" to config.habitat.task.measurements
+    """
+
+    def _find_username(self, config):
+        # if len(config.habitat_baselines.wb.entity):
+        #     return config.habitat_baselines.wb.entity
+        return os.getlogin()
+
+    def _find_git_hash(self):
+        # from https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script
+        # Note that link suggests `import git` is not a good idea in long-running
+        # processes (like RL training), so we avoid it.
+
+        return (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+            .decode("ascii")
+            .strip()
+        )
+
+    def _check_rank_and_find_num_workers(self):
+        if not torch.distributed.is_initialized():
+            return 1
+        else:
+            if torch.distributed.get_rank() != 0:
+                logger.warn(
+                    "PerfLogger is running for worker rank=="
+                    + torch.distributed.get_rank()
+                    + " but we recommend only running it on worker rank==0"
+                )
+            return torch.distributed.get_world_size()
+
+    def _find_job_id(self):
+        job_id = os.environ.get("SLURM_JOB_ID", None)
+        if job_id is None:
+            # use a random int that will generally be unique across train runs
+            random.seed()
+            job_id = str(random.randint(10000, 99999))
+        return job_id
+
+    def __init__(self, config, num_scenes, observation_space, job_id=None):
+        if "runtime_perf_stats" not in config.habitat.task.measurements:
+            logger.warning(
+                "You have profiling.enable_perf_logger==True but you didn't include runtime_perf_stats in habitat.task.measurements. You won't get the full set of runtime perf stats."
+            )
+
+        self._log_counter = 0
+        self._log_skip_interval = (
+            config.habitat_baselines.profiling.perf_logger_skip_interval
+        )
+        self._num_steps = 0
+        self._step_timer = None
+        self._stats = OrderedDict()
+
+        self._stats["user"] = self._find_username(config)
+        self._stats["job id"] = (
+            job_id if job_id is not None else self._find_job_id()
+        )
+        # self._stats["num steps"] = 0
+        self._stats["SPS"] = 0
+        self._stats["git hash"] = self._find_git_hash()
+        self._stats["GPU"] = (
+            torch.cuda.get_device_name()
+            if torch.cuda.is_available()
+            else "none"
+        )
+        self._stats["num workers"] = self._check_rank_and_find_num_workers()
+        self._stats["num envs"] = config.habitat_baselines.num_environments
+        self._stats["num scenes"] = num_scenes
+        self._stats["backbone"] = config.habitat_baselines.rl.ddppo.backbone
+
+        num_rgb = 0
+        num_depth = 0
+        self._stats["viz_types"] = ""
+        viz_shapes_set = set()
+        for k, v in observation_space.spaces.items():
+            if len(v.shape) > 1 and k != ImageGoalSensor.cls_uuid:
+                image_shape = (v.shape[0], v.shape[1])
+                if image_shape not in viz_shapes_set:
+                    viz_shapes_set.add(image_shape)
+
+                if v.shape[2] == 1:
+                    num_depth += 1
+                elif v.shape[2] == 3:
+                    num_rgb += 1
+                else:
+                    logger.warn(
+                        "Failed to understand observation space "
+                        + k
+                        + " with shape "
+                        + v.shape
+                    )
+        # example outputs for below: Depth, RGB, RGBD, RGB 2x, RGB 2x + Depth
+        # todo: figure out how to detect semantic
+        if num_depth == 0 and num_rgb == 0:
+            self._stats["viz_types"] = "Blind"
+        elif num_rgb == 0:
+            self._stats["viz_types"] = "Depth"
+            if num_depth > 1:
+                self._stats["viz_types"] += " " + str(num_depth) + "x"
+        elif num_depth == 0:
+            self._stats["viz_types"] = "RGB"
+            if num_rgb > 1:
+                self._stats["viz_types"] += " " + str(num_rgb) + "x"
+        elif num_depth == num_rgb:
+            self._stats["viz_types"] = "RGBD"
+            if num_depth > 1:
+                self._stats["viz_types"] += " " + str(num_depth) + "x"
+        else:
+            self._stats["viz_types"] = "RGB"
+            if num_rgb > 1:
+                self._stats["viz_types"] += " " + str(num_rgb) + "x"
+            self._stats["viz_types"] += "+ Depth"
+            if num_depth > 1:
+                self._stats["viz_types"] += " " + str(num_depth) + "x"
+
+        self._stats["viz_shapes"] = ";".join(
+            [str(shape[0]) + "x" + str(shape[1]) for shape in viz_shapes_set]
+        )
+
+        # todo: get top-level config name
+
+        self._reset_sample_stats()
+
+    def _reset_sample_stats(self):
+        self._sample_stat_count_average_max = {}
+
+    def _stat_val_to_pretty_string(self, val):
+        if isinstance(val, float):
+            return "{:0.4}".format(val)
+        else:
+            return str(val)
+
+    def add_steps(self, num_steps):
+        if self._step_timer is None:
+            self._step_timer = time.time()
+            self._num_steps = 0
+        else:
+            self._num_steps += num_steps
+
+    def add_sample_stats(self, sample_stat_vals_dict):
+        for name, sample_val in sample_stat_vals_dict.items():
+            if name not in self._sample_stat_count_average_max:
+                self._sample_stat_count_average_max[name] = [0, 0, sample_val]
+            stat_list = self._sample_stat_count_average_max[name]
+            old_count = stat_list[0]
+            stat_list[1] = (stat_list[1] * old_count + sample_val) / (
+                old_count + 1
+            )
+            stat_list[2] = max(stat_list[2], sample_val)
+            stat_list[0] = old_count + 1
+
+    def check_log_summary(self, reset_sample_stats=True):
+        self._log_counter += 1
+        if self._log_counter % self._log_skip_interval != 1:
+            return
+
+        if self._log_counter != 1:
+            # update SPS stat
+            t_curr = time.time()
+            elapsed_since_last_log = t_curr - self._step_timer
+            # self._stats["num steps"] = self._num_steps
+            self._stats["SPS"] = self._num_steps / elapsed_since_last_log
+            self._num_steps = 0
+            self._step_timer = t_curr
+
+            # non-sample-based stats first, then sample count info, then sample-based stats
+            # date/time (comes from log), username, git hash, config name, num envs, GPU, total num updates, updates per summary, **avg_times, max_times, **avg_env_stats, max_env_stats
+
+            all_stat_vals = list(self._stats.values())
+            all_stat_names = list(self._stats.keys())
+            for name, stat_list in self._sample_stat_count_average_max.items():
+                all_stat_names.extend([name + " avg", "max", "count"])
+                all_stat_vals.extend(
+                    [stat_list[1], stat_list[2], stat_list[0]]
+                )
+
+            all_stat_pretty_vals = [
+                self._stat_val_to_pretty_string(val) for val in all_stat_vals
+            ]
+
+            s = "PerfLogger\n"
+            s += ",".join(all_stat_names) + "\n"
+            s += ",".join(all_stat_pretty_vals)
+            logger.info(s)
+        else:
+            # first batch of stats are usually not representative, so don't print them
+            pass
+
+        if reset_sample_stats:
+            self._reset_sample_stats()
+
+
+@registry.register_measure
+class RuntimePerfStats(Measure):
+    cls_uuid: str = "runtime_perf_stats"
+
+    @staticmethod
+    def _get_uuid(*args, **kwargs):
+        return RuntimePerfStats.cls_uuid
+
+    def __init__(self, sim, config, *args, **kwargs):
+        self._sim = sim
+        super().__init__()
+
+    def reset_metric(self, *args, **kwargs):
+        self._metric = {}
+
+    def update_metric(self, *args, task, **kwargs):
+        self._metric = self._sim.get_runtime_perf_stats()


### PR DESCRIPTION
## Motivation and Context

The PerfLogger logs runtime perf stats as name/value pairs on two rows, like so:

```
2023-04-19 19:17:41,331 PerfLogger
user,job id,SPS,git hash,GPU,num workers,num envs,num scenes,backbone,viz_types,viz_shapes,compute actions (ms) avg,max,count,wait for steps (ms) avg,max,count,num rigid avg,max,count,num active rigid avg,max,count,num artic avg,max,count,num active overlaps avg,max,count,num active contacts avg,max,count,num drawables avg,max,count,num faces avg,max,count,get_sensor_observations_async_finish (ms) avg,max,count,RLEnv.step (ms) avg,max,count,reconfigure (ms) avg,max,count,_update_agent (ms) avg,max,count
eundersander,42180,14.29,a7526068,NVIDIA GeForce RTX 2070 Super with Max-Q Design,1,2,63,resnet18,Depth 2x,256x256,35.69,104.4,256,84.38,423.2,256,49.5,50.0,512,0.0,0.0,512,8.0,8.0,512,138.3,203.0,512,4.943,73.0,512,1.988e+03,2.425e+03,512,5.941e+06,7.239e+06,512,6.393,17.19,512,56.13,150.5,512,150.7,268.9,39,421.2,421.2,2
```

The comma-separated lines can be pasted into a spreadsheet as CSV data. Runtime perf stats include timings and measures of scene complexity like object count and triangle count. These can be compared across experiments to understand changes in training throughput (steps per second, aka SPS).

To enable in PPO training:
* set config.habitat_baselines.profiling.enable_perf_logger
* add "runtime_perf_stats" to config.habitat.task.measurements

PerfLogger output from your training should be pasted here to help us track SIRo runtime perf:
https://docs.google.com/spreadsheets/d/1vvqBBbV6k0Kyli7g3dIrZRDqJFFF6ufKnRd9wMBuUsY/edit#gid=1750357307

## How Has This Been Tested

Local testing on Mac and Fedora laptop.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Dependency Upgrade\]** Upgrades one or several dependencies in habitat
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!
- **\[Experiment\]** A pull request that add new features to the [habitat-baselines](/habitat-baselines/) training codebase. Experiments Pull Requests can be any size, must have smoke/integration tests and be isolated from the rest of the code. Your code additions should not rely on other habitat-baselines code. This is to avoid dependencies between different parts of habitat-baselines. You must also include a README that will document how to use your new feature or trainer. **You** will be the maintainer of this code, if the code becomes stale or is not supported often enough, we will eventually remove it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
