### PR TITLE
Sandbox policy-driven agents

### DIFF
--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -11,10 +11,10 @@ This is a 3D interactive GUI app for testing various pieces of SIRo, e.g. rearra
 * When using Floorplanner scenes (see below), the app has very bad runtime perf on older Macbooks (2021 is fine; 2019 is bad).
 * Spot robot stops and doesn't move once it collides with any object (try pressing `M` to reset to a next episode).
 
-## Running HITL eval with a user-controlled humanoid and policy-driven Fetch or Spot
+## Running HITL eval with a user-controlled humanoid and policy-driven Spot
 
 * Make sure you've followed the [SIRo install instructions](../../SIRO_README.md#installation), including grabbing latest habitat-sim `main`.
-* To use Fetch, run:
+<!-- * To use Fetch, run:
 ```
 HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
 python examples/siro_sandbox/sandbox_app.py \
@@ -24,17 +24,18 @@ python examples/siro_sandbox/sandbox_app.py \
 --cfg benchmark/rearrange/rearrange_easy_human_and_fetch.yaml \
 --cfg-opts habitat.dataset.split=minival \
 --sample-random-baseline-base-vel
-```
+``` -->
 * To use Spot, run:
 ```
 HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
 python examples/siro_sandbox/sandbox_app.py \
 --disable-inverse-kinematics \
 --never-end \
---gui-controlled-agent-index 0 \
---cfg benchmark/rearrange/rearrange_easy_human_and_spot.yaml \
---cfg-opts habitat.dataset.split=minival \
---sample-random-baseline-base-vel
+--gui-controlled-agent-index 1 \
+--cfg experiments_hab3/pop_play_kinematic_oracle_humanoid_spot_fp.yaml \
+--cfg-opts \
+habitat_baselines.evaluate=True \
+habitat_baselines.num_environments=1
 ```
 * Solo user-controlled humanoid mode, with sliding enabled:
 ```
@@ -43,9 +44,10 @@ python examples/siro_sandbox/sandbox_app.py \
 --disable-inverse-kinematics \
 --gui-controlled-agent-index 0 \
 --never-end \
---cfg benchmark/rearrange/rearrange_easy_human.yaml \
---cfg-opts habitat.dataset.split=minival \
-habitat.simulator.habitat_sim_v0.allow_sliding=True
+--cfg experiments_hab3/single_agent_pddl_planner_kinematic_oracle_humanoid.yaml \
+--cfg-opts \
+habitat_baselines.evaluate=True \
+habitat_baselines.num_environments=1
 ```
 
 
@@ -66,23 +68,27 @@ Add `--gui-controlled-agent-index` followed by the agent's index you want to con
 
 If not set, it is assumed that scene is empty or all agents are policy-controlled. App switches to free camera mode in this case. User-controlled free camera lets the user observe the scene (instead of controlling one of the agents). For instance, one use case is to (eventually) observe policy-controlled agents.
 
-**Note:** Currently, only robot controllers can be policy-controlled (as for now they perform random actions). Policy-controlled humanoid controller is not implemented yet. So, if you want to test the free camera mode, make sure you are using robot-robot config as a `--cfg` argument value (for example, `--cfg benchmark/rearrange/rearrange_easy_fetch_and_fetch.yaml`).
+**Note:** Currently, only Spot and Humanoid agents can be policy-controlled (PDDL planner + oracle skills). If you want to test the free camera mode, omit `--gui-controlled-agent-index` argument.
 
 ## Solo humanoid mode
-Set `--cfg benchmark/rearrange/rearrange_easy_human.yaml` to run app with only a user-controlled humanoid (no robot).
+Set `--cfg experiments_hab3/single_agent_pddl_planner_kinematic_oracle_humanoid.yaml` to run app with only a user-controlled humanoid (no robot).
 
 ## First-person view humanoid control
 Add `--first-person-mode` to switch to first-person view humanoid control mode. Use  `--max-look-up-angle` and `--min-look-down-angle` arguments to limit humanoid's look up/down angle. For example, `--max-look-up-angle 0 --min-look-down-angle -45` to let the humanoid look down -45 degrees.
 
+## Can grasp/place area
+Use `--can-grasp-place-threshold` argument to set/change grasp/place area radius.
+
 ## Using FP dataset
-To use FP dataset follow the FP installation instructions in [SIRO_README.md](../../SIRO_README.md) and run any of the above Sandbox launch command with the following config overrides:
+To use FP dataset follow the FP installation instructions in [SIRO_README.md](../../SIRO_README.md) and run any of the above Sandbox launch command with the following config overrides appended:
 ```
 ...
 --cfg-opts \
