### PR TITLE
[hab3_merge] remove agent index

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -121,7 +121,6 @@ class EnvironmentConfig(HabitatBaseConfig):
 @dataclass
 class ActionConfig(HabitatBaseConfig):
     type: str = MISSING
-    agent_index: int = 0
 
 
 @dataclass

--- a/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
+++ b/habitat-lab/habitat/config/habitat/task/rearrange/rearrange_easy_multi_agent.yaml
@@ -43,11 +43,6 @@ actions:
     grip_controller: MagicGraspAction
   agent_1_arm_action:
     grip_controller: MagicGraspAction
-    agent_index : 1
-  agent_1_base_velocity:
-    agent_index : 1
-  agent_1_rearrange_stop:
-    agent_index : 1
 measurements:
   force_terminate:
     max_accum_force: 100000.0

--- a/habitat-lab/habitat/core/embodied_task.py
+++ b/habitat-lab/habitat/core/embodied_task.py
@@ -287,6 +287,7 @@ class EmbodiedTask:
                 config=entity_cfg,
                 dataset=self._dataset,
                 task=self,
+                name=entity_name,
             )
         return entities
 

--- a/habitat-lab/habitat/tasks/rearrange/actions/articulated_agent_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/articulated_agent_action.py
@@ -11,12 +11,18 @@ class ArticulatedAgentAction(SimulatorTaskAction):
 
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
-        if "agent" not in self._config or self._config.agent is None:
+        name_action = kwargs["name"]
+        self._multi_agent = len(self._sim.agents) > 1
+
+        if not name_action.startswith("agent_"):
             self._agent_index = 0
-            self._multi_agent = False
+            assert not self._multi_agent, f"Error in action: {name_action}. Multiagent actions should start with agent_X."
         else:
-            self._agent_index = self._config.agent
-            self._multi_agent = True
+            agent_index = name_action.split("_")[1]
+            assert agent_index.isnumeric()
+            agent_index = int(agent_index)
+            assert agent_index < len(self._sim.agents)
+            self._agent_index = agent_index
 
     @property
     def _articulated_agent_mgr(self):

--- a/habitat-lab/habitat/tasks/rearrange/actions/articulated_agent_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/articulated_agent_action.py
@@ -12,7 +12,7 @@ class ArticulatedAgentAction(SimulatorTaskAction):
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
         name_action = kwargs["name"]
-        self._multi_agent = len(self._sim.agents) > 1
+        self._multi_agent = len(self._sim.agents_mgr) > 1
 
         if not name_action.startswith("agent_"):
             self._agent_index = 0
@@ -23,7 +23,7 @@ class ArticulatedAgentAction(SimulatorTaskAction):
             agent_index = name_action.split("_")[1]
             assert agent_index.isnumeric()
             agent_index = int(agent_index)
-            assert agent_index < len(self._sim.agents)
+            assert agent_index < len(self._sim.agents_mgr)
             self._agent_index = agent_index
 
     @property

--- a/habitat-lab/habitat/tasks/rearrange/actions/articulated_agent_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/articulated_agent_action.py
@@ -16,7 +16,9 @@ class ArticulatedAgentAction(SimulatorTaskAction):
 
         if not name_action.startswith("agent_"):
             self._agent_index = 0
-            assert not self._multi_agent, f"Error in action: {name_action}. Multiagent actions should start with agent_X."
+            assert (
+                not self._multi_agent
+            ), f"Error in action: {name_action}. Multiagent actions should start with agent_X."
         else:
             agent_index = name_action.split("_")[1]
             assert agent_index.isnumeric()


### PR DESCRIPTION
## Motivation and Context

Removes the need to specify agent_index in the action config. Makes the agent_index inferrable from the action_name.

## How Has This Been Tested

Passes pytests.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
