### PR TITLE
Adds config flag for HBAO visual effects

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1039,6 +1039,7 @@ class HabitatSimV0Config(HabitatBaseConfig):
     # with concurrent rendering
     leave_context_with_background_renderer: bool = False
     enable_gfx_replay_save: bool = False
+    hbao_visual_effects: bool = False
 
 
 @attr.s(auto_attribs=True, slots=True)


### PR DESCRIPTION
## Motivation and Context

Adds config flag `hbao_visual_effects` for toggling HBAO.

<img width="656" alt="image" src="https://github.com/facebookresearch/habitat-lab/assets/24846546/8ad361a9-64c1-4ffd-b7eb-a5b11c898e68">


Corresponding habitat-sim branch with HBAO support: https://github.com/facebookresearch/habitat-sim/tree/ovmm_hbao

**Note**: For now, we also need to add a soft link to `habitat-sim/src` in the project root directory. This is because the HBAO code expects certain files to be available in `./src/esp/gfx/ssao` (files originally available in the hab-sim build).

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

By visualizing egocentric agent observations with flag ON and OFF.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
