### PR TITLE
Remove typing_extensions.

### DIFF
--- a/habitat-baselines/habitat_baselines/common/tensor_dict.py
+++ b/habitat-baselines/habitat_baselines/common/tensor_dict.py
@@ -15,6 +15,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Protocol,
     Tuple,
     Type,
     TypeVar,
@@ -25,7 +26,6 @@ from typing import (
 
 import numpy as np
 import torch
-from typing_extensions import Protocol
 
 TensorLike = Union[torch.Tensor, np.ndarray, numbers.Real]
 DictTree = Dict[str, Union[TensorLike, "DictTree"]]  # type: ignore

--- a/habitat-lab/habitat/core/batch_rendering/env_batch_renderer_constants.py
+++ b/habitat-lab/habitat/core/batch_rendering/env_batch_renderer_constants.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing_extensions import Final
+from typing import Final
 
 KEYFRAME_OBSERVATION_KEY: Final[str] = "keyframe"
 KEYFRAME_SENSOR_PREFIX: Final[str] = "sensor_"


### PR DESCRIPTION
## Motivation and Context

This minor change removes `typing_extensions` references that were required with Python 3.7, but are not necessary since we have upgraded to 3.9.

## How Has This Been Tested

Tested on CI.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
