### PR TITLE
Add gfx-replay capture to SIRo sandbox app.

### DIFF
--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -81,7 +81,7 @@ Add `--gui-controlled-agent-index` followed by the agent's index you want to con
 
 If not set, it is assumed that scene is empty or all agents are policy-controlled. App switches to free camera mode in this case. User-controlled free camera lets the user observe the scene (instead of controlling one of the agents). For instance, one use case is to (eventually) observe policy-controlled agents.
 
-**Note:** currentrly, only robot controllers can be policy-controlled (as for now they perform random actions). Policy-controlled humanoid controller is not implemented yet. So, if you want to test the free camera mode, make sure you are using robot-robot config as a `--cfg` argument value (for example, `--cfg benchmark/rearrange/rearrange_easy_fetch_and_fetch.yaml`).
+**Note:** Currently, only robot controllers can be policy-controlled (as for now they perform random actions). Policy-controlled humanoid controller is not implemented yet. So, if you want to test the free camera mode, make sure you are using robot-robot config as a `--cfg` argument value (for example, `--cfg benchmark/rearrange/rearrange_easy_fetch_and_fetch.yaml`).
 
 ## Solo humanoid mode
 Set `--cfg benchmark/rearrange/rearrange_easy_human.yaml` to run app with only a user-controlled humanoid (no robot).
@@ -89,7 +89,7 @@ Set `--cfg benchmark/rearrange/rearrange_easy_human.yaml` to run app with only a
 ## First-person humanoid control
 Add `--first-person-mode` to switch to first-person humanoid control mode.
 
-## Uning FP dataset
+## Using FP dataset
 To use FP dataset follow the FP installation instructions in [SIRO_README.md](../../SIRO_README.md) and run any of the above Sandbox launch command with the following config overrides:
 ```
 ...
@@ -99,6 +99,9 @@ habitat.task.pddl_domain_def=fp \
 +habitat.simulator.additional_object_paths="[data/objects/ycb/configs/, data/objects/amazon_berkeley/configs/, data/objects/google_object_dataset/configs/]" \
 habitat.dataset.data_path=data/datasets/floorplanner/rearrange/scratch/train/s108294897_176710602.json.gz
 ```
+
+## Capturing Gfx-Replay Files
+Gfx-Replay files are graphics captures that can be replayed by other applications, such as Blender. Recording can be enabled with the `--enable-gfx-replay-save` argument. Capturing starts at the first frame and ends (is saved) when pressing the period (`.`) key. The `--gfx-replay-save-path` argument can be set to specify a custom save location.
 
 ## Testing BatchReplayRenderer
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -18,7 +18,7 @@ sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
 import argparse
 from functools import wraps
-from typing import Any
+from typing import Any, List
 
 import magnum as mn
 import numpy as np
@@ -102,6 +102,10 @@ class SandboxDriver(GuiAppDriver):
             # limit pith angle to +/- 90 degrees
             self._min_lookat_offset_pitch = -np.pi / 2 + 1e-5
             self._max_lookat_offset_pitch = np.pi / 2 - 1e-5
+
+        self._enable_gfx_replay_save: bool = args.enable_gfx_replay_save
+        self._gfx_replay_save_path: str = args.gfx_replay_save_path
+        self._recording_keyframes: List[str] = []
 
     @property
     def lookat_offset_yaw(self):
@@ -309,8 +313,9 @@ class SandboxDriver(GuiAppDriver):
         return walk_dir, grasp_object_id, drop_pos
 
     def _camera_pitch_and_yaw_wasd_control(self):
-        # update yaw and pitch uning WASD keys
+        # update yaw and pitch using WASD keys
         cam_rot_angle = 0.1
+
         if self.gui_input.get_key(GuiInput.KeyNS.W):
             self._lookat_offset_pitch -= cam_rot_angle
         if self.gui_input.get_key(GuiInput.KeyNS.S):
@@ -435,8 +440,31 @@ class SandboxDriver(GuiAppDriver):
             self.lookat, 0.03, mn.Color3(1, 0, 0)
         )
 