+... \
 habitat.task.task_spec=rearrange_easy_fp \
 habitat.task.pddl_domain_def=fp \
 +habitat.simulator.additional_object_paths="[data/objects/ycb/configs/, data/objects/amazon_berkeley/configs/, data/objects/google_object_dataset/configs/]" \
-habitat.dataset.data_path=data/datasets/floorplanner/rearrange/scratch/train/s108294897_176710602.json.gz
+habitat.dataset.data_path=data/datasets/floorplanner/rearrange/scratch/train/microtrain_v0.1.json.gz
 ```
 
 ## Capturing Gfx-Replay Files

--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -47,7 +47,8 @@ python examples/siro_sandbox/sandbox_app.py \
 --cfg experiments_hab3/single_agent_pddl_planner_kinematic_oracle_humanoid.yaml \
 --cfg-opts \
 habitat_baselines.evaluate=True \
-habitat_baselines.num_environments=1
+habitat_baselines.num_environments=1 \
+habitat.simulator.habitat_sim_v0.allow_sliding=True
 ```
 
 

--- a/examples/siro_sandbox/controllers.py
+++ b/examples/siro_sandbox/controllers.py
@@ -88,6 +88,7 @@ class BaselinesController(Controller):
             gym_obs_space,
             self._gym_ac_space,
             orig_action_space=self._env_ac,
+            agent_name=agent_name,
         )
         self._action_shape, _ = get_action_space_info(self._gym_ac_space)
         self._step_i = 0
@@ -151,6 +152,16 @@ class BaselinesController(Controller):
             for k, v in action["action_args"].items()
         }
         return action, action_data.rnn_hidden_states
+    
+    def on_environment_reset(self):
+        masks = torch.zeros(
+            (
+                1,
+                1,
+            ),
+            dtype=torch.bool,
+        )
+        self._actor_critic._high_level_policy.apply_mask(masks)
 
 
 class GuiRobotController(GuiController):

--- a/examples/siro_sandbox/controllers.py
+++ b/examples/siro_sandbox/controllers.py
@@ -154,14 +154,7 @@ class BaselinesController(Controller):
         return action, action_data.rnn_hidden_states
     
     def on_environment_reset(self):
-        masks = torch.zeros(
-            (
-                1,
-                1,
-            ),
-            dtype=torch.bool,
-        )
-        self._actor_critic._high_level_policy.apply_mask(masks)
+        self._step_i = 0
 
 
 class GuiRobotController(GuiController):

--- a/examples/siro_sandbox/controllers.py
+++ b/examples/siro_sandbox/controllers.py
@@ -319,6 +319,7 @@ class GuiHumanoidController(GuiController):
         self._hint_walk_dir = None
         self._hint_grasp_obj_idx = None
         self._hint_drop_pos = None
+        self._cam_yaw = 0
 
     def get_articulated_agent(self):
         return self._env._sim.agents_mgr[self._agent_idx].articulated_agent
@@ -330,6 +331,7 @@ class GuiHumanoidController(GuiController):
         self._hint_walk_dir = None
         self._hint_grasp_obj_idx = None
         self._hint_drop_pos = None
+        self._cam_yaw = 0
 
     def get_random_joint_action(self):
         # Add random noise to human arms but keep global transform
@@ -391,7 +393,7 @@ class GuiHumanoidController(GuiController):
             assert not self.is_grasped
             self._get_grasp_mgr().snap_to_obj(grasp_object_id)
 
