### PR TITLE
add a flag to overfit

### DIFF
--- a/habitat-lab/habitat/core/env.py
+++ b/habitat-lab/habitat/core/env.py
@@ -143,7 +143,10 @@ class Env:
             for k, v in self._config.environment.iterator_options.items()
         }
         iter_option_dict["seed"] = self._config.seed
-        if "overfit" in self._config.simulator and self._config.simulator["overfit"]:
+        if (
+            "overfit" in self._config.simulator
+            and self._config.simulator["overfit"]
+        ):
             iter_option_dict["num_episode_sample"] = 1
         self._episode_iterator = self._dataset.get_episode_iterator(
             **iter_option_dict

--- a/habitat-lab/habitat/core/env.py
+++ b/habitat-lab/habitat/core/env.py
@@ -143,6 +143,8 @@ class Env:
             for k, v in self._config.environment.iterator_options.items()
         }
         iter_option_dict["seed"] = self._config.seed
+        if "overfit" in self._config.simulator and self._config.simulator["overfit"]:
+            iter_option_dict["num_episode_sample"] = 1
         self._episode_iterator = self._dataset.get_episode_iterator(
             **iter_option_dict
         )

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -79,6 +79,12 @@ class RearrangeTask(NavigationTask):
         self._episode_id: str = ""
         self._cur_episode_step = 0
         self._should_place_articulated_agent = should_place_articulated_agent
+        self._fixed_starting_position: bool = False
+        self._seed = self._sim.habitat_config.seed
+
+        habitat_config = self._sim.habitat_config
+        if "overfit" in habitat_config and habitat_config["overfit"]:
+            self._fixed_starting_position = True
 
         data_path = dataset.config.data_path.format(split=dataset.config.split)
         fname = data_path.split("/")[-1].split(".")[0]
@@ -187,12 +193,9 @@ class RearrangeTask(NavigationTask):
             self._is_episode_active = True
 
             if self._should_place_articulated_agent:
-                
-                habitat_config = self._sim.habitat_config
-                if "overfit" in habitat_config and habitat_config["overfit"]: 
-                    curr_seed = self._sim.habitat_config.seed
-                    np.random.seed(curr_seed)
-                    self._sim.pathfinder.seed(curr_seed)
+                if self._fixed_starting_position: 
+                    np.random.seed(self._seed)
+                    self._sim.pathfinder.seed(self._seed)
                     
                 for agent_idx in range(self._sim.num_articulated_agents):
                     self._set_articulated_agent_start(agent_idx)

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -187,9 +187,16 @@ class RearrangeTask(NavigationTask):
             self._is_episode_active = True
 
             if self._should_place_articulated_agent:
+                
+                habitat_config = self._sim.habitat_config
+                if "overfit" in habitat_config and habitat_config["overfit"]: 
+                    curr_seed = self._sim.habitat_config.seed
+                    np.random.seed(curr_seed)
+                    self._sim.pathfinder.seed(curr_seed)
+                    
                 for agent_idx in range(self._sim.num_articulated_agents):
                     self._set_articulated_agent_start(agent_idx)
-
+        
         self.prev_measures = self.measurements.get_metrics()
         self._targ_idx = 0
         self.coll_accum = CollisionDetails()


### PR DESCRIPTION
## Motivation and Context

Adds an overfitting flag. Simply add at the end of your run:

```+habitat.simulator.overfit=True```

It will use always the same scene and the same starting position.

## How Has This Been Tested


## Types of changes

- **\[Experiment\]** A pull request that add new features to the [habitat-baselines](/habitat-baselines/) training codebase. Experiments Pull Requests can be any size, must have smoke/integration tests and be isolated from the rest of the code. Your code additions should not rely on other habitat-baselines code. This is to avoid dependencies between different parts of habitat-baselines. You must also include a README that will document how to use your new feature or trainer. **You** will be the maintainer of this code, if the code becomes stale or is not supported often enough, we will eventually remove it.

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
