### PR TITLE
[hab3_merge] Define different policies for different agents

### DIFF
--- a/habitat-baselines/habitat_baselines/common/obs_transformers.py
+++ b/habitat-baselines/habitat_baselines/common/obs_transformers.py
@@ -1202,8 +1202,15 @@ def get_active_obs_transforms(
     config: "DictConfig",
 ) -> List[ObservationTransformer]:
     active_obs_transforms = []
-    obs_trans_conf = config.habitat_baselines.rl.policy.obs_transforms
-    if hasattr(config.habitat_baselines.rl.policy, "obs_transforms"):
+
+    # We assume for now that the observation space is shared among agents
+    agent_name = list(config.habitat_baselines.rl.policy.keys())[0]
+    obs_trans_conf = config.habitat_baselines.rl.policy[
+        agent_name
+    ].obs_transforms
+    if hasattr(
+        config.habitat_baselines.rl.policy[agent_name], "obs_transforms"
+    ):
         for obs_transform_config in obs_trans_conf.values():
             obs_trans_cls = baseline_registry.get_obs_transformer(
                 obs_transform_config.type

--- a/habitat-baselines/habitat_baselines/config/default_structured_configs.py
+++ b/habitat-baselines/habitat_baselines/config/default_structured_configs.py
@@ -104,7 +104,6 @@ class CenterCropperConfig(ObsTransformConfig):
 
 
 cs.store(
-    package="habitat_baselines.rl.policy.obs_transforms.center_cropper",
     group="habitat_baselines/rl/policy/obs_transforms",
     name="center_cropper_base",
     node=CenterCropperConfig,
@@ -125,7 +124,6 @@ class ResizeShortestEdgeConfig(ObsTransformConfig):
 
 
 cs.store(
-    package="habitat_baselines.rl.policy.obs_transforms.resize_shortest_edge",
     group="habitat_baselines/rl/policy/obs_transforms",
     name="resize_shortest_edge_base",
     node=ResizeShortestEdgeConfig,
@@ -150,7 +148,6 @@ class Cube2EqConfig(ObsTransformConfig):
 
 
 cs.store(
-    package="habitat_baselines.rl.policy.obs_transforms.cube_2_eq",
     group="habitat_baselines/rl/policy/obs_transforms",
     name="cube_2_eq_base",
     node=Cube2EqConfig,
@@ -177,7 +174,6 @@ class Cube2FishConfig(ObsTransformConfig):
 
 
 cs.store(
-    package="habitat_baselines.rl.policy.obs_transforms.cube_2_fish",
     group="habitat_baselines/rl/policy/obs_transforms",
     name="cube_2_fish_base",
     node=Cube2FishConfig,
@@ -191,7 +187,6 @@ class AddVirtualKeysConfig(ObsTransformConfig):
 
 
 cs.store(
-    package="habitat_baselines.rl.policy.obs_transforms.add_virtual_keys",
     group="habitat_baselines/rl/policy/obs_transforms",
     name="add_virtual_keys_base",
     node=AddVirtualKeysConfig,
@@ -216,7 +211,6 @@ class Eq2CubeConfig(ObsTransformConfig):
 
 
 cs.store(
-    package="habitat_baselines.rl.policy.obs_transforms.eq_2_cube",
     group="habitat_baselines/rl/policy/obs_transforms",
     name="eq_2_cube_base",
     node=Eq2CubeConfig,
@@ -374,7 +368,7 @@ class RLConfig(HabitatBaselinesBaseConfig):
 
     agent: AgentAccessMgrConfig = AgentAccessMgrConfig()
     preemption: PreemptionConfig = PreemptionConfig()
-    policy: PolicyConfig = PolicyConfig()
+    policy: Dict[str, PolicyConfig] = MISSING
     ppo: PPOConfig = PPOConfig()
     ddppo: DDPPOConfig = DDPPOConfig()
     ver: VERConfig = VERConfig()

--- a/habitat-baselines/habitat_baselines/config/rearrange/rl_hierarchical.yaml
+++ b/habitat-baselines/habitat_baselines/config/rearrange/rl_hierarchical.yaml
@@ -7,10 +7,11 @@ defaults:
   - /benchmark/rearrange: rearrange_easy
   - /habitat_baselines: habitat_baselines_rl_config_base
   - /habitat/simulator/sim_sensors@habitat_baselines.eval.extra_sim_sensors.third_rgb_sensor: third_rgb_sensor
-  - /habitat_baselines/rl/policy/obs_transforms:
+  - /habitat_baselines/rl/agent: single_agent
+  - /habitat_baselines/rl/policy/obs_transforms@habitat_baselines.rl.policy.main_agent.obs_transforms.add_virtual_keys:
     - add_virtual_keys_base
-  - /habitat_baselines/rl/policy: hl_fixed
-  - /habitat_baselines/rl/policy/hierarchical_policy/defined_skills: nn_skills
+  - /habitat_baselines/rl/policy@habitat_baselines.rl.policy.main_agent: hl_fixed
+  - /habitat_baselines/rl/policy/hierarchical_policy/defined_skills@habitat_baselines.rl.policy.main_agent.hierarchical_policy.defined_skills: nn_skills
   - /habitat/task/measurements:
     - composite_subgoal_reward
   - _self_

--- a/habitat-baselines/habitat_baselines/config/rearrange/rl_hierarchical_oracle_nav.yaml
+++ b/habitat-baselines/habitat_baselines/config/rearrange/rl_hierarchical_oracle_nav.yaml
@@ -32,10 +32,11 @@ habitat:
 habitat_baselines:
   rl:
     policy:
-      hierarchical_policy:
-        # Override to use the oracle navigation skill.
-        defined_skills:
-          nav_to_obj:
-            skill_name: "OracleNavPolicy"
-            obs_skill_inputs: ["obj_start_sensor", "abs_obj_start_sensor", "obj_goal_sensor", "abs_obj_goal_sensor"]
-            max_skill_steps: 300
+      main_agent:
+        hierarchical_policy:
+          # Override to use the oracle navigation skill (which will actually execute navigation).
+          defined_skills:
+              nav_to_obj:
+                skill_name: "OracleNavPolicy"
+                obs_skill_inputs: ["obj_start_sensor", "abs_obj_start_sensor", "obj_goal_sensor", "abs_obj_goal_sensor"]
+                max_skill_steps: 300

--- a/habitat-baselines/habitat_baselines/config/rearrange/rl_hierarchical_oracle_nav_human.yaml
+++ b/habitat-baselines/habitat_baselines/config/rearrange/rl_hierarchical_oracle_nav_human.yaml
@@ -23,7 +23,7 @@ defaults:
     - rearrange_stop
     - oracle_nav_action
   - override /habitat/task/rearrange: rearrange_easy_base
-  - override /habitat_baselines/rl/policy/hierarchical_policy/defined_skills: oracle_skills
+  - override /habitat_baselines/rl/policy/hierarchical_policy/defined_skills@habitat_baselines.rl.policy.main_agent.hierarchical_policy.defined_skills: oracle_skills
   - _self_
 
 habitat:
@@ -46,67 +46,68 @@ habitat:
   simulator:
     agents:
       main_agent:
-        articulated_agent_urdf: 'data/humanoids/humanoid_data/amass_male.urdf'
+        articulated_agent_urdf: 'data/humanoids/humanoid_data/armatures/human_armature.urdf'
         articulated_agent_type: KinematicHumanoid
         motion_data_path: "data/humanoids/humanoid_data/walking_motion_processed.pkl"
 
 habitat_baselines:
   rl:
     policy:
-      hierarchical_policy:
-        defined_skills:
-          nav_to_obj:
-            ignore_grip: True
-            pddl_action_names: ["nav", "nav_to_receptacle_by_name"]
-          open_cab:
-            skill_name: "NoopSkillPolicy"
-            max_skill_steps: 1
-            apply_postconds: True
-            force_end_on_timeout: False
-            pddl_action_names: ["open_cab_by_name"]
-            ignore_grip: True
-          open_fridge:
-            skill_name: "NoopSkillPolicy"
-            max_skill_steps: 1
-            apply_postconds: True
-            force_end_on_timeout: False
-            pddl_action_names: ["open_fridge_by_name"]
-            ignore_grip: True
-          close_cab:
-            skill_name: "NoopSkillPolicy"
-            obs_skill_inputs: ["obj_start_sensor"]
-            max_skill_steps: 1
-            apply_postconds: True
-            force_end_on_timeout: False
-            pddl_action_names: ["close_cab_by_name"]
-            ignore_grip: True
-          close_fridge:
-            skill_name: "NoopSkillPolicy"
-            obs_skill_inputs: ["obj_start_sensor"]
-            max_skill_steps: 1
-            apply_postconds: True
-            force_end_on_timeout: False
-            pddl_action_names: ["close_fridge_by_name"]
-            ignore_grip: True
-          pick:
-            skill_name: "NoopSkillPolicy"
-            obs_skill_inputs: ["obj_start_sensor"]
-            max_skill_steps: 1
-            apply_postconds: True
-            force_end_on_timeout: False
-            ignore_grip: True
-          place:
-            skill_name: "NoopSkillPolicy"
-            obs_skill_inputs: ["obj_goal_sensor"]
-            max_skill_steps: 1
-            apply_postconds: True
-            force_end_on_timeout: False
-            ignore_grip: True
-          wait:
-            skill_name: "WaitSkillPolicy"
-            ignore_grip: True
-          reset_arm:
-            skill_name: "NoopSkillPolicy"
-            max_skill_steps: 1
-            ignore_grip: True
-            force_end_on_timeout: False
+      main_agent:
+        hierarchical_policy:
+          defined_skills:
+            nav_to_obj:
+              ignore_grip: True
+              pddl_action_names: ["nav", "nav_to_receptacle_by_name"]
+            open_cab:
+              skill_name: "NoopSkillPolicy"
+              max_skill_steps: 1
+              apply_postconds: True
+              force_end_on_timeout: False
+              pddl_action_names: ["open_cab_by_name"]
+              ignore_grip: True
+            open_fridge:
+              skill_name: "NoopSkillPolicy"
+              max_skill_steps: 1
+              apply_postconds: True
+              force_end_on_timeout: False
+              pddl_action_names: ["open_fridge_by_name"]
+              ignore_grip: True
+            close_cab:
+              skill_name: "NoopSkillPolicy"
+              obs_skill_inputs: ["obj_start_sensor"]
+              max_skill_steps: 1
+              apply_postconds: True
+              force_end_on_timeout: False
+              pddl_action_names: ["close_cab_by_name"]
+              ignore_grip: True
+            close_fridge:
+              skill_name: "NoopSkillPolicy"
+              obs_skill_inputs: ["obj_start_sensor"]
+              max_skill_steps: 1
+              apply_postconds: True
+              force_end_on_timeout: False
+              pddl_action_names: ["close_fridge_by_name"]
+              ignore_grip: True
+            pick:
+              skill_name: "NoopSkillPolicy"
+              obs_skill_inputs: ["obj_start_sensor"]
+              max_skill_steps: 1
+              apply_postconds: True
+              force_end_on_timeout: False
+              ignore_grip: True
+            place:
+              skill_name: "NoopSkillPolicy"
+              obs_skill_inputs: ["obj_goal_sensor"]
+              max_skill_steps: 1
+              apply_postconds: True
+              force_end_on_timeout: False
+              ignore_grip: True
+            wait:
+              skill_name: "WaitSkillPolicy"
+              ignore_grip: True
+            reset_arm:
+              skill_name: "NoopSkillPolicy"
+              max_skill_steps: 1
+              ignore_grip: True
+              force_end_on_timeout: False

--- a/habitat-baselines/habitat_baselines/config/rearrange/rl_skill.yaml
+++ b/habitat-baselines/habitat_baselines/config/rearrange/rl_skill.yaml
@@ -34,10 +34,11 @@ habitat_baselines:
 
   rl:
     policy:
-        action_dist:
-           clamp_std: True
-           std_init: -1.0
-           use_std_param: True
+        main_agent:
+          action_dist:
+            clamp_std: True
+            std_init: -1.0
+            use_std_param: True
     ppo:
       # ppo params
       clip_param: 0.2

--- a/habitat-baselines/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -134,6 +134,19 @@ class PointNavResNetPolicy(NetPolicy):
                 )
             )
         )
+
+        agent_name = None
+        if "agent_name" in kwargs:
+            agent_name = kwargs["agent_name"]
+
+        if agent_name is None:
+            if len(config.habitat.simulator.agents_order) > 1:
+                raise ValueError(
+                    "If there is more than an agent, you need to specify the agent name"
+                )
+            else:
+                agent_name = config.habitat.simulator.agents_order[0]
+
         return cls(
             observation_space=filtered_obs,
             action_space=action_space,
@@ -143,7 +156,7 @@ class PointNavResNetPolicy(NetPolicy):
             backbone=config.habitat_baselines.rl.ddppo.backbone,
             normalize_visual_inputs="rgb" in observation_space.spaces,
             force_blind_policy=config.habitat_baselines.force_blind_policy,
-            policy_config=config.habitat_baselines.rl.policy,
+            policy_config=config.habitat_baselines.rl.policy[agent_name],
             aux_loss_config=config.habitat_baselines.rl.auxiliary_losses,
             fuse_keys=None,
         )

--- a/habitat-baselines/habitat_baselines/rl/ppo/single_agent_access_mgr.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/single_agent_access_mgr.py
@@ -45,6 +45,7 @@ class SingleAgentAccessMgr(AgentAccessMgr):
         num_envs: int,
         percent_done_fn: Callable[[], float],
         lr_schedule_fn: Optional[Callable[[float], float]] = None,
+        agent_name=None,
     ):
         """
         :param percent_done_fn: Function that will return the percent of the
@@ -53,6 +54,7 @@ class SingleAgentAccessMgr(AgentAccessMgr):
             specified in the config. Takes as input the current progress in
             training and returns the learning rate multiplier. The default behavior
             is to use `linear_lr_schedule`.
+        :param agent_name: the name of the agent for which we set the singleagentaccessmanager
         """
 
         self._env_spec = env_spec
@@ -64,6 +66,16 @@ class SingleAgentAccessMgr(AgentAccessMgr):
         self._is_static_encoder = (
             not config.habitat_baselines.rl.ddppo.train_encoder
         )
+
+        if agent_name is None:
+            if len(config.habitat.simulator.agents_order) > 1:
+                raise ValueError(
+                    "If there is more than an agent, you should specify the agent name"
+                )
+            else:
+                agent_name = config.habitat.simulator.agents_order[0]
+
+        self.agent_name = agent_name
         self._nbuffers = 2 if self._ppo_cfg.use_double_buffered_sampler else 1
         self._percent_done_fn = percent_done_fn
         if lr_schedule_fn is None:
@@ -172,7 +184,7 @@ class SingleAgentAccessMgr(AgentAccessMgr):
         """
 
         policy = baseline_registry.get_policy(
-            self._config.habitat_baselines.rl.policy.name
+            self._config.habitat_baselines.rl.policy[self.agent_name].name
         )
         if policy is None:
             raise ValueError(
@@ -183,6 +195,7 @@ class SingleAgentAccessMgr(AgentAccessMgr):
             self._env_spec.observation_space,
             self._env_spec.action_space,
             orig_action_space=self._env_spec.orig_action_space,
+            agent_name=self.agent_name,
         )
         if (
             self._config.habitat_baselines.rl.ddppo.pretrained_encoder

--- a/habitat-lab/habitat/tasks/rearrange/actions/actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/actions.py
@@ -708,7 +708,7 @@ class HumanoidJointAction(ArticulatedAgentAction):
         return spaces.Dict(
             {
                 "human_joints_trans": spaces.Box(
-                    shape=(4 * num_joints + num_dim_transform,),
+                    shape=(4 * num_joints + num_dim_transform * 2,),
                     low=-1,
                     high=1,
                     dtype=np.float32,
@@ -730,7 +730,7 @@ class HumanoidJointAction(ArticulatedAgentAction):
         human_joints_trans = kwargs[
             self._action_arg_prefix + "human_joints_trans"
         ]
-        new_joints = human_joints_trans[:-16]
+        new_joints = human_joints_trans[:-32]
         new_pos_transform_base = human_joints_trans[-16:]
         new_pos_transform_offset = human_joints_trans[-32:-16]
 

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
@@ -247,10 +247,12 @@ class HumanoidJointSensor(UsesArticulatedAgentInterface, Sensor):
         )
 
     def get_observation(self, observations, episode, *args, **kwargs):
-        joints_pos = self._sim.get_agent_data(
-            self.agent_id
-        ).articulated_agent.get_joint_transform()[0]
-        return np.array(joints_pos, dtype=np.float32)
+        curr_agent = self._sim.get_agent_data(self.agent_id).articulated_agent
+        if hasattr(curr_agent, "get_joint_transform"):
+            joints_pos = curr_agent.get_joint_transform()[0]
+            return np.array(joints_pos, dtype=np.float32)
+        else:
+            return np.zeros(self.observation_space.shape, dtype=np.float32)
 
 
 @registry.register_sensor

--- a/test/config/habitat_baselines/ddppo_imagenav_test.yaml
+++ b/test/config/habitat_baselines/ddppo_imagenav_test.yaml
@@ -24,7 +24,8 @@ habitat_baselines:
 
   rl:
     policy:
-      name: "PointNavResNetPolicy"
+      main_agent:
+        name: "PointNavResNetPolicy"
 
     ppo:
       # ppo params

--- a/test/config/habitat_baselines/ddppo_instance_imagenav_test.yaml
+++ b/test/config/habitat_baselines/ddppo_instance_imagenav_test.yaml
@@ -33,10 +33,11 @@ habitat_baselines:
 
   rl:
     policy:
-      name: PointNavResNetPolicy
-      obs_transforms:
-        resize_shortest_edge:
-          trans_keys: [rgb, depth, semantic, instance_imagegoal]
+      main_agent:
+        name: PointNavResNetPolicy
+        obs_transforms:
+          resize_shortest_edge:
+            trans_keys: [rgb, depth, semantic, instance_imagegoal]
 
     ppo:
       # ppo params

--- a/test/config/habitat_baselines/ddppo_pointnav_test.yaml
+++ b/test/config/habitat_baselines/ddppo_pointnav_test.yaml
@@ -26,7 +26,8 @@ habitat_baselines:
 
   rl:
     policy:
-      name: "PointNavResNetPolicy"
+      main_agent:
+        name: "PointNavResNetPolicy"
 
     ppo:
       # ppo params

--- a/test/test_baseline_trainers.py
+++ b/test/test_baseline_trainers.py
@@ -226,13 +226,13 @@ def test_cubemap_stiching(
         meta_config.habitat = config
 
         if camera == "equirect":
-            meta_config.habitat_baselines.rl.policy.obs_transforms = {
+            meta_config.habitat_baselines.rl.policy.main_agent.obs_transforms = {
                 "cube2eq": Cube2EqConfig(
                     sensor_uuids=sensor_uuids, width=256, height=256
                 )
             }
         elif camera == "fisheye":
-            meta_config.habitat_baselines.rl.policy.obs_transforms = {
+            meta_config.habitat_baselines.rl.policy.main_agent.obs_transforms = {
                 "cube2fish": Cube2FishConfig(
                     sensor_uuids=sensor_uuids, width=256, height=256
                 )

--- a/test/test_baseline_training.py
+++ b/test/test_baseline_training.py
@@ -263,7 +263,7 @@ def test_hrl(config_path, policy_type, skill_type, mode):
             skill_name,
             skill,
         ) in (
-            config.habitat_baselines.rl.policy.hierarchical_policy.defined_skills.items()
+            config.habitat_baselines.rl.policy.main_agent.hierarchical_policy.defined_skills.items()
         ):
             if skill.load_ckpt_file == "":
                 continue

--- a/test/test_baselines_hydra.py
+++ b/test/test_baselines_hydra.py
@@ -30,7 +30,7 @@ def my_app_compose_api() -> "DictConfig":
                 "habitat_baselines.num_updates=2",
                 "habitat_baselines.num_environments=4",
                 "habitat_baselines.total_num_steps=-1.0",
-                "habitat_baselines.rl.policy.action_distribution_type=gaussian",
+                "habitat_baselines.rl.policy.main_agent.action_distribution_type=gaussian",
                 "+benchmark/rearrange=pick",
                 "habitat.simulator.agents_order=[main_agent]",
             ]


### PR DESCRIPTION
## Motivation and Context

This is needed so that we can define different policy types for each agent. It may be useful to be able to train a multi-agent task where one agent is run by a planner and the other one is run by a neural net, or one has a low level policy and the other has a high level policy. 

Cherry-picked from this PR: https://github.com/facebookresearch/habitat-lab/commit/26a9696d0fd8aad795787ad49d19b89e3359db61

## How Has This Been Tested

Passes Test + End to End Testing.

## Types of changes

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
