### PR TITLE
HITL AppState refactor

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_abc.py
+++ b/examples/siro_sandbox/app_states/app_state_abc.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC
+
+
+# See also SandboxDriver. SandboxDriver loads a habitat env, including scene/episode/task/agent/policy. A derived AppState class drives use-case-specific behavior for the HITL tool during each env step, including processing user input and manipulating the sim state. In the future, SandboxDriver may manage the transition between AppStates, e.g. transition from a non-interactive tutorial state to a user-controlled-agent state.
+#
+# AppState is conceptually an ABC, but all the current methods are optional so there's no use of @abstractmethod here yet.
+class AppState(ABC):
+    # This is where the main app state logic should go. The AppState should update the sim state and also populate post_sim_update_dict["cam_transform"], at a minimum. The AppState can also record to _sandbox_service.step_recorder here.
+    def sim_update(self, dt, post_sim_update_dict):
+        pass
+
+    # The AppState should reset internal members as necessary for the new episode. It can record arbitrary per-episode data to episode_recorder_dict, e.g. episode_recorder_dict["mymetric"] = my_metric, but beware episode_recorder_dict may be None.
+    def on_environment_reset(self, episode_recorder_dict):
+        pass
+
+    # This is a good place to record using _sandbox_service.step_recorder because this function will be skipped if the app isn't recording. However, an AppState is free to record at any time (in other methods, too).
+    def record_state(self):
+        pass

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -23,13 +23,13 @@ class AppStateFetch(AppState):
         gui_agent_ctrl,
     ):
         self._sandbox_service = sandbox_service
-        self.gui_agent_ctrl = gui_agent_ctrl
+        self._gui_agent_ctrl = gui_agent_ctrl
 
         self._can_grasp_place_threshold = (
             self._sandbox_service.args.can_grasp_place_threshold
         )
 
-        self.cam_transform = None
+        self._cam_transform = None
 
         self._held_target_obj_idx = None
 
@@ -80,7 +80,7 @@ class AppStateFetch(AppState):
         else:
             # check for new grasp and call gui_agent_ctrl.set_act_hints
             if self._held_target_obj_idx is None:
-                assert not self.gui_agent_ctrl.is_grasped
+                assert not self._gui_agent_ctrl.is_grasped
                 # pick up an object
                 if self._sandbox_service.gui_input.get_key_down(
                     GuiInput.KeyNS.SPACE
@@ -115,14 +115,12 @@ class AppStateFetch(AppState):
             ):
                 walk_dir = candidate_walk_dir
 
-        self.gui_agent_ctrl.set_act_hints(
+        self._gui_agent_ctrl.set_act_hints(
             walk_dir,
             grasp_object_id,
             drop_pos,
             self._camera_helper.lookat_offset_yaw,
         )
-
-        return drop_pos
 
     def _get_target_object_position(self, target_obj_idx):
         sim = self.get_sim()
@@ -176,18 +174,18 @@ class AppStateFetch(AppState):
             )
 
     def get_gui_controlled_agent_index(self):
-        return self.gui_agent_ctrl._agent_idx
+        return self._gui_agent_ctrl._agent_idx
 
     def _get_agent_translation(self):
-        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        assert isinstance(self._gui_agent_ctrl, GuiHumanoidController)
         return (
-            self.gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+            self._gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
         )
 
     def _get_agent_feet_height(self):
-        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        assert isinstance(self._gui_agent_ctrl, GuiHumanoidController)
         base_offset = (
-            self.gui_agent_ctrl.get_articulated_agent().params.base_offset
+            self._gui_agent_ctrl.get_articulated_agent().params.base_offset
         )
         agent_feet_translation = self._get_agent_translation() + base_offset
         return agent_feet_translation[1]
@@ -273,7 +271,7 @@ class AppStateFetch(AppState):
 
         self._camera_helper.update(self._get_camera_lookat_pos(), dt)
 
