### PR TITLE
HITL fetch state remote mode switch

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -108,7 +108,7 @@ class AppStateFetch(AppState):
         walk_dir = None
         if not self._first_person_mode:
             candidate_walk_dir = (
-                self._nav_helper.viz_and_get_humanoid_walk_dir()
+                self._nav_helper.viz_and_get_humanoid_walk_dir_from_ray_cast()
             )
             if self._sandbox_service.gui_input.get_mouse_button(
                 GuiInput.MouseNS.RIGHT
@@ -172,6 +172,28 @@ class AppStateFetch(AppState):
                 mn.Color3(255 / 255, 255 / 255, 0),
                 24,
             )
+
+    def _viz_agent_go_to_box(self):
+        color = mn.Color3(255 / 255, 0 / 255, 0 / 255)  # red
+
+        agent_pos, _ = self._get_agent_pose()
+
+        box_half_size = 0.5
+        box_offset = mn.Vector3(
+            box_half_size, 2 * box_half_size, box_half_size
+        )
+        self._sandbox_service.line_render.draw_box(
+            agent_pos - box_offset,
+            agent_pos + box_offset,
+            color,
+        )
+        circle_radius = 0.1
+        agent_pos[1] = self._get_agent_feet_height()
+        self._sandbox_service.line_render.draw_circle(
+            agent_pos,
+            circle_radius,
+            color,
+        )
 
     def get_gui_controlled_agent_index(self):
         return self._gui_agent_ctrl._agent_idx
@@ -250,11 +272,15 @@ class AppStateFetch(AppState):
                 text_delta_y=-50,
             )
 
-    def _get_camera_lookat_pos(self):
+    def _get_agent_pose(self):
         agent_root = get_agent_art_obj_transform(
             self.get_sim(), self.get_gui_controlled_agent_index()
         )
-        lookat = agent_root.translation + mn.Vector3(0, 1, 0)
+        return agent_root.translation, agent_root.rotation
+
+    def _get_camera_lookat_pos(self):
+        agent_pos, _ = self._get_agent_pose()
+        lookat = agent_pos + mn.Vector3(0, 1, 0)
         return lookat
 
     def sim_update(self, dt, post_sim_update_dict):

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -112,14 +112,14 @@ class AppStateFetch(AppState):
                 (
                     candidate_walk_dir,
                     candidate_distance_multiplier,
-                ) = self._nav_helper._get_humanoid_walk_dir_from_remote_gui_input(
+                ) = self._nav_helper.get_humanoid_walk_hints_from_remote_gui_input(
                     visualize_path=False
                 )
             else:
                 (
                     candidate_walk_dir,
                     candidate_distance_multiplier,
-                ) = self._nav_helper._get_humanoid_walk_dir_from_ray_cast(
+                ) = self._nav_helper.get_humanoid_walk_dir_from_ray_cast(
                     visualize_path=True
                 )
 
@@ -274,7 +274,8 @@ class AppStateFetch(AppState):
 
     def _get_camera_lookat_pos(self):
         agent_pos, _ = self._get_agent_pose()
-        lookat = agent_pos + mn.Vector3(0, 1, 0)
+        lookat_y_offset = mn.Vector3(0, 1, 0)
+        lookat = agent_pos + lookat_y_offset
         return lookat
 
     def sim_update(self, dt, post_sim_update_dict):

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -106,7 +106,7 @@ class AppStateFetch(AppState):
                         ]
 
         walk_dir = None
