### PR TITLE
using config instead of len for counting envs

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/ver/ver_trainer.py
+++ b/habitat-baselines/habitat_baselines/rl/ver/ver_trainer.py
@@ -75,7 +75,7 @@ class VERTrainer(PPOTrainer):
             is_distrib=self._is_distributed,
             device=self.device,
             resume_state=resume_state,
-            num_envs=len(self.environment_workers),
+            num_envs=self.config.habitat_baselines.num_environments,
             percent_done_fn=self.percent_done,
             **kwargs,
         )


### PR DESCRIPTION
## Motivation and Context

In habitat-lab v0.2.4, VERTrainer is no longer working for evaluating checkpoints, the user has to override the config back to DDPPO to work

## How Has This Been Tested

Eval with pointnav confirmed to work after change

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
