### PR TITLE
Sandbox controls and text polish

### DIFF
--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -50,24 +50,7 @@ habitat.simulator.habitat_sim_v0.allow_sliding=True
 
 
 ## Controls
-* Mouse scroll wheel to zoom the camera in/out.
-* Right-click on the floor and hold to move the humanoid.
-* Mouse-over an object. When you see a yellow highlight, press SPACE to grasp.
-    * Note grasping isn't restricted to proximity to the humanoid.
-    * Press SPACE again to drop the object anywhere in the scene.
-* Camera yaw and pitch control (TODO: decide which one has better UX):
-    1. Press/hold AD keys to look left/right, IK keys to look up/down.
-    2. Hold mouse left button and move mouse.
-* In [free camera mode](#gui-controlled-agents-and-free-camera-mode) use WSJLOP keys to move the look-at point forward/backward/left/right/up/down. Camera yaw/pitch and zoom in/out controls are the same as in the steps above.
-* `M` to reset to a new episode.
-* For humanoid:
-    * W - walk forward in the camera yaw direction
-    * S - walk backward in the opposite to camera yaw direction
-    * (camera yaw and pitch control via keybord or mouse controls from the steps above)
-
-## Collecting a rearrange demonstration with a solo user-controlled humanoid (no robot agent)
-
-TODO
+* See on-screen help text for keyboard and mouse controls
 
 ## Debugging visual sensors
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -36,6 +36,7 @@ from habitat.config.default_structured_configs import (
 from habitat.gui.gui_application import GuiAppDriver, GuiApplication
 from habitat.gui.gui_input import GuiInput
 from habitat.gui.replay_gui_app_renderer import ReplayGuiAppRenderer
+from habitat.gui.text_drawer import TextOnScreenAlignment
 
 # Please reach out to the paper authors to obtain this file
 DEFAULT_POSE_PATH = "data/humanoids/humanoid_data/walking_motion_processed.pkl"
@@ -112,6 +113,8 @@ class SandboxDriver(GuiAppDriver):
         self._gfx_replay_save_path: str = args.gfx_replay_save_path
         self._recording_keyframes: List[str] = []
 
+        self._cursor_style = None
+
     @property
     def lookat_offset_yaw(self):
         return self.to_zero_2pi_range(self._lookat_offset_yaw)
@@ -123,6 +126,9 @@ class SandboxDriver(GuiAppDriver):
     def set_debug_line_render(self, debug_line_render):
         self._debug_line_render = debug_line_render
         self._debug_line_render.set_line_width(3)
+
+    def set_text_drawer(self, text_drawer):
+        self._text_drawer = text_drawer
 
     # trying to get around mypy complaints about missing sim attributes
     def get_sim(self) -> Any:
@@ -336,7 +342,11 @@ class SandboxDriver(GuiAppDriver):
 
     def viz_and_get_humanoid_hints(self):
         grasp_object_id, drop_pos = self.viz_and_get_grasp_drop_hints()
-        walk_dir = self.viz_and_get_humanoid_walk_dir()
+        walk_dir = (
+            self.viz_and_get_humanoid_walk_dir()
+            if not self._first_person_mode
+            else None
+        )
 
         return walk_dir, grasp_object_id, drop_pos
 
@@ -359,15 +369,21 @@ class SandboxDriver(GuiAppDriver):
             self._lookat_offset_yaw += cam_rot_angle
 
     def _camera_pitch_and_yaw_mouse_control(self):
-        # if mouse left button is held update yaw and pitch
-        # by scale * mouse relative position delta
-        if self.gui_input.get_mouse_button(GuiInput.MouseNS.LEFT):
+        enable_mouse_control = (
+            self._first_person_mode
+            and self._cursor_style == Application.Cursor.HIDDEN_LOCKED
+        ) or (
+            not self._first_person_mode
+            and self.gui_input.get_mouse_button(GuiInput.MouseNS.LEFT)
+        )
+        if enable_mouse_control:
+            # update yaw and pitch by scale * mouse relative position delta
             scale = 1 / 50
             self._lookat_offset_yaw += (
-                scale * self.gui_input._relative_mouse_position[0]
+                scale * self.gui_input.relative_mouse_position[0]
             )
             self._lookat_offset_pitch += (
-                scale * self.gui_input._relative_mouse_position[1]
+                scale * self.gui_input.relative_mouse_position[1]
             )
             self._lookat_offset_pitch = np.clip(
                 self._lookat_offset_pitch,
@@ -488,6 +504,46 @@ class SandboxDriver(GuiAppDriver):
         with open(self._gfx_replay_save_path, "w") as json_file:
             json_file.write(json_content)
 
+    def _update_cursor_style(self, post_sim_update_dict):
+        do_update_cursor = False
+        if self._cursor_style is None:
+            if self._first_person_mode:
+                self._cursor_style = Application.Cursor.HIDDEN_LOCKED
+            else:
+                self._cursor_style = Application.Cursor.ARROW
+            do_update_cursor = True
+        else:
+            if self._first_person_mode and self.gui_input.get_mouse_button(
+                GuiInput.MouseNS.LEFT
+            ):
+                # toggle cursor mode
+                self._cursor_style = (
+                    Application.Cursor.HIDDEN_LOCKED
+                    if self._cursor_style == Application.Cursor.ARROW
+                    else Application.Cursor.ARROW
+                )
+                do_update_cursor = True
+
+        if do_update_cursor:
+            post_sim_update_dict["application_cursor"] = self._cursor_style
+
+    def _update_text(self):
+        s = "ESC: exit\n"
+        if self._first_person_mode:
+            s += "Left-click: toggle cursor\n"
+        else:
+            s += "Left-click + drag: rotate camera\n"
+            s += "Right-click: walk\n"
+            s += "Scroll: zoom\n"
+        s += "A, D: turn\n"
+        s += "W, S: walk\n"
+        if self._held_target_obj_idx is not None:
+            s += "Spacebar: put down\n"
+        else:
+            s += "Spacebar: pick up\n"
+
+        self._text_drawer.add_text(s, TextOnScreenAlignment.TOP_LEFT)
+
     def sim_update(self, dt):
         # todo: pipe end_play somewhere
 
@@ -574,6 +630,11 @@ class SandboxDriver(GuiAppDriver):
 
         post_sim_update_dict["cam_transform"] = self.cam_transform
 
+        self._update_cursor_style(post_sim_update_dict)
+
+        if self.gui_input.get_key_down(GuiInput.KeyNS.ESC):
+            post_sim_update_dict["application_exit"] = True
+
         keyframes = (
             self.get_sim().gfx_replay_manager.write_incremental_saved_keyframes_to_string_array()
         )
@@ -600,6 +661,8 @@ class SandboxDriver(GuiAppDriver):
         post_sim_update_dict["debug_images"] = [
             np.flipud(image) for image in debug_images
         ]
+
+        self._update_text()
 
         return post_sim_update_dict
 
@@ -731,13 +794,13 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--max-look-up-angle",
-        default=90,
+        default=15,
         type=float,
         help="Look up angle limit.",
     )
     parser.add_argument(
         "--min-look-down-angle",
-        default=-90,
+        default=-60,
         type=float,
         help="Look down angle limit.",
     )
@@ -874,5 +937,7 @@ if __name__ == "__main__":
     driver.set_debug_line_render(
         app_renderer._replay_renderer.debug_line_render(0)
     )
+    # sloppy: provide app renderer's text_drawer to our driver
+    driver.set_text_drawer(app_renderer._text_drawer)
 
     gui_app_wrapper.exec()

--- a/habitat-lab/habitat/gui/gui_application.py
+++ b/habitat-lab/habitat/gui/gui_application.py
@@ -12,6 +12,7 @@ import magnum as mn
 from magnum.platform.glfw import Application
 
 from habitat.gui.gui_input import GuiInput
+from habitat.gui.text_drawer import TextOnScreenAlignment
 
 
 class GuiAppDriver:
@@ -145,6 +146,13 @@ class GuiApplication(InputHandlerApplication):
     def get_framebuffer_size(self):
         return self.framebuffer_size
 
+    def _post_sim_update(self, post_sim_update_dict):
+        if "application_cursor" in post_sim_update_dict:
+            self.cursor = post_sim_update_dict["application_cursor"]
+
+        if "application_exit" in post_sim_update_dict:
+            self.exit(0)
+
     def draw_event(self):
         # tradeoff between responsiveness and simulation speed
         max_sim_updates_per_render = 1
@@ -186,9 +194,14 @@ class GuiApplication(InputHandlerApplication):
         for _ in range(num_sim_updates):
             post_sim_update_dict = self._driver.sim_update(sim_dt)
             self._sim_input.on_frame_end()
+            self._post_sim_update(post_sim_update_dict)
             self._app_renderer.post_sim_update(post_sim_update_dict)
 
-        self._app_renderer._text_drawer.add_text(f"SPS: {self._debug_sps:.1f}")
+        self._app_renderer._text_drawer.add_text(
+            f"SPS: {self._debug_sps:.1f}",
+            TextOnScreenAlignment.BOTTOM_LEFT,
+            text_delta_y=20,
+        )
 
         render_dt = 1 / 60.0  # todo: drive correctly
         did_render = self._app_renderer.render_update(render_dt)


### PR DESCRIPTION
## Motivation and Context

Various sandbox app polish:

* remove should_end, should_reset from controllers
* polish free-camera mode
* hide-and-lock cursor for proper mouse-look (for first-person mode)
* give SandboxDriver access to TextDrawer
* various polish to controls and GUI for first-person mode and third-person mode
* added text GUI to show controls
* hooked up ESC key to exit app

## How Has This Been Tested

Local testing on Fedora laptop.

## Types of changes

PR into SIRo branch

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