-        elif drop_pos:
+        elif drop_pos is not None:
             assert self.is_grasped
             grasp_object_id = self._get_grasp_mgr().snap_idx
             self._get_grasp_mgr().desnap()

--- a/examples/siro_sandbox/controllers.py
+++ b/examples/siro_sandbox/controllers.py
@@ -152,7 +152,7 @@ class BaselinesController(Controller):
             for k, v in action["action_args"].items()
         }
         return action, action_data.rnn_hidden_states
-    
+
     def on_environment_reset(self):
         self._step_i = 0
 

--- a/examples/siro_sandbox/controllers.py
+++ b/examples/siro_sandbox/controllers.py
@@ -19,7 +19,6 @@ from habitat.tasks.rearrange.actions.actions import ArmEEAction
 from habitat.utils.common import flatten_dict
 from habitat_baselines.common.baseline_registry import baseline_registry
 from habitat_baselines.common.tensor_dict import TensorDict
-from habitat_baselines.config.default import get_config as get_baselines_config
 from habitat_baselines.utils.common import get_action_space_info
 
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -262,6 +262,7 @@ class SandboxDriver(GuiAppDriver):
             return None, None
 
         hit_info = raycast_results.hits[0]
+        # print([h.object_id for h in raycast_results.hits])
         # self._debug_line_render.draw_circle(hit_info.point, 0.03, mn.Color3(1, 0, 0))
 
         if self.gui_agent_ctrl.is_grasped:
@@ -976,12 +977,12 @@ if __name__ == "__main__":
             for action_key in gui_agent_actions:
                 task_actions.pop(action_key)
 
+            action_prefix = f"{gui_agent_key}_" if len(sim_config.agents) > 1 else ""
             task_actions[
-                f"{gui_agent_key}_humanoidjoint_action"
+                f"{action_prefix}humanoidjoint_action"
             ] = HumanoidJointActionConfig(
                 agent_index=args.gui_controlled_agent_index
             )
-
 
     driver = SandboxDriver(args, config, gui_app_wrapper.get_sim_input())
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -13,6 +13,8 @@ import ctypes
 # must call this before importing habitat or magnum! avoids EGL_BAD_ACCESS error on some platforms
 import sys
 
+from habitat_baselines.config.default import get_config as get_baselines_config
+
 flags = sys.getdlopenflags()
 sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 
@@ -65,10 +67,12 @@ class SandboxDriver(GuiAppDriver):
             config.habitat.simulator.habitat_sim_v0.enable_gfx_replay_save = (
                 True
             )
+            config.habitat.simulator.concur_render = False
+
         self.env = habitat.Env(config=config)
         self.obs = self.env.reset()
 
-        self.ctrl_helper = ControllerHelper(self.env, args, gui_input)
+        self.ctrl_helper = ControllerHelper(self.env, config, args, gui_input)
 
         self.gui_agent_ctrl = self.ctrl_helper.get_gui_agent_controller()
 
@@ -883,7 +887,8 @@ if __name__ == "__main__":
         debug_third_person_height,
     ) = parse_debug_third_person(args, framebuffer_size)
 
-    config = habitat.get_config(args.cfg, args.cfg_opts)
+    config = get_baselines_config(args.cfg, args.cfg_opts)
+    # config = habitat.get_config(args.cfg, args.cfg_opts)
     with habitat.config.read_write(config):
         env_config = config.habitat.environment
         sim_config = config.habitat.simulator

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -73,7 +73,9 @@ class SandboxDriver(GuiAppDriver):
         self.env = habitat.Env(config=config)
         if args.gui_controlled_agent_index is not None:
             sim_config = config.habitat.simulator
-            gui_agent_key = sim_config.agents_order[args.gui_controlled_agent_index]
+            gui_agent_key = sim_config.agents_order[
+                args.gui_controlled_agent_index
+            ]
             oracle_nav_sensor_key = f"{gui_agent_key}_has_finished_oracle_nav"
             if oracle_nav_sensor_key in self.env.task.sensor_suite.sensors:
                 del self.env.task.sensor_suite.sensors[oracle_nav_sensor_key]
