### PR TITLE
bug fix to allow recording gfx-replay on episodes

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1228,7 +1228,7 @@ class TaskConfig(HabitatBaseConfig):
     should_save_to_cache: bool = False
     object_in_hand_sample_prob: float = 0.167
     min_start_distance: float = 3.0
-    gfx_replay_dir = "data/replays"
+    gfx_replay_dir: str = "data/replays"
     render_target: bool = True
     # Spawn parameters
     physics_stability_steps: int = 1

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
@@ -543,7 +543,12 @@ class GfxReplayMeasure(Measure):
         self.update_metric(*args, **kwargs)
 
     def update_metric(self, *args, task, **kwargs):
-        if not task._is_episode_active and self._enable_gfx_replay_save:
+        is_timeout = False
+        if "is_timeout" in kwargs:
+            is_timeout = kwargs["is_timeout"]
+        if (
+            is_timeout or not task._is_episode_active
+        ) and self._enable_gfx_replay_save:
             self._metric = (
                 self._sim.gfx_replay_manager.write_saved_keyframes_to_string()
             )


### PR DESCRIPTION
## Motivation and Context

Allows to record gfx-replay files from episodes, to be visualized in blender.

## How Has This Been Tested

Generated gfx-replay file.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
