### PR TITLE
[Bug Fix] change the snap point to be attached the largest island id

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -211,7 +211,6 @@ class RearrangeEpisodeGenerator:
                     raise ValueError(
                         f"Found no object handles for {obj_sampler_info}"
                     )
-
                 self._obj_samplers[
                     obj_sampler_info["name"]
                 ] = samplers.ObjectSampler(
@@ -227,6 +226,9 @@ class RearrangeEpisodeGenerator:
                         "nav_to_min_distance", -1.0
                     ),
                     obj_sampler_info["params"].get("sample_probs", None),
+                    obj_sampler_info["params"].get(
+                        "constrain_to_largest_nav_island", False
+                    ),
                 )
             else:
                 logger.info(

--- a/habitat-lab/habitat/datasets/rearrange/run_episode_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/run_episode_generator.py
@@ -120,8 +120,10 @@ class RearrangeEpisodeGeneratorConfig:
     # Define the object sampling configuration
     object_samplers: List[Any] = field(default_factory=list)
     # {"name":str, "type:str", "params":{})
-    # - uniform sampler params: {"object_sets":[str], "receptacle_sets":[str], "num_samples":[min, max], "orientation_sampling":str)
+    # - uniform sampler params: {"object_sets":[str], "receptacle_sets":[str], "num_samples":[min, max], "orientation_sampling":str, "nav_to_min_distance":float, "constrain_to_largest_nav_island":bool)
     # NOTE: "orientation_sampling" options: "none", "up", "all"
+    # NOTE: (optional) "constrain_to_largest_nav_island" (default False): if True, valid placements must snap to the largest navmesh island
+    # NOTE: (optional) "nav_to_min_distance" (default -1): if not -1, valid placements must snap to the navmesh with horizontal distance less than this value
     # TODO: convert some special examples to yaml:
     # (
     #     "fridge_middle",

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -74,6 +74,7 @@ class ObjectSampler:
         self.sample_region_ratio = sample_region_ratio
         self.nav_to_min_distance = nav_to_min_distance
         self.set_num_samples()
+        self.largest_island_id = -1
         # More possible parameters of note:
         # - surface vs volume
         # - apply physics stabilization: none, dynamic, projection
@@ -87,6 +88,7 @@ class ObjectSampler:
         self.receptacle_candidates = None
         # number of objects in the range should be reset each time
         self.set_num_samples()
+        self.largest_island_id = -1
 
     def sample_receptacle(
         self,
@@ -240,10 +242,14 @@ class ObjectSampler:
 
         # Note: we cache the largest island ID to reject samples which are primarily accessible from disconnected navmesh regions.
         # This assumption limits sampling to the largest navigable component of any scene.
-        island_areas = list(
-            map(sim.pathfinder.island_area, range(sim.pathfinder.num_islands))
-        )
-        self.largest_island_id = island_areas.index(max(island_areas))
+        if self.largest_island_id == -1:
+            island_areas = list(
+                map(
+                    sim.pathfinder.island_area,
+                    range(sim.pathfinder.num_islands),
+                )
+            )
+            self.largest_island_id = island_areas.index(max(island_areas))
 
         while num_placement_tries < self.max_placement_attempts:
             num_placement_tries += 1

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -240,9 +240,10 @@ class ObjectSampler:
 
         # Note: we cache the largest island ID to reject samples which are primarily accessible from disconnected navmesh regions.
         # This assumption limits sampling to the largest navigable component of any scene.
-        island_areas = list(
-            map(sim.pathfinder.island_area, range(sim.pathfinder.num_islands))
-        )
+        island_areas = [
+            sim.pathfinder.island_area(ix)
+            for ix in range(sim.pathfinder.num_islands)
+        ]
         self.largest_island_id = island_areas.index(max(island_areas))
 
         while num_placement_tries < self.max_placement_attempts:

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -237,17 +237,13 @@ class ObjectSampler:
         """
         num_placement_tries = 0
         new_object = None
-        navmesh_vertices = np.stack(
-            sim.pathfinder.build_navmesh_vertices(), axis=0
-        )
+
         # Note: we cache the largest island ID to reject samples which are primarily accessible from disconnected navmesh regions.
         # This assumption limits sampling to the largest navigable component of any scene.
-        island_size = [
-            sim.pathfinder.island_radius(p) for p in navmesh_vertices
-        ]
-        self.largest_island_id = sim.pathfinder.get_island(
-            navmesh_vertices[island_size.index(max(island_size))]
+        island_areas = list(
+            map(sim.pathfinder.island_area, range(sim.pathfinder.num_islands))
         )
+        self.largest_island_id = island_areas.index(max(island_areas))
 
         while num_placement_tries < self.max_placement_attempts:
             num_placement_tries += 1

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -240,10 +240,9 @@ class ObjectSampler:
 
         # Note: we cache the largest island ID to reject samples which are primarily accessible from disconnected navmesh regions.
         # This assumption limits sampling to the largest navigable component of any scene.
-        island_areas = [
-            sim.pathfinder.island_area(ix)
-            for ix in range(sim.pathfinder.num_islands)
-        ]
+        island_areas = list(
+            map(sim.pathfinder.island_area, range(sim.pathfinder.num_islands))
+        )
         self.largest_island_id = island_areas.index(max(island_areas))
 
         while num_placement_tries < self.max_placement_attempts:


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? --> This PR ensures that the snap point of the object is always in the largest island. Previously it was checked by computing the largest island radius, which is not stable. 

This is the joint work with Alex!

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. --> Run the script, and it generates the episode.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
