### PR TITLE
Sandbox third-person camera

### DIFF
--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -8,12 +8,12 @@ This is a 3D interactive GUI app for testing various pieces of SIRo, e.g. rearra
 ## Known Issues
 * The policy-driven agent doesn't seem to be working in terms of producing interesting actions. As a placeholder, I've injected random-base-movement behavior in `BaselinesController.act`; see comment "temp do random base actions".
 * One-time visual flicker shortly after app startup on Mac
-* Spot robot stops and doesn't move once it collides with any object (try pressing `M` to reset to a next episode)
+* Spot robot stops and doesn't move once it collides with any object (try pressing `M` to reset to a next episode).
 
 ## Running HITL eval with a user-controlled humanoid and policy-driven Fetch or Spot
 
-1. Make sure you've followed the [SIRo install instructions](../../SIRO_README.md#installation).
-2. To use Fetch run:
+* Make sure you've followed the [SIRo install instructions](../../SIRO_README.md#installation), including grabbing latest habitat-sim `main`.
+* To use Fetch, run:
 ```
 HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
 python examples/siro_sandbox/sandbox_app.py \
@@ -23,7 +23,7 @@ python examples/siro_sandbox/sandbox_app.py \
 --cfg benchmark/rearrange/rearrange_easy_human_and_fetch.yaml \
 --cfg-opts habitat.dataset.split=minival
 ```
-3. To use Spot run (make sure you are using latest habitat-sim version):
+* To use Spot, run:
 ```
 HABITAT_SIM_LOG=warning MAGNUM_LOG=warning
 python examples/siro_sandbox/sandbox_app.py \
@@ -34,9 +34,7 @@ python examples/siro_sandbox/sandbox_app.py \
 --cfg-opts habitat.dataset.split=minival
 ```
 
-Add `--debug-images` argument followed by the camera sensors ids to enable debug observations visualization in the app GUI. For example, to visualize agent1's head depth sensor observations add: `--debug-images agent_1_head_depth`.
-
-### Controls
+## Controls
 * Mouse scroll wheel to zoom the camera in/out.
 * Right-click on the floor and hold to move the humanoid.
 * Mouse-over an object. When you see a yellow highlight, left-click to grasp.
@@ -46,6 +44,14 @@ Add `--debug-images` argument followed by the camera sensors ids to enable debug
     1. WASD keys
     2. hold Q and move mouse
 * `M` to reset to a new episode.
+
+## Debugging visual sensors
+
+Add `--debug-images` argument followed by the camera sensors ids to enable debug observations visualization in the app GUI. For example, to visualize agent1's head depth sensor observations add: `--debug-images agent_1_head_depth`.
+
+## Debugging simulator-rendering
+
+Add `--debug-third-person-width 600` to enable the debug third-person camera. Like all visual sensors, this is simulator-rendered, unlike the main sandbox app viewport, which is replay-rendered.
 
 ## Testing BatchReplayRenderer
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -370,7 +370,7 @@ def parse_debug_third_person(args, framebuffer_size):
     do_show = args.debug_third_person_width != 0
 
     width = args.debug_third_person_width
-    # default to square aspet ratio
+    # default to square aspect ratio
     height = (
         args.debug_third_person_height
         if args.debug_third_person_height != 0

--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -62,7 +62,7 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
 
         # todo: allocate drawer lazily
         self._image_drawer = ImageFramebufferDrawer(
-            max_width=1024, max_height=1024
+            max_width=1440, max_height=1440
         )
         self._debug_images = []
         self._need_render = True

--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -14,8 +14,14 @@ from habitat_sim import ReplayRenderer, ReplayRendererConfiguration
 
 
 class ReplayGuiAppRenderer(GuiAppRenderer):
-    def __init__(self, width, height, use_batch_renderer=False):
-        self.viewport_size = mn.Vector2i(width, height)
+    def __init__(
+        self,
+        window_width,
+        window_height,
+        use_batch_renderer=False,
+        viewport_rect=None,
+    ):
+        self.window_size = mn.Vector2i(window_width, window_height)
         # arbitrary uuid
         self._sensor_uuid = "rgb_camera"
 
@@ -25,10 +31,22 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         camera_sensor_spec = habitat_sim.CameraSensorSpec()
         camera_sensor_spec.senπsor_type = habitat_sim.SensorType.COLOR
         camera_sensor_spec.uuid = self._sensor_uuid
-        camera_sensor_spec.resolution = [
-            height,
-            width,
-        ]
+        if viewport_rect:
+            # unfortunately, at present, we only support a viewport rect placed
+            # in the bottom left corner. See https://cvmlp.slack.com/archives/G0131KVLBLL/p1682023823697029
+            assert viewport_rect.left == 0
+            assert viewport_rect.bottom == 0
+            assert viewport_rect.right <= window_width
+            assert viewport_rect.top <= window_height
+            camera_sensor_spec.resolution = [
+                viewport_rect.top,
+                viewport_rect.right,
+            ]
+        else:
+            camera_sensor_spec.resolution = [
+                window_height,
+                window_width,
+            ]
         camera_sensor_spec.position = np.array([0, 0, 0])
         camera_sensor_spec.orientation = np.array([0, 0, 0])
 
@@ -84,11 +102,11 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         self._replay_renderer.render(mn.gl.default_framebuffer)
 
         # arrange debug images on right side of frame, tiled down from the top
-        dest_y = self.viewport_size.y
+        dest_y = self.window_size.y
         for image in self._debug_images:
             im_height, im_width, _ = image.shape
             self._image_drawer.draw(
-                image, self.viewport_size.x - im_width, dest_y - im_height
+                image, self.window_size.x - im_width, dest_y - im_height
             )
             dest_y -= im_height
 


### PR DESCRIPTION
## Motivation and Context

This will be useful for troubleshooting simulator-rendering, e.g. skinning.

This builds on our existing debug_image support. I add a flag to enable `debug_render` and the debug third-person camera sensor. I also modify ReplayGuiAppRenderer to more cleanly display the large third-person camera debug image alongside the main viewport.
![sandbox_app_debug_third_person](https://user-images.githubusercontent.com/6557808/233695742-e9dfb108-f9ea-40a6-854e-d1b047e31217.png)

## How Has This Been Tested

Local testing on Mac and Fedora.

## Types of changes
PR into SIRo

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