-        self.cam_transform = self._camera_helper.get_cam_transform()
-        post_sim_update_dict["cam_transform"] = self.cam_transform
+        self._cam_transform = self._camera_helper.get_cam_transform()
+        post_sim_update_dict["cam_transform"] = self._cam_transform
 
         self._update_help_text()

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import magnum as mn
+import numpy as np
+from app_states.app_state_abc import AppState
+from camera_helper import CameraHelper
+from controllers.gui_controller import GuiHumanoidController
+from gui_navigation_helper import GuiNavigationHelper
+from hablab_utils import get_agent_art_obj_transform, get_grasped_objects_idxs
+
+from habitat.gui.gui_input import GuiInput
+from habitat.gui.text_drawer import TextOnScreenAlignment
+
+
+class AppStateFetch(AppState):
+    def __init__(
+        self,
+        sandbox_service,
+        gui_agent_ctrl,
+    ):
+        self._sandbox_service = sandbox_service
+        self.gui_agent_ctrl = gui_agent_ctrl
+
+        self._can_grasp_place_threshold = (
+            self._sandbox_service.args.can_grasp_place_threshold
+        )
+
+        self.cam_transform = None
+
+        self._held_target_obj_idx = None
+
+        # will be set in on_environment_reset
+        self._target_obj_ids = None
+
+        self._camera_helper = CameraHelper(
+            self._sandbox_service.args, self._sandbox_service.gui_input
+        )
+        self._first_person_mode = self._sandbox_service.args.first_person_mode
+
+        self._nav_helper = GuiNavigationHelper(
+            self._sandbox_service, self.get_gui_controlled_agent_index()
+        )
+
+    def on_environment_reset(self, episode_recorder_dict):
+        self._held_target_obj_idx = None
+
+        sim = self.get_sim()
+        temp_ids, _ = sim.get_targets()
+        self._target_obj_ids = [
+            sim._scene_obj_ids[temp_id] for temp_id in temp_ids
+        ]
+
+        self._nav_helper.on_environment_reset()
+
+        self._camera_helper.update(self._get_camera_lookat_pos(), dt=0)
+
+    def get_sim(self):
+        return self._sandbox_service.sim
+
+    def _update_grasping_and_set_act_hints(self):
+        drop_pos = None
+        grasp_object_id = None
+
+        if self._held_target_obj_idx is not None:
+            if self._sandbox_service.gui_input.get_key_down(
+                GuiInput.KeyNS.SPACE
+            ):
+                # temp: drop object right where it is
+                drop_pos = self._get_target_object_position(
+                    self._held_target_obj_idx
+                )
+                drop_pos.y = 0.0
+                self._held_target_obj_idx = None
+
+            # todo: implement throwing, including viz
+        else:
+            # check for new grasp and call gui_agent_ctrl.set_act_hints
+            if self._held_target_obj_idx is None:
+                assert not self.gui_agent_ctrl.is_grasped
+                # pick up an object
+                if self._sandbox_service.gui_input.get_key_down(
+                    GuiInput.KeyNS.SPACE
+                ):
+                    translation = self._get_agent_translation()
+
+                    min_dist = self._can_grasp_place_threshold
+                    min_i = None
+                    for i in range(len(self._target_obj_ids)):
+                        this_target_pos = self._get_target_object_position(i)
+                        # compute distance in xz plane
+                        offset = this_target_pos - translation
+                        offset.y = 0
+                        dist_xz = offset.length()
+                        if dist_xz < min_dist:
+                            min_dist = dist_xz
+                            min_i = i
+
+                    if min_i is not None:
+                        self._held_target_obj_idx = min_i
+                        grasp_object_id = self._target_obj_ids[
+                            self._held_target_obj_idx
+                        ]
+
+        walk_dir = None
+        if not self._first_person_mode:
+            candidate_walk_dir = (
+                self._nav_helper.viz_and_get_humanoid_walk_dir()
+            )
+            if self._sandbox_service.gui_input.get_mouse_button(
+                GuiInput.MouseNS.RIGHT
+            ):
+                walk_dir = candidate_walk_dir
+
+        self.gui_agent_ctrl.set_act_hints(
+            walk_dir,
+            grasp_object_id,
+            drop_pos,
+            self._camera_helper.lookat_offset_yaw,
+        )
+
+        return drop_pos
+
+    def _get_target_object_position(self, target_obj_idx):
+        sim = self.get_sim()
+        rom = sim.get_rigid_object_manager()
+        object_id = self._target_obj_ids[target_obj_idx]
+        return rom.get_object_by_id(object_id).translation
+
+    def _get_target_object_positions(self):
+        sim = self.get_sim()
+        rom = sim.get_rigid_object_manager()
+        return np.array(
+            [
+                rom.get_object_by_id(obj_id).translation
+                for obj_id in self._target_obj_ids
+            ]
+        )
+
+    def _viz_objects(self):
+        if self._held_target_obj_idx is not None:
+            return
+
+        grasped_objects_idxs = get_grasped_objects_idxs(self.get_sim())
+
+        # draw nav_hint and target box
+        for i in range(len(self._target_obj_ids)):
+            # object is grasped
+            if i in grasped_objects_idxs:
+                continue
+
+            color = mn.Color3(255 / 255, 128 / 255, 0)  # orange
+
+            this_target_pos = self._get_target_object_position(i)
+            box_half_size = 0.15
+            box_offset = mn.Vector3(
+                box_half_size, box_half_size, box_half_size
+            )
+            self._sandbox_service.line_render.draw_box(
+                this_target_pos - box_offset,
+                this_target_pos + box_offset,
+                color,
+            )
+
+            # draw can grasp area
+            can_grasp_position = mn.Vector3(this_target_pos)
+            can_grasp_position[1] = self._get_agent_feet_height()
+            self._sandbox_service.line_render.draw_circle(
+                can_grasp_position,
+                self._can_grasp_place_threshold,
+                mn.Color3(255 / 255, 255 / 255, 0),
+                24,
+            )
+
+    def get_gui_controlled_agent_index(self):
+        return self.gui_agent_ctrl._agent_idx
+
+    def _get_agent_translation(self):
+        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        return (
+            self.gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+        )
+
+    def _get_agent_feet_height(self):
+        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        base_offset = (
+            self.gui_agent_ctrl.get_articulated_agent().params.base_offset
+        )
+        agent_feet_translation = self._get_agent_translation() + base_offset
+        return agent_feet_translation[1]
+
+    def _get_controls_text(self):
+        def get_grasp_release_controls_text():
+            if self._held_target_obj_idx is not None:
+                return "Spacebar: throw\n"
+            else:
+                return "Spacebar: pick up\n"
+
+        controls_str: str = ""
+        controls_str += "ESC: exit\n"
+        controls_str += "M: change scene\n"
+
+        if self._first_person_mode:
+            # controls_str += "Left-click: toggle cursor\n"  # make this "unofficial" for now
+            controls_str += "I, K: look up, down\n"
+            controls_str += "A, D: turn\n"
+            controls_str += "W, S: walk\n"
+            controls_str += get_grasp_release_controls_text()
+        # third-person mode
+        else:
+            controls_str += "R + drag: rotate camera\n"
+            controls_str += "Right-click: walk\n"
+            controls_str += "A, D: turn\n"
+            controls_str += "W, S: walk\n"
+            controls_str += "Scroll: zoom\n"
+            controls_str += get_grasp_release_controls_text()
+
+        return controls_str
+
+    def _get_status_text(self):
+        status_str = ""
+
+        if self._held_target_obj_idx is not None:
+            status_str += "Throw the object!"
+        else:
+            status_str += "Grab an object!\n"
+
+        # center align the status_str
+        max_status_str_len = 50
+        status_str = "/n".join(
+            line.center(max_status_str_len) for line in status_str.split("/n")
+        )
+
+        return status_str
+
+    def _update_help_text(self):
+        controls_str = self._get_controls_text()
+        if len(controls_str) > 0:
+            self._sandbox_service.text_drawer.add_text(
+                controls_str, TextOnScreenAlignment.TOP_LEFT
+            )
+
+        status_str = self._get_status_text()
+        if len(status_str) > 0:
+            self._sandbox_service.text_drawer.add_text(
+                status_str,
+                TextOnScreenAlignment.TOP_CENTER,
+                text_delta_x=-280,
+                text_delta_y=-50,
+            )
+
+    def _get_camera_lookat_pos(self):
+        agent_root = get_agent_art_obj_transform(
+            self.get_sim(), self.get_gui_controlled_agent_index()
+        )
+        lookat = agent_root.translation + mn.Vector3(0, 1, 0)
+        return lookat
+
+    def sim_update(self, dt, post_sim_update_dict):
+        if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.ESC):
+            self._sandbox_service.end_episode()
+            post_sim_update_dict["application_exit"] = True
+
+        if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.M):
+            self._sandbox_service.end_episode(do_reset=True)
+
+        self._viz_objects()
+        self._update_grasping_and_set_act_hints()
+        self._sandbox_service.compute_action_and_step_env()
+
+        self._camera_helper.update(self._get_camera_lookat_pos(), dt)
+
+        self.cam_transform = self._camera_helper.get_cam_transform()
+        post_sim_update_dict["cam_transform"] = self.cam_transform
+
+        self._update_help_text()

