### PR TITLE
[Development] Batch renderer PPO training integration

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -268,6 +268,7 @@ class PPOTrainer(BaseRLTrainer):
         self._ppo_cfg = self.config.habitat_baselines.rl.ppo
 
         observations = self.envs.reset()
+        observations = self.envs.post_step(observations)
         batch = batch_obs(observations, device=self.device)
         batch = apply_obs_transforms_batch(batch, self.obs_transforms)  # type: ignore
 
@@ -405,6 +406,7 @@ class PPOTrainer(BaseRLTrainer):
             ]
 
         with g_timer.avg_time("trainer.update_stats"):
+            observations = self.envs.post_step(observations)
             batch = batch_obs(observations, device=self.device)
             batch = apply_obs_transforms_batch(batch, self.obs_transforms)  # type: ignore
 
@@ -848,6 +850,7 @@ class PPOTrainer(BaseRLTrainer):
             self._agent.load_state_dict(ckpt_dict)
 
         observations = self.envs.reset()
+        observations = self.envs.post_step(observations)
         batch = batch_obs(observations, device=self.device)
         batch = apply_obs_transforms_batch(batch, self.obs_transforms)  # type: ignore
 
@@ -963,6 +966,8 @@ class PPOTrainer(BaseRLTrainer):
             )
             for i in range(len(policy_infos)):
                 infos[i].update(policy_infos[i])
+            
+            observations = self.envs.post_step(observations)
             batch = batch_obs(  # type: ignore
                 observations,
                 device=self.device,

--- a/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -966,7 +966,7 @@ class PPOTrainer(BaseRLTrainer):
             )
             for i in range(len(policy_infos)):
                 infos[i].update(policy_infos[i])
-            
+
             observations = self.envs.post_step(observations)
             batch = batch_obs(  # type: ignore
                 observations,

--- a/habitat-baselines/habitat_baselines/rl/ver/ver_trainer.py
+++ b/habitat-baselines/habitat_baselines/rl/ver/ver_trainer.py
@@ -81,6 +81,10 @@ class VERTrainer(PPOTrainer):
         )
 
     def _init_train(self, resume_state):
+        assert (
+            not self.config.habitat.simulator.renderer.enable_batch_renderer
+        ), "VER trainer does not support batch rendering."
+
         if self._is_distributed:
             local_rank, world_rank, _ = get_distrib_size()
 

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -119,6 +119,12 @@ class EnvBatchRenderer:
         # Pre-load graphics assets using composite GLTF files.
         EnvBatchRenderer._load_composite_files(config, self._replay_renderer)
 
+    def close(self) -> None:
+        r"""
+        Release the resources and graphics context.
+        """
+        self._replay_renderer = None
+
     def post_step(self, observations: List[OrderedDict]) -> List[OrderedDict]:
         r"""
         Renders observations for all environments by consuming keyframe observations.

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -72,7 +72,9 @@ class EnvBatchRenderer:
         assert (
             not config.habitat.simulator.create_renderer
         ), "Batch renderer requires create_renderer to be disabled in config."
-
+        assert (
+            not config.habitat.simulator.debug_render
+        ), "Batch renderer requires debug_render to be disabled in config."
         logger.warn(
             "Batch rendering enabled. This feature is experimental and may change at any time."
         )

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -123,7 +123,8 @@ class EnvBatchRenderer:
         r"""
         Release the resources and graphics context.
         """
-        self._replay_renderer = None
+        if self._replay_renderer != None:
+            self._replay_renderer.close()
 
     def post_step(self, observations: List[OrderedDict]) -> List[OrderedDict]:
         r"""

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -55,7 +55,7 @@ class EnvBatchRenderer:
     _replay_renderer_cfg: ReplayRendererConfiguration = None
     _replay_renderer: ReplayRenderer = None
 
-    _gpu_to_cpu_images: List[mn.ImageView2D] = None
+    _gpu_to_cpu_images: List[mn.MutableImageView2D] = None
     _gpu_to_cpu_buffer: np.ndarray = None
 
     def __init__(self, config: DictConfig, num_envs: int) -> None:
