### PR TITLE
SIRo: ignore whitespace errors on SIRo readmes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: v4.2.0
     hooks:
     -   id: trailing-whitespace
+        exclude: .*README.md
     -   id: check-added-large-files
         args: ['--maxkb=2000']
     -   id: end-of-file-fixer

--- a/SIRO_README.md
+++ b/SIRO_README.md
@@ -1,4 +1,4 @@
-# SIRo Project
+# SIRo Project 
 
 Project-specific README for SIRo.
 

--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -1,4 +1,4 @@
-# Sandbox Tool
+# Sandbox Tool 
 
 ![siro_sandbox_screenshot](https://user-images.githubusercontent.com/6557808/230213487-f4812c2f-ec7f-4d68-9bbe-0b65687f769b.png)
 


### PR DESCRIPTION
## Motivation and Context

Ignore whitespace errors on SIRO readmes. This makes it easier/safer to edit the readmes directly from github, without a PR. We want to lower the friction for updating documentation!

## How Has This Been Tested

Local testing on laptop.

## Types of changes
PR into SIRo branch

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