--- a/examples/siro_sandbox/app_states/app_state_rearrange.py
+++ b/examples/siro_sandbox/app_states/app_state_rearrange.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import magnum as mn
+import numpy as np
+from app_states.app_state_abc import AppState
+from camera_helper import CameraHelper
+from controllers.gui_controller import GuiHumanoidController
+from gui_navigation_helper import GuiNavigationHelper
+from hablab_utils import get_agent_art_obj_transform, get_grasped_objects_idxs
+
+from habitat.gui.gui_input import GuiInput
+from habitat.gui.text_drawer import TextOnScreenAlignment
+
+
+class AppStateRearrange(AppState):
+    def __init__(
+        self,
+        sandbox_service,
+        gui_agent_ctrl,
+    ):
+        self._sandbox_service = sandbox_service
+        self.gui_agent_ctrl = gui_agent_ctrl
+
+        # cache items from config; config is expensive to access at runtime
+        config = self._sandbox_service.config
+        self._end_on_success = config.habitat.task.end_on_success
+        self._obj_succ_thresh = config.habitat.task.obj_succ_thresh
+        self._success_measure_name = config.habitat.task.success_measure
+
+        self._can_grasp_place_threshold = (
+            self._sandbox_service.args.can_grasp_place_threshold
+        )
+
+        self.cam_transform = None
+
+        self._num_iter_episodes: int = len(self._sandbox_service.env.episode_iterator.episodes)  # type: ignore
+        self._num_episodes_done: int = 0
+
+        self._held_target_obj_idx = None
+        self._num_remaining_objects = None  # resting, not at goal location yet
+        self._num_busy_objects = None  # currently held by non-gui agents
+
+        # will be set in on_environment_reset
+        self._target_obj_ids = None
+        self._goal_positions = None
+
+        self._camera_helper = CameraHelper(
+            self._sandbox_service.args, self._sandbox_service.gui_input
+        )
+        self._first_person_mode = self._sandbox_service.args.first_person_mode
+
+        self._nav_helper = GuiNavigationHelper(
+            self._sandbox_service, self.get_gui_controlled_agent_index()
+        )
+
+    def on_environment_reset(self, episode_recorder_dict):
+        self._held_target_obj_idx = None
+        self._num_remaining_objects = None  # resting, not at goal location yet
+        self._num_busy_objects = None  # currently held by non-gui agents
+
+        sim = self.get_sim()
+        temp_ids, goal_positions_np = sim.get_targets()
+        self._target_obj_ids = [
+            sim._scene_obj_ids[temp_id] for temp_id in temp_ids
+        ]
+        self._goal_positions = [mn.Vector3(pos) for pos in goal_positions_np]
+
+        self._num_episodes_done += 1
+
+        self._nav_helper.on_environment_reset()
+
+        self._camera_helper.update(self._get_camera_lookat_pos(), dt=0)
+
+        if episode_recorder_dict:
+            episode_recorder_dict["target_obj_ids"] = self._target_obj_ids
+            episode_recorder_dict["goal_positions"] = self._goal_positions
+
+    def get_sim(self):
+        return self._sandbox_service.sim
+
+    def _update_grasping_and_set_act_hints(self):
+        end_radius = self._obj_succ_thresh
+
+        drop_pos = None
+        grasp_object_id = None
+
+        if self._held_target_obj_idx is not None:
+            color = mn.Color3(0, 255 / 255, 0)  # green
+            goal_position = self._goal_positions[self._held_target_obj_idx]
+            self._sandbox_service.line_render.draw_circle(
+                goal_position, end_radius, color, 24
+            )
+
+            self._nav_helper._draw_nav_hint_from_agent(
+                self._camera_helper.get_xz_forward(),
+                mn.Vector3(goal_position),
+                end_radius,
+                color,
+            )
+
+            # draw can place area
+            can_place_position = mn.Vector3(goal_position)
+            can_place_position[1] = self._get_agent_feet_height()
+            self._sandbox_service.line_render.draw_circle(
+                can_place_position,
+                self._can_grasp_place_threshold,
+                mn.Color3(255 / 255, 255 / 255, 0),
+                24,
+            )
+
+            if self._sandbox_service.gui_input.get_key_down(
+                GuiInput.KeyNS.SPACE
+            ):
+                translation = self._get_agent_translation()
+                dist_to_obj = np.linalg.norm(goal_position - translation)
+                if dist_to_obj < self._can_grasp_place_threshold:
+                    self._held_target_obj_idx = None
+                    drop_pos = goal_position
+        else:
+            # check for new grasp and call gui_agent_ctrl.set_act_hints
+            if self._held_target_obj_idx is None:
+                assert not self.gui_agent_ctrl.is_grasped
+                # pick up an object
+                if self._sandbox_service.gui_input.get_key_down(
+                    GuiInput.KeyNS.SPACE
+                ):
+                    translation = self._get_agent_translation()
+
+                    min_dist = self._can_grasp_place_threshold
+                    min_i = None
+                    for i in range(len(self._target_obj_ids)):
+                        if self._is_target_object_at_goal_position(i):
+                            continue
+
+                        this_target_pos = self._get_target_object_position(i)
+                        # compute distance in xz plane
+                        offset = this_target_pos - translation
+                        offset.y = 0
+                        dist_xz = offset.length()
+                        if dist_xz < min_dist:
+                            min_dist = dist_xz
+                            min_i = i
+
+                    if min_i is not None:
+                        self._held_target_obj_idx = min_i
+                        grasp_object_id = self._target_obj_ids[
+                            self._held_target_obj_idx
+                        ]
+
+        walk_dir = None
+        if not self._first_person_mode:
+            candidate_walk_dir = (
+                self._nav_helper.viz_and_get_humanoid_walk_dir()
+            )
+            if self._sandbox_service.gui_input.get_mouse_button(
+                GuiInput.MouseNS.RIGHT
+            ):
+                walk_dir = candidate_walk_dir
+
+        self.gui_agent_ctrl.set_act_hints(
+            walk_dir,
+            grasp_object_id,
+            drop_pos,
+            self._camera_helper.lookat_offset_yaw,
+        )
+
+        return drop_pos
+
+    def _get_target_object_position(self, target_obj_idx):
+        sim = self.get_sim()
+        rom = sim.get_rigid_object_manager()
+        object_id = self._target_obj_ids[target_obj_idx]
+        return rom.get_object_by_id(object_id).translation
+
+    def _get_target_object_positions(self):
+        sim = self.get_sim()
+        rom = sim.get_rigid_object_manager()
+        return np.array(
+            [
+                rom.get_object_by_id(obj_id).translation
+                for obj_id in self._target_obj_ids
+            ]
+        )
+
+    def _is_target_object_at_goal_position(self, target_obj_idx):
+        this_target_pos = self._get_target_object_position(target_obj_idx)
+        end_radius = self._obj_succ_thresh
+        return (
+            this_target_pos - self._goal_positions[target_obj_idx]
+        ).length() < end_radius
+
+    def _update_task(self):
+        end_radius = self._obj_succ_thresh
+
+        grasped_objects_idxs = get_grasped_objects_idxs(
+            self.get_sim(),
+            agent_idx_to_skip=self.get_gui_controlled_agent_index(),
+        )
+        self._num_remaining_objects = 0
+        self._num_busy_objects = len(grasped_objects_idxs)
+
+        # draw nav_hint and target box
+        for i in range(len(self._target_obj_ids)):
+            # object is grasped
+            if i in grasped_objects_idxs:
+                continue
+
+            color = mn.Color3(255 / 255, 128 / 255, 0)  # orange
+            if self._is_target_object_at_goal_position(i):
+                continue
+
+            self._num_remaining_objects += 1
+
+            if self._held_target_obj_idx is None:
+                this_target_pos = self._get_target_object_position(i)
+                box_half_size = 0.15
+                box_offset = mn.Vector3(
+                    box_half_size, box_half_size, box_half_size
+                )
+                self._sandbox_service.line_render.draw_box(
+                    this_target_pos - box_offset,
+                    this_target_pos + box_offset,
+                    color,
+                )
+
+                self._nav_helper._draw_nav_hint_from_agent(
+                    self._camera_helper.get_xz_forward(),
+                    mn.Vector3(this_target_pos),
+                    end_radius,
+                    color,
+                )
+
+                # draw can grasp area
+                can_grasp_position = mn.Vector3(this_target_pos)
+                can_grasp_position[1] = self._get_agent_feet_height()
+                self._sandbox_service.line_render.draw_circle(
+                    can_grasp_position,
+                    self._can_grasp_place_threshold,
+                    mn.Color3(255 / 255, 255 / 255, 0),
+                    24,
+                )
+
+    def get_gui_controlled_agent_index(self):
+        return self.gui_agent_ctrl._agent_idx
+
+    def _get_agent_translation(self):
+        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        return (
+            self.gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+        )
+
+    def _get_agent_feet_height(self):
+        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        base_offset = (
+            self.gui_agent_ctrl.get_articulated_agent().params.base_offset
+        )
+        agent_feet_translation = self._get_agent_translation() + base_offset
+        return agent_feet_translation[1]
+
+    def _next_episode_exists(self):
+        return self._num_episodes_done < self._num_iter_episodes - 1
+
+    def _get_controls_text(self):
+        def get_grasp_release_controls_text():
+            if self._held_target_obj_idx is not None:
+                return "Spacebar: put down\n"
+            else:
+                return "Spacebar: pick up\n"
+
+        controls_str: str = ""
+        controls_str += "ESC: exit\n"
+        if self._next_episode_exists():
+            controls_str += "M: next episode\n"
+
+        if self._env_episode_active():
+            if self._first_person_mode:
+                # controls_str += "Left-click: toggle cursor\n"  # make this "unofficial" for now
+                controls_str += "I, K: look up, down\n"
+                controls_str += "A, D: turn\n"
+                controls_str += "W, S: walk\n"
+                controls_str += get_grasp_release_controls_text()
+            # third-person mode
+            else:
+                controls_str += "R + drag: rotate camera\n"
+                controls_str += "Right-click: walk\n"
+                controls_str += "A, D: turn\n"
+                controls_str += "W, S: walk\n"
+                controls_str += "Scroll: zoom\n"
+                controls_str += get_grasp_release_controls_text()
+
+        return controls_str
+
+    @property
+    def _env_task_complete(self):
+        return (
+            self._end_on_success
+            and self._sandbox_service.get_metrics()[self._success_measure_name]
+        )
+
+    def _env_episode_active(self) -> bool:
+        """
+        Returns True if current episode is active:
+        1) not self._sandbox_service.env.episode_over - none of the constraints is violated, or
+        2) not self._env_task_complete - success measure value is not True
+        """
+        return not (
+            self._sandbox_service.env.episode_over or self._env_task_complete
+        )
+
+    def _get_status_text(self):
+        status_str = ""
+
+        assert self._num_remaining_objects is not None
+        assert self._num_busy_objects is not None
+
+        if not self._env_episode_active():
+            if self._env_task_complete:
+                status_str += "Task complete!\n"
+            else:
+                status_str += "Oops! Something went wrong.\n"
+        elif self._held_target_obj_idx is not None:
+            status_str += "Place the object at its goal location!\n"
+        elif self._num_remaining_objects > 0:
+            status_str += "Move the remaining {} object{}!".format(
+                self._num_remaining_objects,
+                "s" if self._num_remaining_objects > 1 else "",
+            )
+        elif self._num_busy_objects > 0:
+            status_str += "Just wait! The robot is moving the last object.\n"
+        else:
+            # we don't expect to hit this case ever
+            status_str += "Oops! Something went wrong.\n"
+
+        # center align the status_str
+        max_status_str_len = 50
+        status_str = "/n".join(
+            line.center(max_status_str_len) for line in status_str.split("/n")
+        )
+
+        return status_str
+
+    def _update_help_text(self):
+        controls_str = self._get_controls_text()
+        if len(controls_str) > 0:
+            self._sandbox_service.text_drawer.add_text(
+                controls_str, TextOnScreenAlignment.TOP_LEFT
+            )
+
+        status_str = self._get_status_text()
+        if len(status_str) > 0:
+            self._sandbox_service.text_drawer.add_text(
+                status_str,
+                TextOnScreenAlignment.TOP_CENTER,
+                text_delta_x=-280,
+                text_delta_y=-50,
+            )
+
+        progress_str = f"{self._num_iter_episodes - (self._num_episodes_done + 1)} episodes remaining"
+        self._sandbox_service.text_drawer.add_text(
+            progress_str,
+            TextOnScreenAlignment.TOP_RIGHT,
+            text_delta_x=370,
+        )
+
+    def get_num_agents(self):
+        return len(self.get_sim().agents_mgr._all_agent_data)
+
+    def record_state(self):
+        agent_states = []
+        for agent_idx in range(self.get_num_agents()):
+            agent_root = get_agent_art_obj_transform(self.get_sim(), agent_idx)
+            rotation_quat = mn.Quaternion.from_matrix(agent_root.rotation())
+            rotation_list = list(rotation_quat.vector) + [rotation_quat.scalar]
+            pos = agent_root.translation
+
+            snap_idx = (
+                self.get_sim()
+                .agents_mgr._all_agent_data[agent_idx]
+                .grasp_mgr.snap_idx
+            )
+
+            agent_states.append(
+                {
+                    "position": pos,
+                    "rotation_xyzw": rotation_list,
+                    "grasp_mgr_snap_idx": snap_idx,
+                }
+            )
+
+        self._sandbox_service.step_recorder.record(
+            "agent_states", agent_states
+        )
+
+        self._sandbox_service.step_recorder.record(
+            "target_object_positions", self._get_target_object_positions()
+        )
+
+    def _get_camera_lookat_pos(self):
+        agent_root = get_agent_art_obj_transform(
+            self.get_sim(), self.get_gui_controlled_agent_index()
+        )
+        lookat = agent_root.translation + mn.Vector3(0, 1, 0)
+        return lookat
+
+    def sim_update(self, dt, post_sim_update_dict):
+        if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.ESC):
+            self._sandbox_service.end_episode()
+            post_sim_update_dict["application_exit"] = True
+
+        if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.M):
+            self._sandbox_service.end_episode(do_reset=True)
+
+        if self._env_episode_active():
+            self._update_task()
+            self._update_grasping_and_set_act_hints()
+            self._sandbox_service.compute_action_and_step_env()
+
+        self._camera_helper.update(self._get_camera_lookat_pos(), dt)
+
+        self.cam_transform = self._camera_helper.get_cam_transform()
+        post_sim_update_dict["cam_transform"] = self.cam_transform
+
+        self._update_help_text()

