### PR TITLE
Adds hab-lab changes for including static objects in navmesh settings

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -734,7 +734,7 @@ def import_tri_mesh(mesh_file: str) -> List[mn.trade.MeshData]:
         )
         mesh_transformations: List[
             mn.Matrix4
-        ] = mn.scenetools.flatten_transformation_hierarchy3d(
+        ] = mn.scenetools.absolute_field_transformations3d(
             scene, mn.trade.SceneField.MESH
         )
         assert len(mesh_assignments) == len(mesh_transformations)

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -339,6 +339,12 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
             },
         )
 
+        # configure default navmesh parameters to match the configured agent
+        sim_config.navmesh_settings = habitat_sim.nav.NavMeshSettings()
+        sim_config.navmesh_settings.set_defaults()
+        sim_config.navmesh_settings.agent_radius = agent_config.radius
+        sim_config.navmesh_settings.agent_height = agent_config.height
+
         sensor_specifications = []
         for sensor in _sensor_suite.sensors.values():
             assert isinstance(sensor, HabitatSimSensor)

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -391,11 +391,8 @@ class RearrangeSim(HabitatSim):
             self.navmesh_settings.agent_radius = agent_config.radius
             self.navmesh_settings.agent_height = agent_config.height
             self.navmesh_settings.agent_max_climb = 0.01
-            self.recompute_navmesh(
-                self.pathfinder,
-                self.navmesh_settings,
-                include_static_objects=True,
-            )
+            self.navmesh_settings.include_static_objects = True
+            self.recompute_navmesh(self.pathfinder, self.navmesh_settings)
             os.makedirs(osp.dirname(navmesh_path), exist_ok=True)
             self.pathfinder.save_nav_mesh(navmesh_path)
 

--- a/test/test_robot_wrapper.py
+++ b/test/test_robot_wrapper.py
@@ -304,7 +304,8 @@ def test_fetch_robot_wrapper(fixed_base):
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
 
         # add the robot to the world via the wrapper
@@ -458,7 +459,8 @@ def test_franka_robot_wrapper():
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
 
         # add the robot to the world via the wrapper
@@ -579,7 +581,8 @@ def test_spot_robot_wrapper(fixed_base):
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
         # add the robot to the world via the wrapper
         robot_path = "data/robots/hab_spot_arm/urdf/hab_spot_arm.urdf"
@@ -717,7 +720,8 @@ def test_stretch_robot_wrapper(fixed_base):
         # compute a navmesh on the ground plane
         navmesh_settings = habitat_sim.NavMeshSettings()
         navmesh_settings.set_defaults()
-        sim.recompute_navmesh(sim.pathfinder, navmesh_settings, True)
+        navmesh_settings.include_static_objects = True
+        sim.recompute_navmesh(sim.pathfinder, navmesh_settings)
         sim.navmesh_visualization = True
         # add the robot to the world via the wrapper
         robot_path = "data/robots/hab_stretch/urdf/hab_stretch.urdf"


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Dependency Upgrade\]** Upgrades one or several dependencies in habitat
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!
- **\[Experiment\]** A pull request that add new features to the [habitat-baselines](/habitat-baselines/) training codebase. Experiments Pull Requests can be any size, must have smoke/integration tests and be isolated from the rest of the code. Your code additions should not rely on other habitat-baselines code. This is to avoid dependencies between different parts of habitat-baselines. You must also include a README that will document how to use your new feature or trainer. **You** will be the maintainer of this code, if the code becomes stale or is not supported often enough, we will eventually remove it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