+    def _save_recorded_keyframes_to_file(self):
+        # Consolidate recorded keyframes into a single json string
+        # self._recording_keyframes format:
+        #     List['{"keyframe": {...}', '{"keyframe": {...}', ...]
+        # Output format:
+        #     '{"keyframes": [{...}, {...}, ...]}'
+        json_keyframes = "".join(
+            keyframe[12:-1] + ","
+            for keyframe in self._recording_keyframes[:-1]
+        )
+        json_keyframes += self._recording_keyframes[-1:][0][
+            12:-1
+        ]  # Last element without trailing comma
+        json_content = '{{"keyframes": [{}]}}'.format(json_keyframes)
+
+        # Save keyframes to file
+        with open(self._gfx_replay_save_path, "w") as json_file:
+            json_file.write(json_content)
+
     def sim_update(self, dt):
         # todo: pipe end_play somewhere
+
+        # Capture gfx-replay file
+        if self.gui_input.get_key_down(GuiInput.KeyNS.PERIOD):
+            self._save_recorded_keyframes_to_file()
 
         # _viz_anim_fraction goes from 0 to 1 over time and then resets to 0
         viz_anim_speed = 2.0
@@ -517,11 +545,12 @@ class SandboxDriver(GuiAppDriver):
 
         post_sim_update_dict["cam_transform"] = cam_transform
 
-        post_sim_update_dict[
-            "keyframes"
-        ] = (
+        keyframes = (
             self.get_sim().gfx_replay_manager.write_incremental_saved_keyframes_to_string_array()
         )
+        post_sim_update_dict["keyframes"] = keyframes
+        if self._enable_gfx_replay_save:
+            self._recording_keyframes.append(keyframes[0])
 
         def depth_to_rgb(obs):
             converted_obs = np.concatenate(
@@ -531,7 +560,7 @@ class SandboxDriver(GuiAppDriver):
 
         # reference code for visualizing a camera sensor in the app GUI
         assert set(self._debug_images).issubset(set(self.obs.keys())), (
-            f"Cemara sensors ids: {list(set(self._debug_images).difference(set(self.obs.keys())))} "
+            f"Camera sensors ids: {list(set(self._debug_images).difference(set(self.obs.keys())))} "
             f"not in available sensors ids: {list(self.obs.keys())}"
         )
         debug_images = (
@@ -677,13 +706,25 @@ if __name__ == "__main__":
         help="Choose between classic and batch renderer",
     )
     # temp argument:
-    # allowes to switch between oracle baseline nav
+    # allowed to switch between oracle baseline nav
     # and random base vel action
     parser.add_argument(
         "--sample-random-baseline-base-vel",
         action="store_true",
         default=False,
         help="Sample random BaselinesController base vel",
+    )
+    parser.add_argument(
+        "--enable-gfx-replay-save",
+        action="store_true",
+        default=False,
+        help="Save the gfx-replay keyframes to file. Use --gfx-replay-save-path to specify the save location.",
+    )
+    parser.add_argument(
+        "--gfx-replay-save-path",
+        default="./data/gfx-replay.json",
+        type=str,
+        help="Path where the captured graphics replay file is saved.",
     )
 
     args = parser.parse_args()

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -550,7 +550,8 @@ class SandboxDriver(GuiAppDriver):
         )
         post_sim_update_dict["keyframes"] = keyframes
         if self._enable_gfx_replay_save:
-            self._recording_keyframes.append(keyframes[0])
+            for keyframe in keyframes:
+                self._recording_keyframes.append(keyframe)
 
         def depth_to_rgb(obs):
             converted_obs = np.concatenate(

--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -31,7 +31,7 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         cfg.num_environments = 1
         cfg.standalone = False  # Context is owned by the GLFW window
         camera_sensor_spec = habitat_sim.CameraSensorSpec()
-        camera_sensor_spec.senπsor_type = habitat_sim.SensorType.COLOR
+        camera_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
         camera_sensor_spec.uuid = self._sensor_uuid
         if viewport_rect:
             # unfortunately, at present, we only support a viewport rect placed


### PR DESCRIPTION
## Motivation and Context

This provides the sandbox app with the capability to record gfx-replay captures.

When starting the sandbox app with the `--enable-gfx-replay-save` argument, every frame is recorded.
Upon pressing the period key, the gfx-replay file is saved at the location defined in `--gfx-replay-save-path`.

Note that currently, captures have to be done from the start so that all `creation` and `load` keyframes are captured. If we wanted to fix this, we would need to change the recorder so that it can provide the history of loads and creations.

## How Has This Been Tested

Tested locally. Capture validated in Blender.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
