### PR TITLE
Fix Bugs that make hl_fixed policies fail

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/reset.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/reset.py
@@ -66,6 +66,10 @@ class ResetArmSkill(SkillPolicy):
             < 5e-2
         )
 
+    @property
+    def required_obs_keys(self) -> List[str]:
+        return ["joint", "is_holding"]
+
     def _internal_act(
         self,
         observations,

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/skill.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/skill.py
@@ -74,7 +74,10 @@ class SkillPolicy(Policy):
 
     @property
     def required_obs_keys(self) -> List[str]:
-        return []
+        if self._should_keep_hold_state:
+            return [IsHoldingSensor.cls_uuid]
+        else:
+            return []
 
     def _internal_log(self, s):
         baselines_logger.debug(


### PR DESCRIPTION
## Motivation and Context

Adds observations that skills need to have access to, and that made the hl_fixed planner crash.

## How Has This Been Tested
Ran:
```
python habitat-baselines/habitat_baselines/run.py \
--config-name=experiments_hab3/pop_play_kinematic_oracle_humanoid_spot_fp.yaml \
habitat_baselines.evaluate=True \
habitat.simulator.kinematic_mode=True \
habitat.simulator.step_physics=False \
habitat_baselines.num_environments=1
```

## Types of changes
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