@@ -190,30 +190,61 @@ class EnvBatchRenderer:
         :param sensor_spec: Habitat-sim sensor specifications.
         :return: ndarray containing renders.
         """
-        # TODO: Currently only one color sensor is supported.
-        if sensor_spec.sensor_type == habitat_sim.SensorType.COLOR:
+        # TODO: Currently one sensor is supported.
+        is_color_sensor = (
+            sensor_spec.sensor_type == habitat_sim.SensorType.COLOR
+        )
+        is_depth_sensor = (
+            sensor_spec.sensor_type == habitat_sim.SensorType.DEPTH
+        )
+
+        if is_color_sensor or is_depth_sensor:
             if self._gpu_to_cpu_images is None:
                 # Allocate the transfer buffers
                 self._gpu_to_cpu_images = []
                 storage = mn.PixelStorage()
                 storage.alignment = 2
-                self._gpu_to_cpu_buffer = np.empty(
-                    (
-                        self._num_envs,
-                        sensor_spec.resolution[0],
-                        sensor_spec.resolution[1],
-                        sensor_spec.channels,
-                    ),
-                    dtype=np.uint8,
-                )
+
+                if is_color_sensor:
+                    self._gpu_to_cpu_buffer = np.empty(
+                        (
+                            self._num_envs,
+                            sensor_spec.resolution[0],
+                            sensor_spec.resolution[1],
+                            sensor_spec.channels,
+                        ),
+                        dtype=np.uint8,
+                    )
+                elif is_depth_sensor:
+                    self._gpu_to_cpu_buffer = np.empty(
+                        (
+                            self._num_envs,
+                            sensor_spec.resolution[0],
+                            sensor_spec.resolution[1],
+                        ),
+                        dtype=np.float32,
+                    )
 
                 for env_idx in range(self._num_envs):
                     # Create image view for writing into buffer from Magnum
-                    env_img_view = mn.MutableImageView2D(
-                        mn.PixelFormat.RGBA8_UNORM,
-                        [sensor_spec.resolution[1], sensor_spec.resolution[0]],
-                        self._gpu_to_cpu_buffer[env_idx],
-                    )
+                    if is_color_sensor:
+                        env_img_view = mn.MutableImageView2D(
+                            mn.PixelFormat.RGBA8_UNORM,
+                            [
+                                sensor_spec.resolution[1],
+                                sensor_spec.resolution[0],
+                            ],
+                            self._gpu_to_cpu_buffer[env_idx],
+                        )
+                    elif is_depth_sensor:
+                        env_img_view = mn.MutableImageView2D(
+                            mn.PixelFormat.R32F,
+                            [
+                                sensor_spec.resolution[1],
+                                sensor_spec.resolution[0],
+                            ],
+                            self._gpu_to_cpu_buffer[env_idx],
+                        )
                     self._gpu_to_cpu_images.append(env_img_view)
 
                 # Flip the transfer buffer view vertically for presentation
@@ -224,7 +255,11 @@ class EnvBatchRenderer:
             raise NotImplementedError
 
         # Render
-        self._replay_renderer.render(color_images=self._gpu_to_cpu_images)
+        if is_color_sensor:
+            self._replay_renderer.render(color_images=self._gpu_to_cpu_images)
+        elif is_depth_sensor:
+            self._replay_renderer.render(depth_images=self._gpu_to_cpu_images)
+
         return self._gpu_to_cpu_buffer
 
     def _draw_observations_gpu_to_gpu(
@@ -240,13 +275,39 @@ class EnvBatchRenderer:
 
         :return: List of RGB images as ndarrays.
         """
-        # TODO: Only one color sensor supported.
+        # TODO: Only one sensor supported.
         output: List[np.ndarray] = []
         if self._gpu_gpu:
             raise NotImplementedError
         else:
+            sensor_spec = self._sensor_specifications[0]
             for env_idx in range(self._num_envs):
-                output.append(self._gpu_to_cpu_buffer[env_idx][..., 0:3])
+                if sensor_spec.sensor_type == habitat_sim.SensorType.COLOR:
+                    output.append(self._gpu_to_cpu_buffer[env_idx][..., 0:3])
+                elif sensor_spec.sensor_type == habitat_sim.SensorType.DEPTH:
+                    float_depth_image = self._gpu_to_cpu_buffer[env_idx]
+                    int_depth_image = np.zeros_like(
+                        float_depth_image, dtype=np.uint8
+                    )
+                    float_min = float_depth_image.min()
+                    float_max = float_depth_image.max()
+
+                    # Normalize the distance into 0-255 into new array
+                    for y, x in np.ndindex(float_depth_image.shape):
+                        distance_from_camera = float_depth_image[y, x]
+                        normalized_color_value = np.uint8(
+                            255.0
+                            * (
+                                (distance_from_camera - float_min)
+                                / (float_max - float_min)
+                            )
+                        )
+                        int_depth_image[y, x] = normalized_color_value
+
+                    # Expand single channel to RGB channels
+                    rgb_depth_image = np.dstack([int_depth_image] * 3)
+
+                    output.append(rgb_depth_image)
         return output
 
     @staticmethod

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -224,7 +224,7 @@ class EnvBatchRenderer:
             raise NotImplementedError
 
         # Render