--- a/examples/siro_sandbox/app_states/app_state_rearrange.py
+++ b/examples/siro_sandbox/app_states/app_state_rearrange.py
@@ -23,7 +23,7 @@ class AppStateRearrange(AppState):
         gui_agent_ctrl,
     ):
         self._sandbox_service = sandbox_service
-        self.gui_agent_ctrl = gui_agent_ctrl
+        self._gui_agent_ctrl = gui_agent_ctrl
 
         # cache items from config; config is expensive to access at runtime
         config = self._sandbox_service.config
@@ -35,7 +35,7 @@ class AppStateRearrange(AppState):
             self._sandbox_service.args.can_grasp_place_threshold
         )
 
-        self.cam_transform = None
+        self._cam_transform = None
 
         self._num_iter_episodes: int = len(self._sandbox_service.env.episode_iterator.episodes)  # type: ignore
         self._num_episodes_done: int = 0
@@ -123,7 +123,7 @@ class AppStateRearrange(AppState):
         else:
             # check for new grasp and call gui_agent_ctrl.set_act_hints
             if self._held_target_obj_idx is None:
-                assert not self.gui_agent_ctrl.is_grasped
+                assert not self._gui_agent_ctrl.is_grasped
                 # pick up an object
                 if self._sandbox_service.gui_input.get_key_down(
                     GuiInput.KeyNS.SPACE
@@ -161,14 +161,12 @@ class AppStateRearrange(AppState):
             ):
                 walk_dir = candidate_walk_dir
 
