### PR TITLE
[Bug fix]: use default_factory in data default structured configs when creating data classes to support Python 3.11

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -110,7 +110,7 @@ class EnvironmentConfig(HabitatBaseConfig):
     """
     max_episode_steps: int = 1000
     max_episode_seconds: int = 10000000
-    iterator_options: IteratorOptionsConfig = IteratorOptionsConfig()
+    iterator_options: IteratorOptionsConfig = field(default_factory=IteratorOptionsConfig)
 
 
 # -----------------------------------------------------------------------------
@@ -674,7 +674,7 @@ class TopDownMapMeasurementConfig(MeasurementConfig):
     draw_goal_positions: bool = True
     # axes aligned bounding boxes
     draw_goal_aabbs: bool = True
-    fog_of_war: FogOfWarConfig = FogOfWarConfig()
+    fog_of_war: FogOfWarConfig = field(default_factory=FogOfWarConfig)
 
 
 @dataclass
@@ -1417,7 +1417,7 @@ class SimulatorConfig(HabitatBaseConfig):
     # If the number of agents is greater than one,
     # then agents_order has to be set explicitly.
     agents_order: List[str] = MISSING
-    habitat_sim_v0: HabitatSimV0Config = HabitatSimV0Config()
+    habitat_sim_v0: HabitatSimV0Config = field(default_factory=HabitatSimV0Config)
     # ep_info is added to the config in some rearrange tasks inside
     # merge_sim_episode_with_object_config
     ep_info: Optional[Any] = None
@@ -1486,7 +1486,7 @@ class PyrobotConfig(HabitatBaseConfig):
     )
     base_controller: str = "proportional"
     base_planner: str = "none"
-    locobot: LocobotConfig = LocobotConfig()
+    locobot: LocobotConfig = field(default_factory=LocobotConfig)
 
 
 @dataclass
@@ -1541,11 +1541,11 @@ class HabitatConfig(HabitatBaseConfig):
     # The key of the gym environment in the registry to use in GymRegistryEnv
     # for example: `Cartpole-v0`
     env_task_gym_id: str = ""
-    environment: EnvironmentConfig = EnvironmentConfig()
-    simulator: SimulatorConfig = SimulatorConfig()
+    environment: EnvironmentConfig = field(default_factory=EnvironmentConfig)
+    simulator: SimulatorConfig = field(default_factory=SimulatorConfig)
     task: TaskConfig = MISSING
     dataset: DatasetConfig = MISSING
-    gym: GymConfig = GymConfig()
+    gym: GymConfig = field(default_factory=GymConfig)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation and Context

I was trying to set up Habitat-lab for Python 3.11 and ran into this problem:

```
ValueError: mutable default <class 'habitat.config.default_structured_configs.IteratorOptionsConfig'> for field iterator_options is not allowed: use default_factory
```

This PR fixes all cases where a mutable `Config` class is used inside another `dataclass`'s variables by adding a `field(default_factory=...)` call to create a new instance.

Not sure if Python 3.11 is supported yet, but one day it will be and this fix will be needed at that point :)

## How Has This Been Tested

Before the fix:
- Use Python 3.11
- Run the example from README: `python examples/example.py`
- Note the ValueError from earlier.

After the fix, the example runs without errors.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