-        self._replay_renderer.render(self._gpu_to_cpu_images, None)
+        self._replay_renderer.render(color_images=self._gpu_to_cpu_images)
         return self._gpu_to_cpu_buffer
 
     def _draw_observations_gpu_to_gpu(

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer.py
@@ -224,7 +224,7 @@ class EnvBatchRenderer:
             raise NotImplementedError
 
         # Render
-        self._replay_renderer.render(self._gpu_to_cpu_images)
+        self._replay_renderer.render(self._gpu_to_cpu_images, None)
         return self._gpu_to_cpu_buffer
 
     def _draw_observations_gpu_to_gpu(

--- a/habitat-lab/habitat/core/vector_env.py
+++ b/habitat-lab/habitat/core/vector_env.py
@@ -480,8 +480,7 @@ class VectorEnv:
 
         self._is_closed = True
 
-        # Force the batch renderer to release its context.
-        self._batch_renderer = None
+        self._batch_renderer.close()
 
     def pause_at(self, index: int) -> None:
         r"""Pauses computation on this env without destroying the env.

--- a/habitat-lab/habitat/core/vector_env.py
+++ b/habitat-lab/habitat/core/vector_env.py
@@ -480,6 +480,9 @@ class VectorEnv:
 
         self._is_closed = True
 
+        # Force the batch renderer to release its context.
+        self._batch_renderer = None
+
     def pause_at(self, index: int) -> None:
         r"""Pauses computation on this env without destroying the env.
 

--- a/habitat-lab/habitat/core/vector_env.py
+++ b/habitat-lab/habitat/core/vector_env.py
@@ -480,7 +480,8 @@ class VectorEnv:
 
         self._is_closed = True
 
-        self._batch_renderer.close()
+        if self._batch_renderer != None:
+            self._batch_renderer.close()
 
     def pause_at(self, index: int) -> None:
         r"""Pauses computation on this env without destroying the env.

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -291,9 +291,6 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         self._sensor_suite = SensorSuite(sim_sensors)
         self.sim_config = self.create_sim_config(self._sensor_suite)
         self._current_scene = self.sim_config.sim_cfg.scene_id
-        self.sim_config.enable_batch_renderer = (
-            config.renderer.enable_batch_renderer
-        )
         super().__init__(self.sim_config)
         # load additional object paths specified by the dataset
         # TODO: Should this be moved elsewhere?
@@ -414,7 +411,9 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
             ),
         }
 
-        return habitat_sim.Configuration(sim_config, [agent_config])
+        output = habitat_sim.Configuration(sim_config, [agent_config])
+        output.enable_batch_renderer = self.habitat_config.renderer.enable_batch_renderer
+        return output
 
     @property
     def sensor_suite(self) -> SensorSuite:

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -416,7 +416,9 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         }
 
         output = habitat_sim.Configuration(sim_config, [agent_config])
-        output.enable_batch_renderer = self.habitat_config.renderer.enable_batch_renderer
+        output.enable_batch_renderer = (
+            self.habitat_config.renderer.enable_batch_renderer
+        )
         return output
 
     @property

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -858,11 +858,7 @@ class RearrangeSim(HabitatSim):
             self._update_markers()
 
         # TODO: Make debug cameras more flexible
-        if (
-            "third_rgb" in obs
-            and self._debug_render
-            and not self._batch_render
-        ):
+        if "third_rgb" in obs and self._debug_render:
             self._try_acquire_context()
             for k, (pos, r) in add_back_viz_objs.items():
                 viz_id = self.viz_ids[k]

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -825,7 +825,7 @@ class RearrangeSim(HabitatSim):
         if self._batch_render:
             for _ in range(self.ac_freq_ratio):
                 self.internal_step(-1, update_articulated_agent=False)
-                
+
             self._prev_sim_obs = self.get_sensor_observations()
             self.add_keyframe_to_observations(self._prev_sim_obs)
             obs = self._prev_sim_obs
@@ -858,7 +858,11 @@ class RearrangeSim(HabitatSim):
             self._update_markers()
 
         # TODO: Make debug cameras more flexible
-        if "third_rgb" in obs and self._debug_render and not self._batch_render:
+        if (
+            "third_rgb" in obs
+            and self._debug_render
+            and not self._batch_render
+        ):
             self._try_acquire_context()
             for k, (pos, r) in add_back_viz_objs.items():
                 viz_id = self.viz_ids[k]

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -826,11 +826,10 @@ class RearrangeSim(HabitatSim):
             for _ in range(self.ac_freq_ratio):
                 self.internal_step(-1, update_articulated_agent=False)
 
-            self._prev_sim_obs = self.get_sensor_observations()
-            self.add_keyframe_to_observations(self._prev_sim_obs)
-            obs = self._prev_sim_obs
+            obs = self.get_sensor_observations()
+            self.add_keyframe_to_observations(obs)
         elif self._concur_render:
-            self._prev_sim_obs = self.start_async_render()
+            self.start_async_render()
 
             for _ in range(self.ac_freq_ratio):
                 self.internal_step(-1, update_articulated_agent=False)

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -211,7 +211,7 @@ class RearrangeTask(NavigationTask):
     def _get_observations(self, episode):
         # Fetch the simulator observations, all visual sensors.
         obs = self._sim.get_sensor_observations()
-        
+
         if not self._sim.sim_config.enable_batch_renderer:
             # Post-process visual sensor observations
             obs = self._sim._sensor_suite.get_observations(obs)

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -210,9 +210,14 @@ class RearrangeTask(NavigationTask):
     @add_perf_timing_func()
     def _get_observations(self, episode):
         # Fetch the simulator observations, all visual sensors.
-        obs = self._sim._sensor_suite.get_observations(
-            self._sim.get_sensor_observations()
-        )
+        obs = self._sim.get_sensor_observations()
+        
+        if not self._sim.sim_config.enable_batch_renderer:
+            # Post-process visual sensor observations
+            obs = self._sim._sensor_suite.get_observations(obs)
+        else:
+            # Keyframes are added so that the simulator state can be reconstituted later.
+            self._sim.add_keyframe_to_observations(obs)
 
         # Task sensors (all non-visual sensors)
         obs.update(

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -216,7 +216,8 @@ class RearrangeTask(NavigationTask):
             # Post-process visual sensor observations
             obs = self._sim._sensor_suite.get_observations(obs)
         else:
-            # Keyframes are added so that the simulator state can be reconstituted later.
+            # Keyframes are added so that the simulator state can be reconstituted when batch rendering.
+            # The post-processing step above is done after batch rendering.
             self._sim.add_keyframe_to_observations(obs)
 
         # Task sensors (all non-visual sensors)

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -294,14 +294,22 @@ def test_rl_vectorized_envs(gpu2gpu):
 
 
 @pytest.mark.parametrize("classic_replay_renderer", [False, True])
+@pytest.mark.parametrize("sensor_uuid", ["rgb_sensor", "depth_sensor"])
 @pytest.mark.parametrize("gpu2gpu", [False])
 def test_rl_vectorized_envs_batch_renderer(
-    gpu2gpu: bool, classic_replay_renderer: bool
+    gpu2gpu: bool, sensor_uuid: str, classic_replay_renderer: bool
 ):
     import habitat_sim
 
     if gpu2gpu and not habitat_sim.cuda_enabled:
         pytest.skip("GPU-GPU requires CUDA")
+
+    if sensor_uuid == "rgb_sensor":
+        obs_key = "rgb"
+    elif sensor_uuid == "depth_sensor":
+        obs_key = "depth"
+    else:
+        pytest.fail("Unknown sensor uuid: " + sensor_uuid)
 
     configs, datasets = _load_test_data()
     for config in configs:
@@ -316,14 +324,14 @@ def test_rl_vectorized_envs_batch_renderer(
             config.habitat.simulator.create_renderer = False
             config.habitat.simulator.habitat_sim_v0.gpu_gpu = gpu2gpu
             agent_config = get_agent_config(config.habitat.simulator)
-            # Only keep the rgb_sensor
+            ## Only keep one sensor
             agent_config.sim_sensors = {
-                "rgb_sensor": agent_config.sim_sensors["rgb_sensor"]
+                sensor_uuid: agent_config.sim_sensors[sensor_uuid]
             }
 
     num_envs = len(configs)
     env_fn_args = tuple(zip(configs, datasets, range(num_envs)))
-    with habitat.VectorEnv(
+    with habitat.ThreadedVectorEnv(
         make_env_fn=_make_dummy_env_func, env_fn_args=env_fn_args
     ) as envs:
         envs.initialize_batch_renderer(configs[0])
@@ -338,16 +346,21 @@ def test_rl_vectorized_envs_batch_renderer(
         assert len(observations) == num_envs
 
         # TODO: Add screenshot tests. Image stats are compared until then.
-        reset_image_mean: List[float] = [126.23, 126.84, 126.62, 125.63]
-        reset_image_std_dev: List[float] = [26.54, 26.16, 25.80, 26.56]
-        tiled_img = envs.render(mode="rgb_array")
+        threshold: float = 0.01
+        if sensor_uuid == "rgb_sensor":
+            baseline_mean: List[float] = [126.23, 126.84, 126.62, 125.63]
+            baseline_std_dev: List[float] = [26.54, 26.16, 25.80, 26.56]
+        elif sensor_uuid == "depth_sensor":
+            baseline_mean: List[float] = [0.4852, 0.4886, 0.4920, 0.4956]
+            baseline_std_dev: List[float] = [0.0107, 0.0112, 0.0117, 0.0122]
         for env_idx in range(num_envs):
-            mean = float(np.mean(tiled_img[env_idx]))
-            std_dev = float(np.std(tiled_img[env_idx]))
-            assert abs(reset_image_mean[env_idx] - mean) < 0.01
-            assert abs(reset_image_std_dev[env_idx] - std_dev) < 0.01
+            env_obs = observations[env_idx][obs_key]
+            mean = float(np.mean(env_obs[env_idx]))
+            std_dev = float(np.std(env_obs[env_idx]))
+            assert abs(baseline_mean[env_idx] - mean) < threshold
+            assert abs(baseline_std_dev[env_idx] - std_dev) < threshold
 
-        for i in range(2 * configs[0].habitat.environment.max_episode_steps):
+        for _ in range(2 * configs[0].habitat.environment.max_episode_steps):
             outputs = envs.step(
                 sample_non_stop_action_gym(envs.action_spaces[0], num_envs)
             )
@@ -368,20 +381,18 @@ def test_rl_vectorized_envs_batch_renderer(
             assert len(dones) == num_envs
             assert len(infos) == num_envs
 
+            # Note: Uncomment this line to visualize:
+            # envs.render(mode="human")
+
             tiled_img = envs.render(mode="rgb_array")
             new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
             new_width = int(np.ceil(float(NUM_ENVS) / new_height))
-            h, w, c = observations[0]["rgb"].shape
+            h, w, _c = observations[0][obs_key].shape
             assert tiled_img.shape == (
                 h * new_height,
                 w * new_width,
-                c,
+                3,
             ), "vector env render is broken"
-
-            if (i + 1) % configs[0].habitat.environment.max_episode_steps == 0:
-                assert all(
-                    dones
-                ), "dones should be true after max_episode steps"
 
 
 @pytest.mark.parametrize("gpu2gpu", [False, True])

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -331,7 +331,7 @@ def test_rl_vectorized_envs_batch_renderer(
 
     num_envs = len(configs)
     env_fn_args = tuple(zip(configs, datasets, range(num_envs)))
-    with habitat.ThreadedVectorEnv(
+    with habitat.VectorEnv(
         make_env_fn=_make_dummy_env_func, env_fn_args=env_fn_args
     ) as envs:
         envs.initialize_batch_renderer(configs[0])
@@ -387,7 +387,7 @@ def test_rl_vectorized_envs_batch_renderer(
             tiled_img = envs.render(mode="rgb_array")
             new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
             new_width = int(np.ceil(float(NUM_ENVS) / new_height))
-            h, w, _c = observations[0][obs_key].shape
+            h, w, _ = observations[0][obs_key].shape
             assert tiled_img.shape == (
                 h * new_height,
                 w * new_width,

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -348,11 +348,11 @@ def test_rl_vectorized_envs_batch_renderer(
         # TODO: Add screenshot tests. Image stats are compared until then.
         threshold: float = 0.01
         if sensor_uuid == "rgb_sensor":
-            baseline_mean: List[float] = [126.23, 126.84, 126.62, 125.63]
-            baseline_std_dev: List[float] = [26.54, 26.16, 25.80, 26.56]
+            baseline_mean = [126.23, 126.84, 126.62, 125.63]
+            baseline_std_dev = [26.54, 26.16, 25.80, 26.56]
         elif sensor_uuid == "depth_sensor":
-            baseline_mean: List[float] = [0.4852, 0.4886, 0.4920, 0.4956]
-            baseline_std_dev: List[float] = [0.0107, 0.0112, 0.0117, 0.0122]
+            baseline_mean = [0.4852, 0.4886, 0.4920, 0.4956]
+            baseline_std_dev = [0.0107, 0.0112, 0.0117, 0.0122]
         for env_idx in range(num_envs):
             env_obs = observations[env_idx][obs_key]
             mean = float(np.mean(env_obs[env_idx]))


### PR DESCRIPTION
## Motivation and Context

This changeset adds supports for using the PPO trainer with the batch renderer.

Example run command:
```
habitat-baselines/habitat_baselines/run.py --config-name=rearrange/rl_skill.yaml habitat_baselines.trainer_name="ppo" habitat.simulator.renderer.enable_batch_renderer=True habitat.simulator.habitat_sim_v0.enable_gfx_replay_save=True habitat.simulator.create_renderer=False habitat.simulator.concur_render=False habitat.simulator.renderer.composite_files=[path/to/composite_file.gltf]
```

Documentation to train with the batch renderer: https://github.com/facebookresearch/habitat-lab/pull/1443

## How Has This Been Tested

Tested locally against `rl_skill.yaml` and with extended `test_trainers` test.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
