### PR TITLE
Bug fix for loading weights when resuming training

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/ppo/single_agent_access_mgr.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/single_agent_access_mgr.py
@@ -79,8 +79,11 @@ class SingleAgentAccessMgr(AgentAccessMgr):
             )
         if resume_state is not None:
             self._updater.load_state_dict(resume_state["state_dict"])
-            self._updater.optimizer.load_state_dict(
-                resume_state["optim_state"]
+            self._updater.load_state_dict(
+                {
+                    "actor_critic." + k: v
+                    for k, v, in resume_state["state_dict"].items()
+                }
             )
         self._policy_action_space = self._actor_critic.get_policy_action_space(
             self._env_spec.action_space


### PR DESCRIPTION
## Motivation and Context

When training is restarted and weights from the resume state are reloaded, an error occurs because the keys within the resume state checkpoint are not prefixed with "actor_critic."

## How Has This Been Tested

Just PointNav RL training with VERTrainer.

## Types of changes
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
