### PR TITLE
[CI] - add `--no-prune` to automatic downloader calls

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
@@ -60,7 +60,12 @@ class RearrangeDatasetV0(PointNavDatasetV1):
                 "Rearrange task assets are not downloaded locally, downloading and extracting now..."
             )
             data_downloader.main(
-                ["--uids", "rearrange_task_assets", "--no-replace"]
+                [
+                    "--uids",
+                    "rearrange_task_assets",
+                    "--no-replace",
+                    "--no-prune",
+                ]
             )
             logger.info("Downloaded and extracted the data.")
 

--- a/test/test_baseline_training.py
+++ b/test/test_baseline_training.py
@@ -38,7 +38,9 @@ except ImportError:
 
 def setup_function(test_trainers):
     # Download the needed datasets
-    data_downloader.main(["--uids", "rearrange_task_assets", "--no-replace"])
+    data_downloader.main(
+        ["--uids", "rearrange_task_assets", "--no-replace", "--no-prune"]
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Motivation and Context

If automated downloads are called on CI, `--no-prune` is required.
Missed by #1450 

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