-        self.gui_agent_ctrl.set_act_hints(
+        self._gui_agent_ctrl.set_act_hints(
             walk_dir,
             grasp_object_id,
             drop_pos,
             self._camera_helper.lookat_offset_yaw,
         )
-
-        return drop_pos
 
     def _get_target_object_position(self, target_obj_idx):
         sim = self.get_sim()
@@ -245,18 +243,18 @@ class AppStateRearrange(AppState):
                 )
 
     def get_gui_controlled_agent_index(self):
-        return self.gui_agent_ctrl._agent_idx
+        return self._gui_agent_ctrl._agent_idx
 
     def _get_agent_translation(self):
-        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        assert isinstance(self._gui_agent_ctrl, GuiHumanoidController)
         return (
-            self.gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+            self._gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
         )
 
     def _get_agent_feet_height(self):
-        assert isinstance(self.gui_agent_ctrl, GuiHumanoidController)
+        assert isinstance(self._gui_agent_ctrl, GuiHumanoidController)
         base_offset = (
-            self.gui_agent_ctrl.get_articulated_agent().params.base_offset
+            self._gui_agent_ctrl.get_articulated_agent().params.base_offset
         )
         agent_feet_translation = self._get_agent_translation() + base_offset
         return agent_feet_translation[1]
@@ -421,7 +419,7 @@ class AppStateRearrange(AppState):
 
         self._camera_helper.update(self._get_camera_lookat_pos(), dt)
 
-        self.cam_transform = self._camera_helper.get_cam_transform()
-        post_sim_update_dict["cam_transform"] = self.cam_transform
+        self._cam_transform = self._camera_helper.get_cam_transform()
+        post_sim_update_dict["cam_transform"] = self._cam_transform
 
         self._update_help_text()

