### PR TITLE
Only consider 2d distance for pddl_sim_statE

### DIFF
--- a/habitat-lab/habitat/config/benchmark/rearrange/multi_agent_tidy_house_fp_spot_humanoid.yaml
+++ b/habitat-lab/habitat/config/benchmark/rearrange/multi_agent_tidy_house_fp_spot_humanoid.yaml
@@ -114,6 +114,7 @@ habitat:
         motion_control: human_joints
         spawn_max_dist_to_obj: -1.0
         collision_threshold: 0.02
+        dist_thresh: 0.5
         # The navmesh offset for the action control
         navmesh_offset: [[0.0, 0.0]]
         # The navmesh offset for the agent placement

--- a/habitat-lab/habitat/tasks/rearrange/multi_task/pddl_sim_state.py
+++ b/habitat-lab/habitat/tasks/rearrange/multi_task/pddl_sim_state.py
@@ -117,9 +117,9 @@ class PddlRobotState:
             # Do transformation
             pos = T.inverted().transform_point(targ_pos)
             # Compute distance
-            dist = np.linalg.norm(pos)
             # Project to 2D plane (x,y,z=0)
             pos[2] = 0.0
+            dist = np.linalg.norm(pos)
             # Unit vector of the pos
             pos = pos.normalized()
             # Define the coordinate of the robot


### PR DESCRIPTION
## Motivation and Context
Use distance projected on the ground plane to check if robot is at in the PDDL conditions. This is needed so that is_at does not depend to the robot height, and only the forward/side distance.

## How Has This Been Tested

Ran eval

## Types of changes
- **\[Experiment\]** A pull request that add new features to the [habitat-baselines](/habitat-baselines/) training codebase. Experiments Pull Requests can be any size, must have smoke/integration tests and be isolated from the rest of the code. Your code additions should not rely on other habitat-baselines code. This is to avoid dependencies between different parts of habitat-baselines. You must also include a README that will document how to use your new feature or trainer. **You** will be the maintainer of this code, if the code becomes stale or is not supported often enough, we will eventually remove it.

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
