### PR TITLE
[breaking] - NavMeshSettings refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,8 +190,6 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat;
               cd habitat-sim
-              git fetch --all
-              git checkout navmesh-settings-refactor
               pip install -r requirements.txt --progress-bar off
               pip install imageio imageio-ffmpeg
               python -u setup.py install --headless --with-cuda --bullet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,8 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat;
               cd habitat-sim
+              git fetch --all
+              git checkout navmesh-settings-refactor
               pip install -r requirements.txt --progress-bar off
               pip install imageio imageio-ffmpeg
               python -u setup.py install --headless --with-cuda --bullet

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -349,6 +349,12 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
             },
         )
 
+        # configure default navmesh parameters to match the configured agent
+        sim_config.navmesh_settings = habitat_sim.nav.NavMeshSettings()
+        sim_config.navmesh_settings.set_defaults()
+        sim_config.navmesh_settings.agent_radius = agent_config.radius
+        sim_config.navmesh_settings.agent_height = agent_config.height
+
         sensor_specifications = []
         for sensor in _sensor_suite.sensors.values():
             assert isinstance(sensor, HabitatSimSensor)

--- a/test/test_humanoid.py
+++ b/test/test_humanoid.py
@@ -194,7 +194,8 @@ def test_humanoid_controller():
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
 
         # add the humanoid to the world via the wrapper

--- a/test/test_robot_wrapper.py
+++ b/test/test_robot_wrapper.py
@@ -305,7 +305,8 @@ def test_fetch_robot_wrapper(fixed_base):
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
 
         # add the robot to the world via the wrapper
@@ -459,7 +460,8 @@ def test_franka_robot_wrapper():
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
 
         # add the robot to the world via the wrapper
@@ -580,7 +582,8 @@ def test_spot_robot_wrapper(fixed_base):
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
         # add the robot to the world via the wrapper
         robot_path = "data/robots/hab_spot_arm/urdf/hab_spot_arm.urdf"
@@ -718,7 +721,8 @@ def test_stretch_robot_wrapper(fixed_base):
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
         # add the robot to the world via the wrapper
         robot_path = "data/robots/hab_stretch/urdf/hab_stretch.urdf"


### PR DESCRIPTION
## Motivation and Context

Accompanying lab PR for sim [PR 2111](https://github.com/facebookresearch/habitat-sim/pull/2111).

Refactors lab uses of `recompute_navmesh` and maintains backwards compatibility with expectations that Simulator reconfigure will use agent radius and height to automatically recompute the NavMesh.

This PR aims to provide a transparent shift to the new API rather than improve the handling of NavMeshSettings from lab. That refactor should follow.

## How Has This Been Tested

CI pointed to the sim branch. (removed with merge)

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