--- a/examples/siro_sandbox/camera_helper.py
+++ b/examples/siro_sandbox/camera_helper.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import magnum as mn
+import numpy as np
+
+from habitat.gui.gui_input import GuiInput
+
+
+class CameraHelper:
+    def __init__(self, args, gui_input):
+        # lookat offset yaw (spin left/right) and pitch (up/down)
+        # to enable camera rotation and pitch control
+        self._first_person_mode = args.first_person_mode
+        if self._first_person_mode:
+            self._lookat_offset_yaw = 0.0
+            self._lookat_offset_pitch = float(
+                mn.Rad(mn.Deg(20.0))
+            )  # look slightly down
+            self._min_lookat_offset_pitch = (
+                -max(min(np.radians(args.max_look_up_angle), np.pi / 2), 0)
+                + 1e-5
+            )
+            self._max_lookat_offset_pitch = (
+                -min(max(np.radians(args.min_look_down_angle), -np.pi / 2), 0)
+                - 1e-5
+            )
+        else:
+            # (computed from previously hardcoded mn.Vector3(0.5, 1, 0.5).normalized())
+            self._lookat_offset_yaw = 0.785
+            self._lookat_offset_pitch = 0.955
+            self._min_lookat_offset_pitch = -np.pi / 2 + 1e-5
+            self._max_lookat_offset_pitch = np.pi / 2 - 1e-5
+
+        self.cam_zoom_dist = 1.0
+        self._max_zoom_dist = 50.0
+        self._min_zoom_dist = 0.02
+        self._cam_transform = None
+        self._gui_input = gui_input
+
+    def _camera_pitch_and_yaw_wasd_control(self):
+        # update yaw and pitch using ADIK keys
+        cam_rot_angle = 0.1
+
+        if self._gui_input.get_key(GuiInput.KeyNS.I):
+            self._lookat_offset_pitch -= cam_rot_angle
+        if self._gui_input.get_key(GuiInput.KeyNS.K):
+            self._lookat_offset_pitch += cam_rot_angle
+        self._lookat_offset_pitch = np.clip(
+            self._lookat_offset_pitch,
+            self._min_lookat_offset_pitch,
+            self._max_lookat_offset_pitch,
+        )
+        if self._gui_input.get_key(GuiInput.KeyNS.A):
+            self._lookat_offset_yaw -= cam_rot_angle
+        if self._gui_input.get_key(GuiInput.KeyNS.D):
+            self._lookat_offset_yaw += cam_rot_angle
+
+    def _camera_pitch_and_yaw_mouse_control(self):
+        enable_mouse_control = self._gui_input.get_key(GuiInput.KeyNS.R)
+
+        if enable_mouse_control:
+            # update yaw and pitch by scale * mouse relative position delta
+            scale = 1 / 50
+            self._lookat_offset_yaw += (
+                scale * self._gui_input.relative_mouse_position[0]
+            )
+            self._lookat_offset_pitch += (
+                scale * self._gui_input.relative_mouse_position[1]
+            )
+            self._lookat_offset_pitch = np.clip(
+                self._lookat_offset_pitch,
+                self._min_lookat_offset_pitch,
+                self._max_lookat_offset_pitch,
+            )
+
+    def _get_eye_and_lookat(self, base_pos) -> Tuple[mn.Vector3, mn.Vector3]:
+        offset = mn.Vector3(
+            np.cos(self.lookat_offset_yaw) * np.cos(self.lookat_offset_pitch),
+            np.sin(self.lookat_offset_pitch),
+            np.sin(self.lookat_offset_yaw) * np.cos(self.lookat_offset_pitch),
+        )
+
+        if self._first_person_mode:
+            eye_pos = base_pos
+            lookat_pos = base_pos + -offset.normalized()
+        else:
+            eye_pos = base_pos + offset.normalized() * self.cam_zoom_dist
+            lookat_pos = base_pos
+        return eye_pos, lookat_pos
+
+    def update(self, base_pos, dt):
+        if (
+            not self._first_person_mode
+            and self._gui_input.mouse_scroll_offset != 0
+        ):
+            zoom_sensitivity = 0.07
+            if self._gui_input.mouse_scroll_offset < 0:
+                self.cam_zoom_dist *= (
+                    1.0
+                    + -self._gui_input.mouse_scroll_offset * zoom_sensitivity
+                )
+            else:
+                self.cam_zoom_dist /= (
+                    1.0
+                    + self._gui_input.mouse_scroll_offset * zoom_sensitivity
+                )
+            self.cam_zoom_dist = mn.math.clamp(
+                self.cam_zoom_dist,
+                self._min_zoom_dist,
+                self._max_zoom_dist,
+            )
+
+        # two ways for camera pitch and yaw control for UX comparison:
+        # 1) press/hold ADIK keys
+        self._camera_pitch_and_yaw_wasd_control()
+        # 2) press left mouse button and move mouse
+        self._camera_pitch_and_yaw_mouse_control()
+
+        eye_pos, lookat_pos = self._get_eye_and_lookat(base_pos)
+        self._cam_transform = mn.Matrix4.look_at(
+            eye_pos, lookat_pos, mn.Vector3(0, 1, 0)
+        )
+
+    def get_xz_forward(self):
+        assert self._cam_transform
+        forward_dir = self._cam_transform.transform_vector(
+            -mn.Vector3(0, 0, 1)
+        )
+        forward_dir.y = 0
+        # todo: handle case of degenerate zero vector here due to camera looking
+        # straight up or down
+        forward_dir = forward_dir.normalized()
+        return forward_dir
+
+    def get_cam_transform(self):
+        assert self._cam_transform
+        return self._cam_transform
+
+    @property
+    def lookat_offset_yaw(self):
+        return self._to_zero_2pi_range(self._lookat_offset_yaw)
+
+    @property
+    def lookat_offset_pitch(self):
+        return self._lookat_offset_pitch
+
+    @staticmethod
+    def _to_zero_2pi_range(radians):
+        """Helper method to properly clip radians to [0, 2pi] range."""
+        return (
+            (2 * np.pi) - ((-radians) % (2 * np.pi))
+            if radians < 0
+            else radians % (2 * np.pi)
+        )