-        distance_multiplier = 0.0
+        distance_multiplier = 1.0
         if not self._first_person_mode:
             if self._sandbox_service.args.remote_gui_mode:
                 (
@@ -119,7 +119,7 @@ class AppStateFetch(AppState):
                 (
                     candidate_walk_dir,
                     candidate_distance_multiplier,
-                ) = self._nav_helper.get_humanoid_walk_dir_from_ray_cast(
+                ) = self._nav_helper.get_humanoid_walk_hints_from_ray_cast(
                     visualize_path=True
                 )
 

--- a/examples/siro_sandbox/app_states/app_state_rearrange.py
+++ b/examples/siro_sandbox/app_states/app_state_rearrange.py
@@ -157,7 +157,7 @@ class AppStateRearrange(AppState):
             (
                 candidate_walk_dir,
                 candidate_distance_multiplier,
-            ) = self._nav_helper._get_humanoid_walk_dir_from_ray_cast(
+            ) = self._nav_helper.get_humanoid_walk_hints_from_ray_cast(
                 visualize_path=True
             )
             if self._sandbox_service.gui_input.get_mouse_button(
@@ -407,7 +407,8 @@ class AppStateRearrange(AppState):
         agent_root = get_agent_art_obj_transform(
             self.get_sim(), self.get_gui_controlled_agent_index()
         )
-        lookat = agent_root.translation + mn.Vector3(0, 1, 0)
+        lookat_y_offset = mn.Vector3(0, 1, 0)
+        lookat = agent_root.translation + lookat_y_offset
         return lookat
 
     def sim_update(self, dt, post_sim_update_dict):

--- a/examples/siro_sandbox/app_states/app_state_rearrange.py
+++ b/examples/siro_sandbox/app_states/app_state_rearrange.py
@@ -152,17 +152,23 @@ class AppStateRearrange(AppState):
                         ]
 
         walk_dir = None
+        distance_multiplier = 0.0
         if not self._first_person_mode:
-            candidate_walk_dir = (
-                self._nav_helper.viz_and_get_humanoid_walk_dir_from_ray_cast()
+            (
+                candidate_walk_dir,
+                candidate_distance_multiplier,
+            ) = self._nav_helper._get_humanoid_walk_dir_from_ray_cast(
+                visualize_path=True
             )
             if self._sandbox_service.gui_input.get_mouse_button(
                 GuiInput.MouseNS.RIGHT
             ):
                 walk_dir = candidate_walk_dir
+                distance_multiplier = candidate_distance_multiplier
 
         self._gui_agent_ctrl.set_act_hints(
             walk_dir,
+            distance_multiplier,
             grasp_object_id,
             drop_pos,
             self._camera_helper.lookat_offset_yaw,

--- a/examples/siro_sandbox/app_states/app_state_rearrange.py
+++ b/examples/siro_sandbox/app_states/app_state_rearrange.py
@@ -154,7 +154,7 @@ class AppStateRearrange(AppState):
         walk_dir = None
         if not self._first_person_mode:
             candidate_walk_dir = (
-                self._nav_helper.viz_and_get_humanoid_walk_dir()
+                self._nav_helper.viz_and_get_humanoid_walk_dir_from_ray_cast()
             )
             if self._sandbox_service.gui_input.get_mouse_button(
                 GuiInput.MouseNS.RIGHT

--- a/examples/siro_sandbox/app_states/app_state_socialnav.py
+++ b/examples/siro_sandbox/app_states/app_state_socialnav.py
@@ -180,17 +180,23 @@ class AppStateSocialNav(AppState):
             self._episode_found_obj_ids.add(closest_object_id)
 
         walk_dir = None
+        distance_multiplier = 0.0
         if not self._camera_helper._first_person_mode:
-            candidate_walk_dir = (
-                self._nav_helper.viz_and_get_humanoid_walk_dir_from_ray_cast()
+            (
+                candidate_walk_dir,
+                candidate_distance_multiplier,
+            ) = self._nav_helper._get_humanoid_walk_dir_from_ray_cast(
+                visualize_path=True
             )
             if self._sandbox_service.gui_input.get_mouse_button(
                 GuiInput.MouseNS.RIGHT
             ):
                 walk_dir = candidate_walk_dir
+                distance_multiplier = candidate_distance_multiplier
 
         self._gui_agent_ctrl.set_act_hints(
             walk_dir,
+            distance_multiplier,
             None,
             None,
             self._camera_helper.lookat_offset_yaw,

--- a/examples/siro_sandbox/app_states/app_state_socialnav.py
+++ b/examples/siro_sandbox/app_states/app_state_socialnav.py
@@ -125,7 +125,8 @@ class AppStateSocialNav(AppState):
         agent_root = get_agent_art_obj_transform(
             self.get_sim(), self.get_gui_controlled_agent_index()
         )
-        lookat = agent_root.translation + mn.Vector3(0, 1, 0)
+        lookat_y_offset = mn.Vector3(0, 1, 0)
+        lookat = agent_root.translation + lookat_y_offset
         return lookat
 
     def _update_task(self):
@@ -185,7 +186,7 @@ class AppStateSocialNav(AppState):
             (
                 candidate_walk_dir,
                 candidate_distance_multiplier,
-            ) = self._nav_helper._get_humanoid_walk_dir_from_ray_cast(
+            ) = self._nav_helper.get_humanoid_walk_hints_from_ray_cast(
                 visualize_path=True
             )
             if self._sandbox_service.gui_input.get_mouse_button(

--- a/examples/siro_sandbox/app_states/app_state_socialnav.py
+++ b/examples/siro_sandbox/app_states/app_state_socialnav.py
@@ -182,7 +182,7 @@ class AppStateSocialNav(AppState):
         walk_dir = None
         if not self._camera_helper._first_person_mode:
             candidate_walk_dir = (
-                self._nav_helper.viz_and_get_humanoid_walk_dir()
+                self._nav_helper.viz_and_get_humanoid_walk_dir_from_ray_cast()
             )
             if self._sandbox_service.gui_input.get_mouse_button(
                 GuiInput.MouseNS.RIGHT

--- a/examples/siro_sandbox/controllers/gui_controller.py
+++ b/examples/siro_sandbox/controllers/gui_controller.py
@@ -186,6 +186,7 @@ class GuiHumanoidController(GuiController):
         self._humanoid_controller = HumanoidRearrangeController(walk_pose_path)
         self._env = env
         self._hint_walk_dir = None
+        self._hint_distance_multiplier = None
         self._hint_grasp_obj_idx = None
         self._hint_drop_pos = None
         self._cam_yaw = 0
@@ -200,6 +201,7 @@ class GuiHumanoidController(GuiController):
         base_trans = self.get_articulated_agent().base_transformation
         self._humanoid_controller.reset(base_trans)
         self._hint_walk_dir = None
+        self._hint_distance_multiplier = None
         self._hint_grasp_obj_idx = None
         self._hint_drop_pos = None
         self._cam_yaw = 0
@@ -245,8 +247,16 @@ class GuiHumanoidController(GuiController):
         )
         return humanoidjoint_action
 
-    def set_act_hints(self, walk_dir, grasp_obj_idx, do_drop, cam_yaw=None):
+    def set_act_hints(
+        self,
+        walk_dir,
+        distance_multiplier,
+        grasp_obj_idx,
+        do_drop,
+        cam_yaw=None,
+    ):
         self._hint_walk_dir = walk_dir
+        self._hint_distance_multiplier = distance_multiplier
         self._hint_grasp_obj_idx = grasp_obj_idx
         self._hint_drop_pos = do_drop
         self._cam_yaw = cam_yaw

--- a/examples/siro_sandbox/controllers/gui_controller.py
+++ b/examples/siro_sandbox/controllers/gui_controller.py
@@ -355,7 +355,17 @@ class GuiHumanoidController(GuiController):
             + base_offset
         )
 
-        self._humanoid_controller.calculate_walk_pose(relative_pos)
+        # 1.0 is the default value indicating mowing in the relative_pos direction
+        # 0.0 indicates no movement but possibly a rotation on the spot
+        distance_multiplier = (
+            1.0
+            if self._hint_distance_multiplier is None
+            else self._hint_distance_multiplier
+        )
+
+        self._humanoid_controller.calculate_walk_pose(
+            relative_pos, distance_multiplier
+        )
 
         # calculate_walk_pose has updated obj_transform_base.translation with
         # desired motion, but this should be filtered (restricted to navmesh).

--- a/examples/siro_sandbox/gui_navigation_helper.py
+++ b/examples/siro_sandbox/gui_navigation_helper.py
@@ -124,7 +124,7 @@ class GuiNavigationHelper:
 
         walk_dir, distance_multiplier = self._get_humanoid_walk_hints(
             target_pos=target_on_floor,
-            target_rot_quat=habitat_sim.utils.common.random_quaternion(),  # habitat_sim.utils.common.random_quaternion() can be used to generate random rotations for testing
+            target_rot_quat=None,  # habitat_sim.utils.common.random_quaternion() can be used to generate random rotations for testing
             visualize_path=visualize_path,
         )
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -606,7 +606,13 @@ if __name__ == "__main__":
         "--app-state",
         default="rearrange",
         type=str,
-        help=("'rearrange' (default) or 'fetch'"),
+        help="'rearrange' (default) or 'fetch'",
+    )
+    parser.add_argument(
+        "--remote-gui-mode",
+        action="store_true",
+        default=False,
+        help="Observer mode, where the humanoid follows the VR headset pose provided by remote_gui_input",
     )
 
     args = parser.parse_args()
@@ -620,6 +626,11 @@ if __name__ == "__main__":
 
     if args.show_tutorial:
         raise ValueError("--show-tutorial is temporarily unsupported!")
+
+    if args.remote_gui_mode and args.app_state != "fetch":
+        raise ValueError(
+            "--remote-gui-mode is only supported for fetch app-state"
+        )
 
     glfw_config = Application.Configuration()
     glfw_config.title = "Sandbox App"


### PR DESCRIPTION
## Motivation and Context

Adaptation of the `app_state_fetch.py` to support GUI-controlled humanoid following arbitrary pose (position and orientation change, for example, from the VR headset).

`gui_navigation_helper.py` is refactored to support calculating walk direction to arbitrary position and once that position is reached walk direction is set to rotation vector. Walk direction is represented as a tuple of (walk_dir, distance_multiplier). If distance_multiplier = 1 agent moves in the walk_dir by |walk_dir|, if distance_multiplier is 0 agent rotates on the spot in the walk_dir.

 `gui_controller.py` is not changed since it was designed to follow the walk_dir specified as an actuation hint. 
 
 In theory, switching to VR headset pose following should be enabled by adding `--remote-gui-mode` argument and providing `self._sandbox_service.remote_gui_input`.

## How Has This Been Tested
Launching app locally on MacBook Pro 2021.

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **Development:** PR into SIRo_hitl

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