@@ -186,8 +188,8 @@ class SandboxDriver(GuiAppDriver):
         scene_pos = sim.get_scene_pos()
         target_pos = scene_pos[idxs]
         end_radius = self.env._config.task.obj_succ_thresh
-        drop_pos=None
-        
+        drop_pos = None
+
         if self._held_target_obj_idx != None:
             color = mn.Color3(0, 255 / 255, 0)  # green
             try:
@@ -213,21 +215,26 @@ class SandboxDriver(GuiAppDriver):
                         can_place_position = goal_position.copy()
                         can_place_position[1] = self.get_agent_feet_height()
                         self._debug_line_render.draw_circle(
-                            can_place_position, 1, mn.Color3(255 / 255, 255 / 255, 0), 24
+                            can_place_position,
+                            1,
+                            mn.Color3(255 / 255, 255 / 255, 0),
+                            24,
                         )
 
                     assert self._held_target_obj_idx is not None
                     if self.gui_input.get_key_down(GuiInput.KeyNS.SPACE):
                         translation = self.get_agent_translation()
-                        dist_to_obj = np.linalg.norm(goal_position - translation)
+                        dist_to_obj = np.linalg.norm(
+                            goal_position - translation
+                        )
                         if dist_to_obj < self._can_grasp_place_threshold:
                             self._held_target_obj_idx = None
                             # object_drop_height = 0.15
                             drop_pos = (
-                                goal_position 
+                                goal_position
                                 # + mn.Vector3(0, object_drop_height, 0)
                             )
-        
+
             except ValueError:
                 pass
         else:
@@ -262,7 +269,10 @@ class SandboxDriver(GuiAppDriver):
                         can_grasp_position = this_target_pos.copy()
                         can_grasp_position[1] = self.get_agent_feet_height()
                         self._debug_line_render.draw_circle(
-                            can_grasp_position, 1, mn.Color3(255 / 255, 255 / 255, 0), 24
+                            can_grasp_position,
+                            1,
+                            mn.Color3(255 / 255, 255 / 255, 0),
+                            24,
                         )
 
             # pick up an object
@@ -277,8 +287,9 @@ class SandboxDriver(GuiAppDriver):
 
         if isinstance(self.gui_agent_ctrl, GuiHumanoidController):
             grasp_object_id = (
-                sim.scene_obj_ids[self._held_target_obj_idx] 
-                if self._held_target_obj_idx is not None  and not self.gui_agent_ctrl.is_grasped 
+                sim.scene_obj_ids[self._held_target_obj_idx]
+                if self._held_target_obj_idx is not None
+                and not self.gui_agent_ctrl.is_grasped
                 else None
             )
 
@@ -305,16 +316,20 @@ class SandboxDriver(GuiAppDriver):
                 grasped_objects_idxs.append(
                     sim.scene_obj_ids.index(grasp_mgr.snap_idx)
                 )
-        
+
         return grasped_objects_idxs
-    
+
     def get_agent_translation(self):
         assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
-        return self.gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+        return (
+            self.gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+        )
 
     def get_agent_feet_height(self):
         assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
-        base_offset = self.gui_agent_ctrl.get_articulated_agent().params.base_offset
+        base_offset = (
+            self.gui_agent_ctrl.get_articulated_agent().params.base_offset
+        )
         agent_feet_translation = self.get_agent_translation() + base_offset
         return agent_feet_translation[1]
 
@@ -394,10 +409,10 @@ class SandboxDriver(GuiAppDriver):
             (
                 self._first_person_mode
                 and self._cursor_style == Application.Cursor.HIDDEN_LOCKED
-            ) 
+            )
             or (not self._first_person_mode)
         )
-        
+
         if enable_mouse_control:
             # update yaw and pitch by scale * mouse relative position delta
             scale = 1 / 50
@@ -852,7 +867,7 @@ if __name__ == "__main__":
         "--can-grasp-place-threshold",
         default=1.0,
         type=float,
-        help="Object grasp/place proximity threshold"
+        help="Object grasp/place proximity threshold",
     )
     # temp argument:
     # allowed to switch between oracle baseline nav