--- a/examples/siro_sandbox/gui_navigation_helper.py
+++ b/examples/siro_sandbox/gui_navigation_helper.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import magnum as mn
+from hablab_utils import get_agent_art_obj_transform
+
+import habitat_sim
+from habitat.datasets.rearrange.navmesh_utils import get_largest_island_index
+
+
+class GuiNavigationHelper:
+    def __init__(self, gui_service, agent_idx):
+        self._sandbox_service = gui_service
+        self._agent_idx = agent_idx
+        self._largest_island_idx = None
+
+    def _get_sim(self):
+        return self._sandbox_service.sim
+
+    def _draw_nav_hint_from_agent(
+        self, forward_dir, end_pos, end_radius, color
+    ):
+        assert forward_dir
+        agent_idx = self._agent_idx
+        assert agent_idx is not None
+        art_obj = (
+            self._get_sim().agents_mgr[agent_idx].articulated_agent.sim_obj
+        )
+        agent_pos = art_obj.transformation.translation
+
+        # if not forward_dir:
+        #     transformation = self.cam_transform or art_obj.transformation
+        #     forward_dir = transformation.transform_vector(-mn.Vector3(0, 0, 1))
+        #     forward_dir[1] = 0
+        #     forward_dir = forward_dir.normalized()
+
+        self._draw_nav_hint(
+            agent_pos,
+            forward_dir,
+            end_pos,
+            end_radius,
+            color,
+            self._sandbox_service.get_anim_fraction(),
+        )
+
+    def on_environment_reset(self):
+        sim = self._get_sim()
+        # recompute the largest indoor island id whenever the sim backend may have changed
+        self._largest_island_idx = get_largest_island_index(
+            sim.pathfinder, sim, allow_outdoor=False
+        )
+
+    def viz_and_get_humanoid_walk_dir(self):
+        path_color = mn.Color3(0, 153 / 255, 255 / 255)
+        path_endpoint_radius = 0.12
+
+        ray = self._sandbox_service.gui_input.mouse_ray
+
+        floor_y = 0.15  # hardcoded to ReplicaCAD
+
+        if not ray or ray.direction.y >= 0 or ray.origin.y <= floor_y:
+            return None
+
+        dist_to_floor_y = (ray.origin.y - floor_y) / -ray.direction.y
+        target_on_floor = ray.origin + ray.direction * dist_to_floor_y
+
+        agent_root = get_agent_art_obj_transform(
+            self._get_sim(), self._agent_idx
+        )
+
+        pathfinder = self._get_sim().pathfinder
+        # snap target to the selected island
+        assert self._largest_island_idx is not None
+        snapped_pos = pathfinder.snap_point(
+            target_on_floor, island_index=self._largest_island_idx
+        )
+        snapped_start_pos = agent_root.translation
+        snapped_start_pos.y = snapped_pos.y
+
+        path = habitat_sim.ShortestPath()
+        path.requested_start = snapped_start_pos
+        path.requested_end = snapped_pos
+        found_path = pathfinder.find_path(path)
+
+        if not found_path or len(path.points) < 2:
+            return None
+
+        path_points = []
+        for path_i in range(0, len(path.points)):
+            adjusted_point = mn.Vector3(path.points[path_i])
+            # first point in path is at wrong height
+            if path_i == 0:
+                adjusted_point.y = mn.Vector3(path.points[path_i + 1]).y
+            path_points.append(adjusted_point)
+
+        self._sandbox_service.line_render.draw_path_with_endpoint_circles(
+            path_points, path_endpoint_radius, path_color
+        )
+
+        if len(path.points) >= 2:
+            walk_dir = mn.Vector3(path.points[1]) - mn.Vector3(path.points[0])
+            return walk_dir
+
+        return None
+
+    @staticmethod
+    def _evaluate_cubic_bezier(ctrl_pts, t):
+        assert len(ctrl_pts) == 4
+        weights = (
+            pow(1 - t, 3),
+            3 * t * pow(1 - t, 2),
+            3 * pow(t, 2) * (1 - t),
+            pow(t, 3),
+        )
+
+        result = weights[0] * ctrl_pts[0]
+        for i in range(1, 4):
+            result += weights[i] * ctrl_pts[i]
+
+        return result
+
+    def _draw_nav_hint(
+        self, start_pos, start_dir, end_pos, end_radius, color, anim_fraction
+    ):
+        assert isinstance(start_pos, mn.Vector3)
+        assert isinstance(start_dir, mn.Vector3)
+        assert isinstance(end_pos, mn.Vector3)
+
+        bias_weight = 0.5
+        biased_dir = (
+            start_dir + (end_pos - start_pos).normalized() * bias_weight
+        ).normalized()
+
+        start_dir_weight = min(4.0, (end_pos - start_pos).length() / 2)
+        ctrl_pts = [
+            start_pos,
+            start_pos + biased_dir * start_dir_weight,
+            end_pos,
+            end_pos,
+        ]
+
+        steps_per_meter = 10
+        pad_meters = 1.0
+        alpha_ramp_dist = 1.0
+        num_steps = max(
+            2,
+            int(
+                ((end_pos - start_pos).length() + pad_meters) * steps_per_meter
+            ),
+        )
+
+        prev_pos = None
+        for step_idx in range(num_steps):
+            t = step_idx / (num_steps - 1) + anim_fraction * (
+                1 / (num_steps - 1)
+            )
+            pos = self._evaluate_cubic_bezier(ctrl_pts, t)
+
+            if (pos - end_pos).length() < end_radius:
+                break
+
+            if step_idx > 0:
+                alpha = min(1.0, (pos - start_pos).length() / alpha_ramp_dist)
+
+                radius = 0.05
+                num_segments = 12
+                # todo: use safe_normalize
+                normal = (pos - prev_pos).normalized()
+                color_with_alpha = mn.Color4(color)
+                color_with_alpha[3] *= alpha
+                self._sandbox_service.line_render.draw_circle(
+                    pos, radius, color_with_alpha, num_segments, normal
+                )
+            prev_pos = pos

--- a/examples/siro_sandbox/hablab_utils.py
+++ b/examples/siro_sandbox/hablab_utils.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Utilities built on top of Habitat-lab
+
+
+def get_agent_art_obj(sim, agent_idx):
+    assert agent_idx is not None
+    art_obj = sim.agents_mgr[agent_idx].articulated_agent.sim_obj
+    return art_obj
+
+
+def get_agent_art_obj_transform(sim, agent_idx):
+    assert agent_idx is not None
+    art_obj = sim.agents_mgr[agent_idx].articulated_agent.sim_obj
+    return art_obj.transformation
+
+
+def get_grasped_objects_idxs(sim, agent_idx_to_skip=None):
+    agents_mgr = sim.agents_mgr
+
+    grasped_objects_idxs = []
+    for agent_idx in range(len(agents_mgr._all_agent_data)):
+        if agent_idx == agent_idx_to_skip:
+            continue
+        grasp_mgr = agents_mgr._all_agent_data[agent_idx].grasp_mgr
+        if grasp_mgr.is_grasped:
+            grasped_objects_idxs.append(
+                sim.scene_obj_ids.index(grasp_mgr.snap_idx)
+            )
+
+    return grasped_objects_idxs

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -100,7 +100,6 @@ class SandboxDriver(GuiAppDriver):
         self.habitat_env: habitat.Env = (  # type: ignore
             self.gym_habitat_env.unwrapped.habitat_env
         )
-        self._sim = self.habitat_env.task._sim
 
         if args.gui_controlled_agent_index is not None:
             sim_config = config.habitat.simulator
@@ -159,7 +158,7 @@ class SandboxDriver(GuiAppDriver):
             text_drawer,
             lambda: self._viz_anim_fraction,
             self.habitat_env,
-            self._sim,
+            self.get_sim(),
             lambda: self._compute_action_and_step_env(),
             self._step_recorder,
             lambda: self._get_recent_metrics(),
