### PR TITLE
Sandbox tool trained agents

### DIFF
--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -92,6 +92,12 @@ Add `--first-person-mode` to switch to first-person view humanoid control mode. 
 ## Can grasp/place area
 Use `--can-grasp-place-threshold` argument to set/change grasp/place area radius.
 
+## Disable episode end on collision
+In the multi agent tidy house task, episode is considered over when humanoid and robot agents collide. Sandbox app will crash in this case as the actions can't be executed if env episode is over. In this case, you may want too disable episode end on collision. It can be done by appending the following line to your `--cfg-opts`:
+```
+habitat.task.measurements.cooperate_subgoal_reward.end_on_collide=False
+```
+
 ## Using FP dataset
 To use FP dataset follow the FP installation instructions in [SIRO_README.md](../../SIRO_README.md) and run any of the above Sandbox launch command with the following config overrides appended:
 ```

--- a/examples/siro_sandbox/controllers.py
+++ b/examples/siro_sandbox/controllers.py
@@ -18,6 +18,10 @@ from habitat.gui.gui_input import GuiInput
 from habitat.tasks.rearrange.actions.actions import ArmEEAction
 from habitat.utils.common import flatten_dict
 from habitat_baselines.common.baseline_registry import baseline_registry
+from habitat_baselines.common.obs_transformers import (
+    apply_obs_transforms_obs_space,
+    get_active_obs_transforms,
+)
 from habitat_baselines.common.tensor_dict import TensorDict
 from habitat_baselines.utils.common import get_action_space_info
 
@@ -65,12 +69,10 @@ class BaselinesController(Controller):
         sample_random_baseline_base_vel=False,
     ):
         super().__init__(agent_idx, is_multi_agent)
-        agent_name = config.habitat.simulator.agents_order[agent_idx]
-        policy_cls = baseline_registry.get_policy(
-            config.habitat_baselines.rl.policy[agent_name].name
-        )
+        self._config = config
         self._env_ac = env.action_space
         env_obs = env.observation_space
+        agent_name = config.habitat.simulator.agents_order[self._agent_idx]
         if self._is_multi_agent:
             self._agent_k = f"agent_{self._agent_idx}_"
         else:
@@ -80,8 +82,14 @@ class BaselinesController(Controller):
             env_obs = clean_dict(env_obs, self._agent_k)
 
         self._gym_ac_space = gym_wrapper.create_action_space(self._env_ac)
+        self.obs_transforms = get_active_obs_transforms(config, agent_name)
+        env_obs = apply_obs_transforms_obs_space(env_obs, self.obs_transforms)
         gym_obs_space = gym_wrapper.smash_observation_space(
             env_obs, list(env_obs.keys())
+        )
+
+        policy_cls = baseline_registry.get_policy(
+            config.habitat_baselines.rl.policy[agent_name].name
         )
         self._actor_critic = policy_cls.from_config(
             config,
@@ -90,7 +98,28 @@ class BaselinesController(Controller):
             orig_action_space=self._env_ac,
             agent_name=agent_name,
         )
-        self._action_shape, _ = get_action_space_info(self._gym_ac_space)
+        if config.habitat_baselines.eval.should_load_ckpt:
+            checkpoint = torch.load(
+                config.habitat_baselines.eval_ckpt_path_dir, map_location="cpu"
+            )
+            self._actor_critic.load_state_dict(
+                checkpoint[self._agent_idx]["state_dict"]
+            )
+        self.device = (
+            torch.device("cuda", config.habitat_baselines.torch_gpu_id)
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        self._actor_critic.to(self.device)
+        self._actor_critic.eval()
+
+        policy_action_space = self._actor_critic.get_policy_action_space(
+            self._gym_ac_space
+        )
+        self._action_shape, self._discrete_actions = get_action_space_info(
+            policy_action_space
+        )
+
         self._step_i = 0
         self._sample_random_baseline_base_vel = sample_random_baseline_base_vel
 
@@ -100,6 +129,7 @@ class BaselinesController(Controller):
                 1,
                 1,
             ),
+            device=self.device,
             dtype=torch.bool,
         )
         if self._step_i == 0:
@@ -108,16 +138,20 @@ class BaselinesController(Controller):
         hxs = torch.ones(
             (
                 1,
-                1,
+                self._actor_critic.num_recurrent_layers,
+                self._config.habitat_baselines.rl.ppo.hidden_size,
             ),
+            device=self.device,
             dtype=torch.float32,
         )
+
         prev_ac = torch.ones(
             (
                 1,
-                self._action_shape[0],
+                *self._action_shape,
             ),
-            dtype=torch.float32,
+            device=self.device,
+            dtype=torch.long if self._discrete_actions else torch.float,
         )
         obs = flatten_dict(obs)
         obs = TensorDict(
@@ -126,6 +160,7 @@ class BaselinesController(Controller):
                     len(self._agent_k) if k.startswith(self._agent_k) else 0 :
                 ]: torch.tensor(v).unsqueeze(0)
                 for k, v in obs.items()
+                if k.startswith(self._agent_k) or "agent_" not in k
             }
         )
         with torch.no_grad():

--- a/habitat-baselines/habitat_baselines/common/obs_transformers.py
+++ b/habitat-baselines/habitat_baselines/common/obs_transformers.py
@@ -1199,12 +1199,16 @@ class Equirect2CubeMap(ProjectionTransformer):
 
 
 def get_active_obs_transforms(
-    config: "DictConfig",
+    config: "DictConfig", agent_name: str = None
 ) -> List[ObservationTransformer]:
     active_obs_transforms = []
 
     # We assume for now that the observation space is shared among agents
-    agent_name = list(config.habitat_baselines.rl.policy.keys())[0]
+    # if agent_name is not specified explicitly
+    agent_name = (
+        agent_name or list(config.habitat_baselines.rl.policy.keys())[0]
+    )
+
     obs_trans_conf = config.habitat_baselines.rl.policy[
         agent_name
     ].obs_transforms

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml
@@ -49,9 +49,6 @@ habitat:
       agent_1_oracle_nav_action:
         motion_control: human_joints
         spawn_max_dist_to_obj: -1
-    measurements:
-      cooperate_subgoal_reward:
-        end_on_collide: False
   environment:
     max_episode_steps: 1000
 

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml
@@ -9,12 +9,13 @@ defaults:
     - add_virtual_keys_base
   - /habitat_baselines/rl/policy/obs_transforms@habitat_baselines.rl.policy.agent_1.obs_transforms.add_virtual_keys:
     - add_virtual_keys_base
-  - /habitat_baselines/rl/policy@habitat_baselines.rl.policy.agent_0: hab3_hl_neural
-  - /habitat_baselines/rl/policy@habitat_baselines.rl.policy.agent_1: hab3_hl_neural
+  - /habitat_baselines/rl/policy@habitat_baselines.rl.policy.agent_0: hab3_hl_neural_ma
+  - /habitat_baselines/rl/policy@habitat_baselines.rl.policy.agent_1: hab3_hl_neural_ma
   - /habitat_baselines/rl/policy/hierarchical_policy/defined_skills@habitat_baselines.rl.policy.agent_0.hierarchical_policy.defined_skills: oracle_skills_ma
   - /habitat_baselines/rl/policy/hierarchical_policy/defined_skills@habitat_baselines.rl.policy.agent_1.hierarchical_policy.defined_skills: oracle_skills_ma_humanoid
   - /habitat/task/measurements:
     - composite_subgoal_reward
+    - runtime_perf_stats
   - /habitat/task/lab_sensors:
     - relative_resting_pos_sensor
     - target_start_sensor
@@ -26,12 +27,15 @@ defaults:
     - target_goal_gps_compass_sensor
     - localization_sensor
     - humanoid_joint_sensor
+    - other_agent_gps
     - has_finished_oracle_nav
   - /habitat/task/actions@habitat.task.actions.agent_0_arm_action: arm_action
   - override /habitat/task/rearrange: multi_agent_tidy_house_base
   # For Spot observation space
   - override /habitat/simulator/agents@habitat.simulator.agents.agent_0: rgbd_head_rgbd_arm_agent
   - _self_
+
+replan_distance: 1.5
 
 hydra:
   job:
@@ -46,7 +50,7 @@ habitat:
         motion_control: human_joints
         spawn_max_dist_to_obj: -1
   environment:
-    max_episode_steps: 700
+    max_episode_steps: 1000
 
   gym:
     obs_keys:
@@ -60,6 +64,7 @@ habitat:
       - agent_0_is_holding
       - agent_0_ee_pos
       - agent_0_localization_sensor
+      - agent_0_other_agent_gps
       - agent_0_has_finished_oracle_nav
       - agent_1_head_depth
       - agent_1_relative_resting_position
@@ -71,6 +76,7 @@ habitat:
       - agent_1_ee_pos
       - agent_1_localization_sensor
       - agent_1_humanoid_joint_sensor
+      - agent_1_other_agent_gps
       - agent_1_has_finished_oracle_nav
   simulator:
     # Add Spot robot agents
@@ -127,32 +133,75 @@ habitat_baselines:
   wb:
     project_name: 'hab3'
     entity: 'andrew-colab'
-    run_name: ${hydra:job.name}_${now:%Y-%m-%d}_${now:%H-%M-%S}
+    run_name: ${hydra:job.name}/${now:%Y-%m-%d}/${now:%H-%M-%S}/${hydra:job.num}
+
+  profiling:
+    enable_perf_logger: True
+    perf_logger_skip_interval: 20
 
   eval:
-    should_load_ckpt: False
+    should_load_ckpt: True
     video_option: ["disk"]
 
   rl:
     agent:
-      num_pool_agents_per_type: [1, 1]
+      num_pool_agents_per_type: [1, 8]
+      agent_sample_interval: 20
     policy:
       agent_0:
         hierarchical_policy:
+          high_level_policy:
+            replan_dist: ${replan_distance}
+            allowed_actions:
+              - nav_to_receptacle_by_name
+              - nav_to_goal
+              - nav_to_obj
+              - pick
+              - place
+            policy_input_keys:
+              - "head_depth"
+              - "joint"
+              - "is_holding"
+              - "obj_start_sensor"
+              - "obj_goal_sensor"
+              - "obj_start_gps_compass"
+              - "obj_goal_gps_compass"
+              - "other_agent_gps"
           # Override to use the oracle navigation skill (which will actually execute navigation).
           defined_skills:
             nav_to_obj:
               skill_name: "OracleNavPolicy"
               obs_skill_inputs: ["obj_start_sensor", "abs_obj_start_sensor", "obj_goal_sensor", "abs_obj_goal_sensor"]
               max_skill_steps: 300
+              stop_thresh: 0.00001
+              apply_postconds: False
       agent_1:
         hierarchical_policy:
+          high_level_policy:
+            replan_dist: ${replan_distance}
+            allowed_actions:
+              - nav_to_receptacle_by_name
+              - nav_to_goal
+              - nav_to_obj
+              - pick
+              - place
+            policy_input_keys:
+              - "head_depth"
+              - "humanoid_joint_sensor"
+              - "is_holding"
+              - "obj_start_sensor"
+              - "obj_goal_sensor"
+              - "obj_start_gps_compass"
+              - "obj_goal_gps_compass"
+              - "other_agent_gps"
           # Override to use the oracle navigation skill (which will actually execute navigation).
           defined_skills:
             nav_to_obj:
               skill_name: "OracleNavPolicy"
               obs_skill_inputs: ["obj_start_sensor", "abs_obj_start_sensor", "obj_goal_sensor", "abs_obj_goal_sensor"]
               max_skill_steps: 300
+              stop_thresh: 0.00001
+              apply_postconds: False
 
     ppo:
       # ppo params

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml
@@ -49,6 +49,9 @@ habitat:
       agent_1_oracle_nav_action:
         motion_control: human_joints
         spawn_max_dist_to_obj: -1
+    measurements:
+      cooperate_subgoal_reward:
+        end_on_collide: False
   environment:
     max_episode_steps: 1000
 

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot_fp.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot_fp.yaml
@@ -45,9 +45,6 @@ habitat:
       agent_1_oracle_nav_with_backing_up_action:
         motion_control: human_joints
         spawn_max_dist_to_obj: -1
-    measurements:
-      cooperate_subgoal_reward:
-        end_on_collide: False
   environment:
     max_episode_steps: 5000
 

--- a/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot_fp.yaml
+++ b/habitat-baselines/habitat_baselines/config/experiments_hab3/pop_play_kinematic_oracle_humanoid_spot_fp.yaml
@@ -45,6 +45,9 @@ habitat:
       agent_1_oracle_nav_with_backing_up_action:
         motion_control: human_joints
         spawn_max_dist_to_obj: -1
+    measurements:
+      cooperate_subgoal_reward:
+        end_on_collide: False
   environment:
     max_episode_steps: 5000
 


### PR DESCRIPTION
## Motivation and Context

Update BaselinesController to run trained-policy-based agents in the Sandbox tool.

Currently, separate BaselineController is created for each non-GUI agent from the config.  BaselineController has custom code that directly initializes actor_critic and uses actor_critic’s act method to get action. 

Alternatively,  we can create just one BaselinesController and instead of initializing actor_critic directly, initialize Single/MultiAgentAccessMgr (depending on how many agents we will have) that will handle actor_critic’s initialization. This way Sandbox BaselinesController will reuse  a lot of code from PPOTrainer._eval_checkpoint. However this option will take extra time compared to the first one as the first one is already implemented.

To run random-policy-controlled Spot and Humanoid in free camera mode:
```
HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
python examples/siro_sandbox/sandbox_app.py \
--disable-inverse-kinematics \
--never-end \
--cfg experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml \
--cfg-opts \
habitat_baselines.evaluate=True \
habitat_baselines.num_environments=1 \
habitat_baselines.eval.should_load_ckpt=False
```

To run random-policy-controlled (initialized with random weights) Spot and GUI-controlled Humanoid :
```
HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
python examples/siro_sandbox/sandbox_app.py \
--disable-inverse-kinematics \
--never-end \
--gui-controlled-agent-index 1 \
--cfg experiments_hab3/pop_play_kinematic_oracle_humanoid_spot.yaml \
--cfg-opts \
habitat_baselines.evaluate=True \
habitat_baselines.num_environments=1 \
habitat_baselines.eval.should_load_ckpt=False
```

To use trained-policy-controlled agent(s) instead of random-policy-controlled: 
1. Download the pre-trained [checkpoint](https://drive.google.com/file/d/1swH5ZUgxe3xQn_k0s5OD7Ow6-mwCN_ic/view?usp=share_link) (150 updates).
2.  Run two above commands with the following  cfg-opts:       
```
--cfg-opts \
habitat_baselines.evaluate=True \
habitat_baselines.num_environments=1 \ 
habitat_baselines.eval.should_load_ckpt=True \
habitat_baselines.eval_ckpt_path_dir=path/to/latest.pth
```

Example of trained-policy-controlled Spot and GUI-controlled Humanoid:

https://github.com/facebookresearch/habitat-lab/assets/37709869/0d65b678-7591-4b8d-9989-e3f2c478d253

Todo:
- update Sandbox tool README run commands if this PR changes are aproved

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local testing on MacBook Pro 2021 laptop.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **Refactoring** 
- **Development** 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
