### PR TITLE
[Development] Batch renderer: Depth sensor support

### DIFF
--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -55,7 +55,7 @@ class EnvBatchRenderer:
     _replay_renderer_cfg: ReplayRendererConfiguration = None
     _replay_renderer: ReplayRenderer = None
 
-    _gpu_to_cpu_images: List[mn.ImageView2D] = None
+    _gpu_to_cpu_images: List[mn.MutableImageView2D] = None
     _gpu_to_cpu_buffer: np.ndarray = None
 
     def __init__(self, config: DictConfig, num_envs: int) -> None:
@@ -190,30 +190,61 @@ class EnvBatchRenderer:
         :param sensor_spec: Habitat-sim sensor specifications.
         :return: ndarray containing renders.
         """
-        # TODO: Currently only one color sensor is supported.
-        if sensor_spec.sensor_type == habitat_sim.SensorType.COLOR:
+        # TODO: Currently one sensor is supported.
+        is_color_sensor = (
+            sensor_spec.sensor_type == habitat_sim.SensorType.COLOR
+        )
+        is_depth_sensor = (
+            sensor_spec.sensor_type == habitat_sim.SensorType.DEPTH
+        )
+
+        if is_color_sensor or is_depth_sensor:
             if self._gpu_to_cpu_images is None:
                 # Allocate the transfer buffers
                 self._gpu_to_cpu_images = []
                 storage = mn.PixelStorage()
                 storage.alignment = 2
-                self._gpu_to_cpu_buffer = np.empty(
-                    (
-                        self._num_envs,
-                        sensor_spec.resolution[0],
-                        sensor_spec.resolution[1],
-                        sensor_spec.channels,
-                    ),
-                    dtype=np.uint8,
-                )
+
+                if is_color_sensor:
+                    self._gpu_to_cpu_buffer = np.empty(
+                        (
+                            self._num_envs,
+                            sensor_spec.resolution[0],
+                            sensor_spec.resolution[1],
+                            sensor_spec.channels,
+                        ),
+                        dtype=np.uint8,
+                    )
+                elif is_depth_sensor:
+                    self._gpu_to_cpu_buffer = np.empty(
+                        (
+                            self._num_envs,
+                            sensor_spec.resolution[0],
+                            sensor_spec.resolution[1],
+                        ),
+                        dtype=np.float32,
+                    )
 
                 for env_idx in range(self._num_envs):
                     # Create image view for writing into buffer from Magnum
-                    env_img_view = mn.MutableImageView2D(
-                        mn.PixelFormat.RGBA8_UNORM,
-                        [sensor_spec.resolution[1], sensor_spec.resolution[0]],
-                        self._gpu_to_cpu_buffer[env_idx],
-                    )
+                    if is_color_sensor:
+                        env_img_view = mn.MutableImageView2D(
+                            mn.PixelFormat.RGBA8_UNORM,
+                            [
+                                sensor_spec.resolution[1],
+                                sensor_spec.resolution[0],
+                            ],
+                            self._gpu_to_cpu_buffer[env_idx],
+                        )
+                    elif is_depth_sensor:
+                        env_img_view = mn.MutableImageView2D(
+                            mn.PixelFormat.R32F,
+                            [
+                                sensor_spec.resolution[1],
+                                sensor_spec.resolution[0],
+                            ],
+                            self._gpu_to_cpu_buffer[env_idx],
+                        )
                     self._gpu_to_cpu_images.append(env_img_view)
 
                 # Flip the transfer buffer view vertically for presentation
@@ -224,7 +255,11 @@ class EnvBatchRenderer:
             raise NotImplementedError
 
         # Render
-        self._replay_renderer.render(color_images=self._gpu_to_cpu_images)
+        if is_color_sensor:
+            self._replay_renderer.render(color_images=self._gpu_to_cpu_images)
+        elif is_depth_sensor:
+            self._replay_renderer.render(depth_images=self._gpu_to_cpu_images)
+
         return self._gpu_to_cpu_buffer
 
     def _draw_observations_gpu_to_gpu(
@@ -240,13 +275,39 @@ class EnvBatchRenderer:
 
         :return: List of RGB images as ndarrays.
         """
-        # TODO: Only one color sensor supported.
+        # TODO: Only one sensor supported.
         output: List[np.ndarray] = []
         if self._gpu_gpu:
             raise NotImplementedError
         else:
+            sensor_spec = self._sensor_specifications[0]
             for env_idx in range(self._num_envs):
