### PR TITLE
save velocity of objects in simstate

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -706,9 +706,14 @@ class RearrangeSim(HabitatSim):
         ]
         art_T = [ao.transformation for ao in self.art_objs]
         rom = self.get_rigid_object_manager()
-        static_T = [
-            rom.get_object_by_id(i).transformation for i in self._scene_obj_ids
-        ]
+        
+
+        rigid_T, rigid_V = [], []
+        for i in self._scene_obj_ids:
+            obj_i = rom.get_object_by_id(i)
+            rigid_T.append(obj_i.transformation)
+            rigid_V.append((obj_i.linear_velocity, obj_i.angular_velocity))
+
         art_pos = [ao.joint_positions for ao in self.art_objs]
 
         articulated_agent_js = [
@@ -719,7 +724,8 @@ class RearrangeSim(HabitatSim):
         ret = {
             "articulated_agent_T": articulated_agent_T,
             "art_T": art_T,
-            "static_T": static_T,
+            "rigid_T": rigid_T,
+            "rigid_V": rigid_V,
             "art_pos": art_pos,
             "obj_hold": [
                 grasp_mgr.snap_idx for grasp_mgr in self.agents_mgr.grasp_iter
@@ -760,12 +766,12 @@ class RearrangeSim(HabitatSim):
         for T, ao in zip(state["art_T"], self.art_objs):
             ao.transformation = T
 
-        for T, i in zip(state["static_T"], self._scene_obj_ids):
+        for T, V, i in zip(state["rigid_T"], state["rigid_V"], self._scene_obj_ids):
             # reset object transform
             obj = rom.get_object_by_id(i)
             obj.transformation = T
-            obj.linear_velocity = mn.Vector3()
-            obj.angular_velocity = mn.Vector3()
+            obj.linear_velocity = V[0]
+            obj.angular_velocity = V[1]
 
         for p, ao in zip(state["art_pos"], self.art_objs):
             ao.joint_positions = p

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -706,7 +706,6 @@ class RearrangeSim(HabitatSim):
         ]
         art_T = [ao.transformation for ao in self.art_objs]
         rom = self.get_rigid_object_manager()
-        
 
         rigid_T, rigid_V = [], []
         for i in self._scene_obj_ids:
@@ -766,7 +765,9 @@ class RearrangeSim(HabitatSim):
         for T, ao in zip(state["art_T"], self.art_objs):
             ao.transformation = T
 
-        for T, V, i in zip(state["rigid_T"], state["rigid_V"], self._scene_obj_ids):
+        for T, V, i in zip(
+            state["rigid_T"], state["rigid_V"], self._scene_obj_ids
+        ):
             # reset object transform
             obj = rom.get_object_by_id(i)
             obj.transformation = T


### PR DESCRIPTION
## Motivation and Context

Make capture state also save the velocity of objects. This is needed so that we can apply oracle actions when objects have a certain velocity. 

## How Has This Been Tested

Ran oracle policies and verified that velocities stay the same.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
