### PR TITLE
add default navmesh construction config options to SimulatorConfig

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1442,6 +1442,12 @@ class SimulatorConfig(HabitatBaseConfig):
     # If the number of agents is greater than one,
     # then agents_order has to be set explicitly.
     agents_order: List[str] = MISSING
+
+    # Simulator should use default navmesh settings from agent config
+    default_agent_navmesh: bool = True
+    # if default navmesh is used, should it include static objects
+    navmesh_include_static_objects: bool = False
+
     habitat_sim_v0: HabitatSimV0Config = HabitatSimV0Config()
     # ep_info is added to the config in some rearrange tasks inside
     # merge_sim_episode_with_object_config

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -351,10 +351,14 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         )
 
         # configure default navmesh parameters to match the configured agent
-        sim_config.navmesh_settings = habitat_sim.nav.NavMeshSettings()
-        sim_config.navmesh_settings.set_defaults()
-        sim_config.navmesh_settings.agent_radius = agent_config.radius
-        sim_config.navmesh_settings.agent_height = agent_config.height
+        if self.habitat_config.default_agent_navmesh:
+            sim_config.navmesh_settings = habitat_sim.nav.NavMeshSettings()
+            sim_config.navmesh_settings.set_defaults()
+            sim_config.navmesh_settings.agent_radius = agent_config.radius
+            sim_config.navmesh_settings.agent_height = agent_config.height
+            sim_config.navmesh_settings.include_static_objects = (
+                self.habitat_config.navmesh_include_static_objects
+            )
 
         sensor_specifications = []
         for sensor in _sensor_suite.sensors.values():


### PR DESCRIPTION
## Motivation and Context

After #1351 we want config hooks for changing the default navmesh construction behavior for the simulator.

This PR adds the option to turn off default navmesh and to include static objects. Defaults are set to current behavior.  

This represents the first step. Ideally we expand these options further with an additional dataclass or other mechanism for detailed navmesh parameter tuning from config.

## How Has This Been Tested

Not tested yet.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