@@ -303,6 +302,10 @@ class SandboxDriver(GuiAppDriver):
         if saved_keyframes or saved_episode_data:
             self._num_recorded_episodes += 1
 
+    # trying to get around mypy complaints about missing sim attributes
+    def get_sim(self) -> Any:
+        return self.habitat_env.task._sim
+
     def _end_episode(self, do_reset=False):
         self._check_save_episode_data(session_ended=do_reset == False)
         self._num_episodes_done += 1
@@ -372,8 +375,8 @@ class SandboxDriver(GuiAppDriver):
         # visualization is only implemented for simulator-rendering, not replay-
         # rendering.
         if self._gui_input.get_key_down(GuiInput.KeyNS.N):
-            self._sim.navmesh_visualization = (  # type: ignore
-                not self._sim.navmesh_visualization  # type: ignore
+            self.get_sim().navmesh_visualization = (  # type: ignore
+                not self.get_sim().navmesh_visualization  # type: ignore
             )
 
         self._app_state.sim_update(dt, post_sim_update_dict)
@@ -385,7 +388,7 @@ class SandboxDriver(GuiAppDriver):
             self._pending_cursor_style = None
 
         keyframes = (
-            self._sim.gfx_replay_manager.write_incremental_saved_keyframes_to_string_array()
+            self.get_sim().gfx_replay_manager.write_incremental_saved_keyframes_to_string_array()
         )
 
         if self._save_gfx_replay_keyframes:

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -331,18 +331,22 @@ class SandboxDriver(GuiAppDriver):
         save_as_gzip(json_content.encode("utf-8"), filepath)
 
     def _record_action(self, action):
-        action_args = action["action_args"]
+        if not isinstance(action, np.ndarray):
+            action_args = action["action_args"]
 
-        # These are large arrays and they massively bloat the record file size, so
-        # let's exclude them.
-        keys_to_clear = [
-            "human_joints_trans",
-            "agent_0_human_joints_trans",
-            "agent_1_human_joints_trans",
-        ]
-        for key in keys_to_clear:
-            if key in action_args:
-                action_args[key] = None
+            # These are large arrays and they massively bloat the record file size, so
+            # let's exclude them.
+            keys_to_clear = [
+                "human_joints_trans",
+                "agent_0_human_joints_trans",
+                "agent_1_human_joints_trans",
+            ]
+            for key in keys_to_clear:
+                if key in action_args:
+                    action_args[key] = None
+        else:
+            # no easy way to remove the joints from the action ndarray
+            pass
 
         self._step_recorder.record("action", action)
 

--- a/examples/siro_sandbox/sandbox_service.py
+++ b/examples/siro_sandbox/sandbox_service.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# Helpers to provide to AppState classes, provided by the underlying SandboxDriver
+class SandboxService:
+    def __init__(
+        self,
+        args,
+        config,
+        gui_input,
+        line_render,
+        text_drawer,
+        get_anim_fraction,
+        env,
+        sim,
+        compute_action_and_step_env,
+        step_recorder,
+        get_metrics,
+        end_episode,
+        set_cursor_style,
+    ):
+        self._args = args
+        self._config = config
+        self._gui_input = gui_input
+        self._line_render = line_render
+        self._text_drawer = text_drawer
+        self._get_anim_fraction = get_anim_fraction
+        self._env = env
+        self._sim = sim
+        self._compute_action_and_step_env = compute_action_and_step_env
+        self._step_recorder = step_recorder
+        self._get_metrics = get_metrics
+        self._end_episode = end_episode
+        self._set_cursor_style = set_cursor_style
+
+    @property
+    def args(self):
+        return self._args
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def gui_input(self):
+        return self._gui_input
+
+    @property
+    def line_render(self):
+        return self._line_render
+
+    @property
+    def text_drawer(self):
+        return self._text_drawer
+
+    @property
+    def get_anim_fraction(self):
+        return self._get_anim_fraction
+
+    @property
+    def env(self):
+        return self._env
+
+    @property
+    def sim(self):
+        return self._sim
+
+    @property
+    def compute_action_and_step_env(self):
+        return self._compute_action_and_step_env
+
+    @property
+    def step_recorder(self):
+        return self._step_recorder
+
+    @property
+    def get_metrics(self):
+        return self._get_metrics
+
+    @property
+    def end_episode(self):
+        return self._end_episode
+
+    @property
+    def set_cursor_style(self):
+        return self._set_cursor_style


### PR DESCRIPTION
## Motivation and Context

Refactor to better support multiple HITL-tool use cases: rearrange, SocialNav, fetch.

### Limitations
Free camera and tutorial functionality are temporarily unsupported. We'll create new AppStates for these soon.

### AppState classes
SandboxDriver loads a habitat env, including scene/episode/task/agent/policy. A derived AppState class drives use-case-specific behavior for the HITL tool during each env step, including processing user input and manipulating the sim state. In the future, SandboxDriver may manage the transition between AppStates, e.g. transition from a non-interactive tutorial state to a user-controlled-agent state. So far, I have `AppStateRearrange` (the existing HITL functionality) and a work-in-progress `AppStateFetch`. They differ slightly, for example, in the fetch app state, the user isn't expected to move objects to certain goal positions, and the episode doesn't end.

### SandboxService
This is a set of singletons and helpers provided by SandboxDriver to AppStates and other helper classes. The pattern here is sometimes called a "DI Container" (DI = dependency injection).

### GuiNavigationHelper, CameraHelper, hablab_utils.py
These are examples of helpers that allow us to share code/behavior between AppStates. Notably, we use composition here: each AppState object has a GuiNavigationHelper object, etc. Contrast this to dumping all this shared code into the AppState base class; individual helper classes are a cleaner approach because (1) they each encapsulate a specific functionality and (2) derived AppState classes don't inherit base functionality they don't need (e.g. `AppStateFreeCamera` won't construct a `GuiNavigationHelper`).

## How Has This Been Tested

Local testing on Fedora, e.g.
```
HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
python examples/siro_sandbox/sandbox_app.py \
--app-state fetch \
--disable-inverse-kinematics \
--never-end \
--gui-controlled-agent-index 1 \
--cfg experiments_hab3/pop_play_kinematic_oracle_humanoid_spot_fp.yaml \
--cfg-opts \
habitat_baselines.evaluate=True \
habitat_baselines.num_environments=1 \
habitat_baselines.eval.should_load_ckpt=False \
~habitat.task.measurements.agent_blame_measure
```
## Types of changes

PR into SIRo branch

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
