### PR TITLE
SIRo sandbox: add episode recording

### DIFF
--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -96,6 +96,9 @@ habitat_baselines.eval_ckpt_path_dir=path/to/latest.pth
 * `N` to toggle navmesh visualization in the debug third-person view (`--debug-third-person-width`)
 * For `--first-person-mode`, you can toggle mouse-look by left-clicking anywhere
 
+## Saving episode data
+Use `--save-filepath-base my_session`. When the user presses `M` to reset the env, the first episode will be saved as `my_session.0.json.gz` and `my_session.0.pkl.gz`. These files contain mostly-identical data; we save both so that developers have two choices for how to consume the data later. After pressing `M` again, the second episode will be saved as `my_session.1.json.gz`, etc. For an example of consuming this data, see `test_episode_save_files.py` .
+
 ## Workaround to avoid broken skinned humanoid
 
 Following the instructions above, a broken skinned humanoid is rendered which blocks the first-person camera view at times. This is a known issue: the sandbox app uses replay-rendering, which doesn't yet support skinning.

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -170,7 +170,7 @@ class SandboxDriver(GuiAppDriver):
         self._cursor_style = None
         self._can_grasp_place_threshold = args.can_grasp_place_threshold
 
-        self.reset_environment()
+        self._reset_environment()
 
     def _env_step(self, action):
         self._obs = self.env.step(action)
@@ -199,18 +199,18 @@ class SandboxDriver(GuiAppDriver):
             self.record_metrics(self.env.get_metrics())
             self._step_recorder.finish_step()
 
-    def find_episode_save_filepath_base(self, session_filepath_base):
+    def _find_episode_save_filepath_base(self, session_filepath_base):
         retval = (
             self._save_filepath_base + "." + str(self._num_recorded_episodes)
         )
         self._num_recorded_episodes += 1
         return retval
 
-    def save_episode_recorder_dict(self):
+    def _save_episode_recorder_dict(self):
         if not self._save_filepath_base or not len(self._step_recorder._steps):
             return
 
