### PR TITLE
Fix Articulated Object Drift

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -312,7 +312,11 @@ class RearrangeSim(HabitatSim):
         for ao, (set_joint_state, set_T) in self._start_art_states.items():
             ao.clear_joint_states()
             ao.joint_positions = set_joint_state
-            ao.transformation = set_T
+            if not is_hard_reset:
+                # [Andrew Szot 2023-08-22]: If we don't correct for this, some
+                # articulated objects may "drift" over time when the scene
+                # reset is skipped.
+                ao.transformation = set_T
 
         # Load specified articulated object states from episode config
         self._set_ao_states_from_ep(ep_info)


### PR DESCRIPTION
## Motivation and Context

The transformations of articulated objects would sometimes drift over the course of training if simulator resets are skipped. This resets the articulated object transformation when the simulator reset is skipped.

## How Has This Been Tested

End-to-end testing.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
