### PR TITLE
[CI] - disable hab2 multi-proc benchmark assertions

### DIFF
--- a/scripts/hab2_bench/assert_bench.py
+++ b/scripts/hab2_bench/assert_bench.py
@@ -94,12 +94,12 @@ if __name__ == "__main__":
             NAME_MAP, MINIMUM_PERFORMANCE_1_PROCESS, "1_200_-1_"
         )
     )
-    #TODO: understand CI multi-process issues before asserting on these bench results
-    #failed_runs.extend(
+    # TODO: understand CI multi-process issues before asserting on these bench results
+    # failed_runs.extend(
     #    check_benchmark_sps(
     #        NAME_MAP, MINIMUM_PERFORMANCE_16_PROCESS, "16_200_-1_"
     #    )
-    #)
+    # )
 
     print(failed_runs)
 

--- a/scripts/hab2_bench/assert_bench.py
+++ b/scripts/hab2_bench/assert_bench.py
@@ -94,11 +94,12 @@ if __name__ == "__main__":
             NAME_MAP, MINIMUM_PERFORMANCE_1_PROCESS, "1_200_-1_"
         )
     )
-    failed_runs.extend(
-        check_benchmark_sps(
-            NAME_MAP, MINIMUM_PERFORMANCE_16_PROCESS, "16_200_-1_"
-        )
-    )
+    #TODO: understand CI multi-process issues before asserting on these bench results
+    #failed_runs.extend(
+    #    check_benchmark_sps(
+    #        NAME_MAP, MINIMUM_PERFORMANCE_16_PROCESS, "16_200_-1_"
+    #    )
+    #)
 
     print(failed_runs)
 


### PR DESCRIPTION
## Motivation and Context

Disabling CI regression assertions on multi-processing hab2 benchmark in light of recently observed flakyness.
Possible source of flakyness is resource limits. CI machine claims to have 8vCPU, we run a 16 process benchmark. This could cause thrashing or resource allocation issues.

This should be re-enabled after investigation and possible corrections to the CI benchmarking workflow.
We'll still run the multi-process benchmark and generate artifacts for debugging and investigation purposes.

## How Has This Been Tested

CI shows benchmark regression with habitat-sim commit (https://github.com/facebookresearch/habitat-sim/commit/8eb02ad1e12f310fef7e67628a0e992bd8fea834).
Local testing on cluster shows no regression. 
Contents of commit should not impact performance, so CI flakyness is likely.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