-                output.append(self._gpu_to_cpu_buffer[env_idx][..., 0:3])
+                if sensor_spec.sensor_type == habitat_sim.SensorType.COLOR:
+                    output.append(self._gpu_to_cpu_buffer[env_idx][..., 0:3])
+                elif sensor_spec.sensor_type == habitat_sim.SensorType.DEPTH:
+                    float_depth_image = self._gpu_to_cpu_buffer[env_idx]
+                    int_depth_image = np.zeros_like(
+                        float_depth_image, dtype=np.uint8
+                    )
+                    float_min = float_depth_image.min()
+                    float_max = float_depth_image.max()
+
+                    # Normalize the distance into 0-255 into new array
+                    for y, x in np.ndindex(float_depth_image.shape):
+                        distance_from_camera = float_depth_image[y, x]
+                        normalized_color_value = np.uint8(
+                            255.0
+                            * (
+                                (distance_from_camera - float_min)
+                                / (float_max - float_min)
+                            )
+                        )
+                        int_depth_image[y, x] = normalized_color_value
+
+                    # Expand single channel to RGB channels
+                    rgb_depth_image = np.dstack([int_depth_image] * 3)
+
+                    output.append(rgb_depth_image)
         return output
 
     @staticmethod

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -224,7 +224,7 @@ class EnvBatchRenderer:
             raise NotImplementedError
 
         # Render
