### PR TITLE
lint

### DIFF
--- a/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
+++ b/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
@@ -256,8 +256,11 @@ class HumanoidRearrangeController:
         )
 
         # Remove the forward component, and orient according to forward_V
-        add_rot = mn.Matrix4.rotation(mn.Rad(np.pi), mn.Vector3(0, 1.0, 0))
-        obj_transform = add_rot @ obj_transform
+        add_rot = mn.Matrix4.rotation(mn.Rad(np.pi), mn.Vector3(1.0, 0, 0))
+        add_rot2 = mn.Matrix4.rotation(
+            mn.Rad(-np.pi / 2), mn.Vector3(0, 0, 1.0)
+        )
+        obj_transform = add_rot @ add_rot2 @ obj_transform
         obj_transform.translation *= mn.Vector3.x_axis() + mn.Vector3.y_axis()
 
         # This is the rotation and translation caused by the current motion pose

--- a/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
+++ b/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
@@ -81,7 +81,16 @@ class KinematicHumanoid(MobileManipulator):
         # to simulate different gaits
         self.sim = sim
         self.offset_transform = mn.Matrix4()
+
         self.offset_rot = -np.pi / 2
+        add_rot = mn.Matrix4.rotation(
+            mn.Rad(self.offset_rot), mn.Vector3(0, 1.0, 0)
+        )
+        perm = mn.Matrix4.rotation(
+            mn.Rad(self.offset_rot), mn.Vector3(0, 0, 1.0)
+        )
+        self.offset_transform_base = perm @ add_rot
+
         self.rest_joints = None
         self.rest_matrix = mn.Matrix4()
 
@@ -104,12 +113,10 @@ class KinematicHumanoid(MobileManipulator):
 
     @property
     def base_transformation(self):
-        angle_rot = self.offset_rot
-        add_rot = mn.Matrix4.rotation(mn.Rad(angle_rot), mn.Vector3(0, 1.0, 0))
         return (
             self.sim_obj.transformation
             @ self.inverse_offset_transform
-            @ add_rot
+            @ self.offset_transform_base
         )
 
     @property
@@ -239,9 +246,8 @@ class KinematicHumanoid(MobileManipulator):
         """Sets the joints, base and offset transform of the humanoid"""
         self.sim_obj.joint_positions = joint_list
         self.offset_transform = offset_transform
-        add_rot = mn.Matrix4.rotation(
-            mn.Rad(-self.offset_rot), mn.Vector3(0, 1.0, 0)
-        )
+
+        add_rot = self.offset_transform_base.inverted()
         final_transform = (base_transform @ add_rot) @ offset_transform
 
         self.sim_obj.transformation = final_transform


### PR DESCRIPTION
## Motivation and Context

Correct relative transform human. This fix makes the relative transform of the human match that of the robot. Before the human's base_transformation was shifted. Now it works as it should: local Z coordinate of the human points upwards. This is needed so that pddl_Sim_state works.

## How Has This Been Tested

Sandbox app and test episodes

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