-        filepath_base = self.find_episode_save_filepath_base(
+        filepath_base = self._find_episode_save_filepath_base(
             self._save_filepath_base
         )
 
@@ -220,7 +220,7 @@ class SandboxDriver(GuiAppDriver):
         pkl_filepath = filepath_base + ".pkl.gz"
         save_as_pickle_gzip(self._episode_recorder_dict, pkl_filepath)
 
-    def start_episode_recorder(self):
+    def _start_episode_recorder(self):
         assert self._save_filepath_base and self._step_recorder
         ep_dict: Any = dict()
         ep_dict["start_time"] = datetime.now()
@@ -239,7 +239,7 @@ class SandboxDriver(GuiAppDriver):
 
         self._episode_recorder_dict = ep_dict
 
-    def reset_environment(self):
+    def _reset_environment(self):
         self._obs = self.env.reset()
         self._metrics = self.env.get_metrics()
         self.ctrl_helper.on_environment_reset()
@@ -271,8 +271,8 @@ class SandboxDriver(GuiAppDriver):
         self._tutorial_stage_index: int = 0
 
         if self._save_filepath_base:
-            self.save_episode_recorder_dict()
-            self.start_episode_recorder()
+            self._save_episode_recorder_dict()
+            self._start_episode_recorder()
 
     @property
     def _env_task_complete(self):
@@ -332,7 +332,7 @@ class SandboxDriver(GuiAppDriver):
         object_id = self._target_obj_ids[target_obj_idx]
         return rom.get_object_by_id(object_id).translation
 
-    def get_target_object_positions(self):
+    def _get_target_object_positions(self):
         sim = self.get_sim()
         rom = sim.get_rigid_object_manager()
         return np.array(
@@ -884,7 +884,7 @@ class SandboxDriver(GuiAppDriver):
         self._step_recorder.record("agent_states", agent_states)
 
         self._step_recorder.record(
-            "target_object_positions", self.get_target_object_positions()
+            "target_object_positions", self._get_target_object_positions()
         )
 
     def record_action(self, action):
@@ -969,7 +969,7 @@ class SandboxDriver(GuiAppDriver):
             self._save_recorded_keyframes_to_file()
 
         if self.gui_input.get_key_down(GuiInput.KeyNS.M):
-            self.reset_environment()
+            self._reset_environment()
 
         # _viz_anim_fraction goes from 0 to 1 over time and then resets to 0
         viz_anim_speed = 2.0

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -93,6 +93,7 @@ class SandboxDriver(GuiAppDriver):
             self._episode_recorder_dict = {}
         else:
             self._step_recorder = NullRecorder()
+            self._save_filepath_base = None
 
         with habitat.config.read_write(config):
             # needed so we can provide keyframes to GuiApplication

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -813,9 +813,11 @@ class SandboxDriver(GuiAppDriver):
             rotation_list = list(rotation_quat.vector) + [rotation_quat.scalar]
             pos = art_obj.transformation.translation
 
-            snap_idx = self.env.task._sim.agents_mgr._all_agent_data[
-                agent_idx
-            ].grasp_mgr.snap_idx
+            snap_idx = (
+                self.get_sim()
+                .agents_mgr._all_agent_data[agent_idx]
+                .grasp_mgr.snap_idx
+            )
 
             agent_states.append(
                 {

--- a/examples/siro_sandbox/serialize_utils.py
+++ b/examples/siro_sandbox/serialize_utils.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copyreg
+import gzip
+import json
+import pickle
+from abc import abstractmethod
+from datetime import datetime
+from typing import Any, List
+
+import magnum as mn
+import numpy as np
+
+
+def unpickle_vector3(data):
+    return mn.Vector3(data)
+
+
+def pickle_vector3(obj):
+    pickled_data = list(obj)
+    return unpickle_vector3, (pickled_data,)
+
+
+# fix for unpickable type; run once at startup
+copyreg.pickle(mn.Vector3, pickle_vector3)
+
+
+def convert_to_json_friendly(obj):
+    if isinstance(obj, (int, str, bool, type(None))):
+        # If obj is a simple data type (except float), return it as is
+        return obj
+    elif isinstance(obj, float):
+        # If obj is a simple float, round to 5 decimal places
+        return round(obj, 5)
+    elif isinstance(obj, (list, np.ndarray, tuple)):
+        # If obj is a list or ndarray, recursively convert its elements
+        return [convert_to_json_friendly(item) for item in obj]
+    elif isinstance(obj, dict):
+        # If obj is a dictionary, recursively convert its values
+        return {
+            key: convert_to_json_friendly(value) for key, value in obj.items()
+        }
+    elif isinstance(obj, np.generic):
+        # If obj is a NumPy scalar type, convert it to a standard Python scalar type
+        return convert_to_json_friendly(obj.item())
+    elif isinstance(obj, datetime):
+        # convert datetime to repr string
+        return convert_to_json_friendly(repr(obj))
+    elif isinstance(obj, mn.Vector3):
+        # convert Vector3 to list
+        return convert_to_json_friendly(list(obj))
+    else:
+        # If obj is a complex object, convert its attributes to a dictionary
+        attributes = {
+            attr: convert_to_json_friendly(getattr(obj, attr))
+            for attr in dir(obj)
+            if not attr.startswith("__") and not callable(getattr(obj, attr))
+        }
+        return convert_to_json_friendly(attributes)
+
+
+def save_as_pickle_gzip(obj, filepath):
+    pickled_data = pickle.dumps(obj)
+    with gzip.open(filepath, "wb") as file:
+        file.write(pickled_data)
+    print("wrote " + filepath)
+
+
+def save_as_json_gzip(obj, filepath):
+    json_data = json.dumps(
+        convert_to_json_friendly(obj), separators=(",", ":")
+    )
+    with gzip.open(filepath, "wb") as file:
+        file.write(json_data.encode("utf-8"))
+    print("wrote " + filepath)
+
+
+def load_pickle_gzip(filepath):
+    with gzip.open(filepath, "rb") as file:
+        loaded_object = pickle.load(file)
+    return loaded_object
+
+
+def load_json_gzip(filepath):
+    with gzip.open(filepath, "rb") as file:
+        json_data = file.read().decode("utf-8")
+        loaded_data = json.loads(json_data)
+    return loaded_data
+
+
+class NullRecorder:
+    def record(self, key, value):
+        pass
+
+    def get_nested_recorder(self, key):
+        return NullRecorder()
+
+
+class BaseRecorder:
+    @abstractmethod
+    def _get_this_dict(self):
+        pass
+
+    def record(self, key, value):
+        this_dict = self._get_this_dict()
+        assert key not in this_dict
+        this_dict[key] = value
+
+    def get_nested_recorder(self, key):
+        return NestedRecorder(self, key)
+
+    def _get_nested_dict(self, key):
+        this_dict = self._get_this_dict()
+        if key in this_dict:
+            assert isinstance(this_dict[key], dict)
+        else:
+            this_dict[key] = {}
+
+        return this_dict[key]
+
+
+class StepRecorder(BaseRecorder):
+    def __init__(self):
+        self._partial_step_dict: Any = {}
+        self._steps: List[Any] = []
+
+    def finish_step(self):
+        self._steps.append(self._partial_step_dict)
+        self._partial_step_dict = {}
+
+    def reset(self):
+        self._partial_step_dict = {}
+        self._steps = []
+
+    def _get_this_dict(self):
+        return self._partial_step_dict
+
+
+class NestedRecorder(BaseRecorder):
+    def __init__(self, parent, scope_key):
+        self._parent = parent
+        self._scope_key = scope_key
+
+    def _get_this_dict(self):
+        return self._parent._get_nested_dict(self._scope_key)

--- a/examples/siro_sandbox/test_episode_save_files.py
+++ b/examples/siro_sandbox/test_episode_save_files.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+
+import numpy as np
+from serialize_utils import load_json_gzip, load_pickle_gzip
+
+
+def get_comp_value(a):
+    if isinstance(a, np.generic):
+        # If obj is a NumPy scalar type, convert it to a standard Python scalar type
+        return a.item()
+    else:
+        return a
+
+
+# Not completely general-purpose. Works for simple types and list-like types.
+def approx_equal(a_src, b_src, eps=1e-4):
+    a = get_comp_value(a_src)
+    b = get_comp_value(b_src)
+
+    if isinstance(a, (int, str, bool, type(None))):
+        return a == b
+    elif isinstance(a, float):
+        return abs(a - b) < eps
+    else:
+        a_list = a
+        b_list = b
+        if len(a_list) != len(b_list):
+            return False
+
+        return all(
+            approx_equal(a_list[i], b_list[i]) for i in range(len(a_list))
+        )
+
+
+def test_episode_save_files(filepath_base):
+    json_filepath = filepath_base + ".json.gz"
+    pkl_filepath = filepath_base + ".pkl.gz"
+
+    pkl_obj = load_pickle_gzip(pkl_filepath)
+    json_obj = load_json_gzip(json_filepath)
+
+    # Spot-check selected items for equality. We don't expect equality in all items
+    # because of differences in how the two data files are serialized/deserialized.
+    # For example, for json, some complex types are converted to strings and floats
+    # are rounded to 5 digits of precision.
+
+    for key in ["episode_id", "target_obj_ids"]:
+        assert pkl_obj[key] == json_obj[key]
+
+    for key in ["goal_positions"]:
+        assert len(pkl_obj[key])
+        assert approx_equal(pkl_obj[key], json_obj[key])
+
+    for step_idx in range(len(pkl_obj["steps"])):
+        pkl_step = pkl_obj["steps"][step_idx]
+        json_step = json_obj["steps"][step_idx]
+
+        assert approx_equal(
+            pkl_step["gui_humanoid"]["cam_yaw"],
+            json_step["gui_humanoid"]["cam_yaw"],
+        )
+
+        pkl_subobj = pkl_step["action"]["action_args"]
+        json_subobj = json_step["action"]["action_args"]
+        keys = [
+            "agent_0_arm_action",
+            "agent_0_oracle_nav_with_backing_up_action",
+        ]
+        for key in keys:
+            assert len(pkl_subobj[key])
+            assert approx_equal(pkl_subobj[key], json_subobj[key])
+
+        # We chose not to save these because it's too much data and bloats save files.
+        assert pkl_subobj["agent_1_human_joints_trans"] == None
+        assert json_subobj["agent_1_human_joints_trans"] == None
+
+        pkl_agent_states = pkl_step["agent_states"]
+        json_agent_states = pkl_step["agent_states"]
+        assert len(pkl_agent_states)
+        keys = ["position", "rotation_xyzw", "grasp_mgr_snap_idx"]
+        for i in range(len(pkl_agent_states)):
+            pkl_subobj = pkl_agent_states[i]
+            json_subobj = json_agent_states[i]
+            for key in keys:
+                assert approx_equal(pkl_subobj[key], json_subobj[key])
+
+        pkl_subobj = pkl_step["target_object_positions"]
+        json_subobj = json_step["target_object_positions"]
+        assert len(pkl_subobj)
+        approx_equal(pkl_subobj, json_subobj)
+
+    print("success!")
+    return
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--load-filepath-base",
+        type=str,
+        help="Same filepath base used for the sandbox app's --save-filepath-base.",
+    )
+    args = parser.parse_args()
+
+    test_episode_save_files(args.load_filepath_base)

--- a/examples/siro_sandbox/test_episode_save_files.py
+++ b/examples/siro_sandbox/test_episode_save_files.py
@@ -66,6 +66,7 @@ def test_episode_save_files(filepath_base):
             json_step["gui_humanoid"]["cam_yaw"],
         )
 
+        # These will not be present if the episode didn't include a policy-driven robot.
         pkl_subobj = pkl_step["action"]["action_args"]
         json_subobj = json_step["action"]["action_args"]
         keys = [


### PR DESCRIPTION
## Motivation and Context

When running the sandbox app, use `--save-filepath-base my_session`. When the user presses `M` to reset the env, the first episode will be saved as `my_session.0.json.gz` and `my_session.0.pkl.gz`. These files contain mostly-identical data; we save both so that developers have two choices for how to consume the data later. After pressing `M` again, the second episode will be saved as `my_session.1.json.gz`, etc. For an example of consuming this data, see `test_episode_save_files.py` .

We should also save episode gfx-replay files. This will be a separate PR.

This PR also includes some unrelated polish on help text and nav hints.

## How Has This Been Tested

Local testing on Fedora laptop

## Types of changes
PR into SIRo branch

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
