### PR TITLE
Sandbox App CLI episodes filter

### DIFF
--- a/examples/siro_sandbox/README.md
+++ b/examples/siro_sandbox/README.md
@@ -141,6 +141,10 @@ In the multi agent tidy house task, episode is considered over when humanoid and
 habitat.task.measurements.cooperate_subgoal_reward.end_on_collide=False
 ```
 
+## Play episodes filter
+Specify a subset of play episodes on the command line by adding `--episodes-filter`  argument followed by the filter string. Episodes filter string should be in the form `"0:10 12 14:20:2"`, where single integer number ('12' in this case) represents an episode id and colon separated integers ('0:10' and '14:20:2') represent start:stop:step episodes ids range.
+
+
 ## Using FP dataset
 To use FP dataset follow the FP installation instructions in [SIRO_README.md](../../SIRO_README.md) and run any of the above Sandbox launch command with the following config overrides appended:
 ```

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -185,7 +185,7 @@ class SandboxDriver(GuiAppDriver):
         )
 
         if self._play_episodes_filter_str is not None:
-            _max_num_digits: int = len(str(len(dataset.episodes)))
+            max_num_digits: int = len(str(len(dataset.episodes)))
 
             def get_play_episodes_ids(play_episodes_filter_str):
                 play_episodes_ids: Set[str] = set()
@@ -193,14 +193,12 @@ class SandboxDriver(GuiAppDriver):
                     if ":" in ep_filter_str:
                         range_params = map(int, ep_filter_str.split(":"))
                         play_episodes_ids.update(
-                            episode_id.zfill(_max_num_digits)
+                            episode_id.zfill(max_num_digits)
                             for episode_id in map(str, range(*range_params))
                         )
                     else:
                         episode_id = ep_filter_str
-                        play_episodes_ids.add(
-                            episode_id.zfill(_max_num_digits)
-                        )
+                        play_episodes_ids.add(episode_id.zfill(max_num_digits))
 
                 return play_episodes_ids
 
@@ -210,8 +208,7 @@ class SandboxDriver(GuiAppDriver):
             dataset.episodes = [
                 ep
                 for ep in dataset.episodes
-                if ep.episode_id.zfill(_max_num_digits)
-                in play_episodes_ids_set
+                if ep.episode_id.zfill(max_num_digits) in play_episodes_ids_set
             ]
 
         return dataset
@@ -824,11 +821,9 @@ class SandboxDriver(GuiAppDriver):
 
         if not self._env_episode_active():
             if self._env_task_complete:
-                status_str += (
-                    "Task complete!\nPress M to start the next episode.\n"
-                )
+                status_str += "Task complete!\n"
             else:
-                status_str += "Oops! Something went wrong.\nPress M to try again on the next episode.\n"
+                status_str += "Oops! Something went wrong.\n"
         elif self._held_target_obj_idx is not None:
             # reference code to display object handle
             # sim = self.get_sim()
@@ -855,7 +850,13 @@ class SandboxDriver(GuiAppDriver):
             status_str += "Just wait! The robot is moving the last object.\n"
         else:
             # we don't expect to hit this case ever
-            status_str += "Oops! Something went wrong.\nPress M to try again on the next episode.\n"
+            status_str += "Oops! Something went wrong.\n"
+
+        # center align the status_str
+        max_status_str_len = 50
+        status_str = "/n".join(
+            line.center(max_status_str_len) for line in status_str.split("/n")
+        )
 
         return status_str
 
@@ -872,7 +873,7 @@ class SandboxDriver(GuiAppDriver):
                 self._text_drawer.add_text(
                     status_str,
                     TextOnScreenAlignment.TOP_CENTER,
-                    text_delta_x=-150,
+                    text_delta_x=-280,
                     text_delta_y=-50,
                 )
 
@@ -895,7 +896,7 @@ class SandboxDriver(GuiAppDriver):
                 self._text_drawer.add_text(
                     tutorial_str,
                     TextOnScreenAlignment.TOP_CENTER,
-                    text_delta_x=-150,
+                    text_delta_x=-280,
                     text_delta_y=-50,
                 )
 

--- a/examples/siro_sandbox/test_episode_save_files.py
+++ b/examples/siro_sandbox/test_episode_save_files.py
@@ -50,7 +50,7 @@ def test_episode_save_files(filepath_base):
     # For example, for json, some complex types are converted to strings and floats
     # are rounded to 5 digits of precision.
 
-    for key in ["episode_id", "target_obj_ids"]:
+    for key in ["scene_id", "episode_id", "target_obj_ids"]:
         assert pkl_obj[key] == json_obj[key]
 
     for key in ["goal_positions"]:

--- a/habitat-lab/habitat/gui/text_drawer.py
+++ b/habitat-lab/habitat/gui/text_drawer.py
@@ -67,7 +67,7 @@ class TextDrawer:
             string.ascii_lowercase
             + string.ascii_uppercase
             + string.digits
-            + ":-_+,.! %µ",
+            + ":-_+,.! %µ/",
         )
         self._shader = shaders.VectorGL2D()
         self._window_text = text.Renderer2D(

--- a/habitat-lab/habitat/gui/text_drawer.py
+++ b/habitat-lab/habitat/gui/text_drawer.py
@@ -67,7 +67,7 @@ class TextDrawer:
             string.ascii_lowercase
             + string.ascii_uppercase
             + string.digits
-            + ":-_+,.! %µ/",
+            + ":-_+,.! %µ",
         )
         self._shader = shaders.VectorGL2D()
         self._window_text = text.Renderer2D(


### PR DESCRIPTION
## Motivation and Context

Enabled a possibility to specify a subset of play episodes on the command line (`--episodes-filter` CLI argument).

Episodes filter string should be in the form '0:10 12 14:20:2', where single integer number ('12' in this case) represents an episode id, colon separated integers ('0:10' and '14:20:2') represent start:stop:step ids range.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Local testing on MacBook Pro 2021.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- PR into SIRo branch

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