@@ -950,29 +965,32 @@ if __name__ == "__main__":
         if args.gui_controlled_agent_index is not None:
             assert (
                 args.gui_controlled_agent_index >= 0
-                and args.gui_controlled_agent_index
-                < len(sim_config.agents)
+                and args.gui_controlled_agent_index < len(sim_config.agents)
             ), (
                 f"--gui-controlled-agent-index argument value ({args.gui_controlled_agent_index}) "
                 f"must be >= 0 and < number of agents ({len(sim_config.agents)})"
             )
-            
-            gui_agent_key = sim_config.agents_order[args.gui_controlled_agent_index]
+
+            gui_agent_key = sim_config.agents_order[
+                args.gui_controlled_agent_index
+            ]
             assert (
-                sim_config.agents[
-                    gui_agent_key
-                ].articulated_agent_type == "KinematicHumanoid"
+                sim_config.agents[gui_agent_key].articulated_agent_type
+                == "KinematicHumanoid"
             ), "Only humanoid GUI control supported at the moment."
-            
+
             task_actions = task_config.actions
             gui_agent_actions = [
-                action_key for action_key in task_actions.keys() 
+                action_key
+                for action_key in task_actions.keys()
                 if action_key.startswith(gui_agent_key)
             ]
             for action_key in gui_agent_actions:
                 task_actions.pop(action_key)
 
-            action_prefix = f"{gui_agent_key}_" if len(sim_config.agents) > 1 else ""
+            action_prefix = (
+                f"{gui_agent_key}_" if len(sim_config.agents) > 1 else ""
+            )
             task_actions[
                 f"{action_prefix}humanoidjoint_action"
             ] = HumanoidJointActionConfig(

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -223,9 +223,7 @@ class SandboxDriver(GuiAppDriver):
                 assert self._held_target_obj_idx is not None
                 if self.gui_input.get_key_down(GuiInput.KeyNS.SPACE):
                     translation = self.get_agent_translation()
-                    dist_to_obj = np.linalg.norm(
-                        goal_position - translation
-                    )
+                    dist_to_obj = np.linalg.norm(goal_position - translation)
                     if dist_to_obj < self._can_grasp_place_threshold:
                         self._held_target_obj_idx = None
                         # object_drop_height = 0.15
@@ -972,13 +970,14 @@ if __name__ == "__main__":
             gui_agent_key = sim_config.agents_order[
                 args.gui_controlled_agent_index
             ]
-            if not (
+            if (
                 sim_config.agents[gui_agent_key].articulated_agent_type
-                == "KinematicHumanoid"
+                != "KinematicHumanoid"
             ):
                 print(
                     f"Selected agent for GUI control is of type {sim_config.agents[gui_agent_key].articulated_agent_type}, "
-                    "but only KinematicHumanoid is supported at the moment.")
+                    "but only KinematicHumanoid is supported at the moment."
+                )
                 exit()
 
             task_actions = task_config.actions

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -292,7 +292,6 @@ class SandboxDriver(GuiAppDriver):
                         )
                     )
                     assert rigid_obj
-                    rigid_obj.motion_type = habitat_sim.physics.MotionType.DYNAMIC
                     if (
                         rigid_obj.motion_type
                         == habitat_sim.physics.MotionType.DYNAMIC


### PR DESCRIPTION
## Motivation and Context

- Implement policy-driven (PDDL planner + oracle skill) agents (Humanoid and Spot).
- Use baselines config instead of benchmark config to setup Sandbox app. Baselines config should contain all the information not only about the benchmark but also about baseline agents that we should use to configure controllers. 
- implement [Revised object-grasping and placing](https://docs.google.com/document/d/1KUYO1jJwsTdT8yAJEmCrdpzrgFCu2yhtZf9lWxdasNE/edit#bookmark=kix.x377g3s361bn)
    - Add object grasp/place proximity threshold CLI argument.
- Remove nav hints to the objects grasped by the other agent.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
<!--- Please describe here how your modifications have been tested. -->
Running Sandbox app locally.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **Refactoring**

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
