### PR TITLE
[Bug Fix] Fix bug in method to find action range

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/hrl/utils.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/utils.py
@@ -26,4 +26,4 @@ def find_action_range(
         start_idx += get_num_actions(action_space[k])
     if not found:
         raise ValueError(f"Could not find {search_key} in {action_space}")
-    return start_idx, start_idx+end_idx
+    return start_idx, start_idx + end_idx

--- a/habitat-baselines/habitat_baselines/rl/hrl/utils.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/utils.py
@@ -25,5 +25,5 @@ def find_action_range(
             break
         start_idx += get_num_actions(action_space[k])
     if not found:
-        raise ValueError(f"Could not find stop action in {action_space}")
-    return start_idx, end_idx
+        raise ValueError(f"Could not find {search_key} in {action_space}")
+    return start_idx, start_idx+end_idx


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- The find_action_range method was returning wrong ranges due to a bug in the logic.
- This update fixes the logic and makes sure that correct range is returned.


<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
- This issue was discovered when adding multiple custom actions in habitat-llm which uses habitat-lab.
- The updated logic was tested by making sure that the correct action spaces is returned for all actions. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