-        self._replay_renderer.render(self._gpu_to_cpu_images, None)
+        self._replay_renderer.render(color_images=self._gpu_to_cpu_images)
         return self._gpu_to_cpu_buffer
 
     def _draw_observations_gpu_to_gpu(

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -224,7 +224,7 @@ class EnvBatchRenderer:
             raise NotImplementedError
 
         # Render
-        self._replay_renderer.render(self._gpu_to_cpu_images)
+        self._replay_renderer.render(self._gpu_to_cpu_images, None)
         return self._gpu_to_cpu_buffer
 
     def _draw_observations_gpu_to_gpu(

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -294,14 +294,22 @@ def test_rl_vectorized_envs(gpu2gpu):
 
 
 @pytest.mark.parametrize("classic_replay_renderer", [False, True])
+@pytest.mark.parametrize("sensor_uuid", ["rgb_sensor", "depth_sensor"])
 @pytest.mark.parametrize("gpu2gpu", [False])
 def test_rl_vectorized_envs_batch_renderer(
-    gpu2gpu: bool, classic_replay_renderer: bool
+    gpu2gpu: bool, sensor_uuid: str, classic_replay_renderer: bool
 ):
     import habitat_sim
 
     if gpu2gpu and not habitat_sim.cuda_enabled:
         pytest.skip("GPU-GPU requires CUDA")
+
+    if sensor_uuid == "rgb_sensor":
+        obs_key = "rgb"
+    elif sensor_uuid == "depth_sensor":
+        obs_key = "depth"
+    else:
+        pytest.fail("Unknown sensor uuid: " + sensor_uuid)
 
     configs, datasets = _load_test_data()
     for config in configs:
@@ -316,14 +324,14 @@ def test_rl_vectorized_envs_batch_renderer(
             config.habitat.simulator.create_renderer = False
             config.habitat.simulator.habitat_sim_v0.gpu_gpu = gpu2gpu
             agent_config = get_agent_config(config.habitat.simulator)
-            # Only keep the rgb_sensor
+            ## Only keep one sensor
             agent_config.sim_sensors = {
-                "rgb_sensor": agent_config.sim_sensors["rgb_sensor"]
+                sensor_uuid: agent_config.sim_sensors[sensor_uuid]
             }
 
     num_envs = len(configs)
     env_fn_args = tuple(zip(configs, datasets, range(num_envs)))
-    with habitat.VectorEnv(
+    with habitat.ThreadedVectorEnv(
         make_env_fn=_make_dummy_env_func, env_fn_args=env_fn_args
     ) as envs:
         envs.initialize_batch_renderer(configs[0])
@@ -338,16 +346,21 @@ def test_rl_vectorized_envs_batch_renderer(
         assert len(observations) == num_envs
 
         # TODO: Add screenshot tests. Image stats are compared until then.
-        reset_image_mean: List[float] = [126.23, 126.84, 126.62, 125.63]
-        reset_image_std_dev: List[float] = [26.54, 26.16, 25.80, 26.56]
-        tiled_img = envs.render(mode="rgb_array")
+        threshold: float = 0.01
+        if sensor_uuid == "rgb_sensor":
+            baseline_mean: List[float] = [126.23, 126.84, 126.62, 125.63]
+            baseline_std_dev: List[float] = [26.54, 26.16, 25.80, 26.56]
+        elif sensor_uuid == "depth_sensor":
+            baseline_mean: List[float] = [0.4852, 0.4886, 0.4920, 0.4956]
+            baseline_std_dev: List[float] = [0.0107, 0.0112, 0.0117, 0.0122]
         for env_idx in range(num_envs):
-            mean = float(np.mean(tiled_img[env_idx]))
-            std_dev = float(np.std(tiled_img[env_idx]))
-            assert abs(reset_image_mean[env_idx] - mean) < 0.01
-            assert abs(reset_image_std_dev[env_idx] - std_dev) < 0.01
+            env_obs = observations[env_idx][obs_key]
+            mean = float(np.mean(env_obs[env_idx]))
+            std_dev = float(np.std(env_obs[env_idx]))
+            assert abs(baseline_mean[env_idx] - mean) < threshold
+            assert abs(baseline_std_dev[env_idx] - std_dev) < threshold
 
-        for i in range(2 * configs[0].habitat.environment.max_episode_steps):
+        for _ in range(2 * configs[0].habitat.environment.max_episode_steps):
             outputs = envs.step(
                 sample_non_stop_action_gym(envs.action_spaces[0], num_envs)
             )
@@ -368,20 +381,18 @@ def test_rl_vectorized_envs_batch_renderer(
             assert len(dones) == num_envs
             assert len(infos) == num_envs
 
+            # Note: Uncomment this line to visualize:
+            # envs.render(mode="human")
+
             tiled_img = envs.render(mode="rgb_array")
             new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
             new_width = int(np.ceil(float(NUM_ENVS) / new_height))
-            h, w, c = observations[0]["rgb"].shape
+            h, w, _c = observations[0][obs_key].shape
             assert tiled_img.shape == (
                 h * new_height,
                 w * new_width,
-                c,
+                3,
             ), "vector env render is broken"
-
-            if (i + 1) % configs[0].habitat.environment.max_episode_steps == 0:
-                assert all(
-                    dones
-                ), "dones should be true after max_episode steps"
 
 
 @pytest.mark.parametrize("gpu2gpu", [False, True])

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -331,7 +331,7 @@ def test_rl_vectorized_envs_batch_renderer(
 
     num_envs = len(configs)
     env_fn_args = tuple(zip(configs, datasets, range(num_envs)))
-    with habitat.ThreadedVectorEnv(
+    with habitat.VectorEnv(
         make_env_fn=_make_dummy_env_func, env_fn_args=env_fn_args
     ) as envs:
         envs.initialize_batch_renderer(configs[0])
@@ -387,7 +387,7 @@ def test_rl_vectorized_envs_batch_renderer(
             tiled_img = envs.render(mode="rgb_array")
             new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
             new_width = int(np.ceil(float(NUM_ENVS) / new_height))
-            h, w, _c = observations[0][obs_key].shape
+            h, w, _ = observations[0][obs_key].shape
             assert tiled_img.shape == (
                 h * new_height,
                 w * new_width,

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -348,11 +348,11 @@ def test_rl_vectorized_envs_batch_renderer(
         # TODO: Add screenshot tests. Image stats are compared until then.
         threshold: float = 0.01
         if sensor_uuid == "rgb_sensor":
-            baseline_mean: List[float] = [126.23, 126.84, 126.62, 125.63]
-            baseline_std_dev: List[float] = [26.54, 26.16, 25.80, 26.56]
+            baseline_mean = [126.23, 126.84, 126.62, 125.63]
+            baseline_std_dev = [26.54, 26.16, 25.80, 26.56]
         elif sensor_uuid == "depth_sensor":
-            baseline_mean: List[float] = [0.4852, 0.4886, 0.4920, 0.4956]
-            baseline_std_dev: List[float] = [0.0107, 0.0112, 0.0117, 0.0122]
+            baseline_mean = [0.4852, 0.4886, 0.4920, 0.4956]
+            baseline_std_dev = [0.0107, 0.0112, 0.0117, 0.0122]
         for env_idx in range(num_envs):
             env_obs = observations[env_idx][obs_key]
             mean = float(np.mean(env_obs[env_idx]))


### PR DESCRIPTION
## Motivation and Context

This changeset adds support for depth sensors in `env_batch_renderer`.
The limitation that only one sensor is supported still holds. Either one color or depth sensor can be used at the moment.

Depends on: https://github.com/facebookresearch/habitat-sim/pull/2129

## How Has This Been Tested

- `test_rl_vectorized_envs_batch_renderer` has been updated with depth sensor baselines.
- `envs.render(mode="human")` has been run locally to validate generated images.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
