### PR TITLE
Fix distance_multiplier for rearrange and socialnav

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_rearrange.py
+++ b/examples/siro_sandbox/app_states/app_state_rearrange.py
@@ -152,7 +152,7 @@ class AppStateRearrange(AppState):
                         ]
 
         walk_dir = None
-        distance_multiplier = 0.0
+        distance_multiplier = 1.0
         if not self._first_person_mode:
             (
                 candidate_walk_dir,

--- a/examples/siro_sandbox/app_states/app_state_socialnav.py
+++ b/examples/siro_sandbox/app_states/app_state_socialnav.py
@@ -181,7 +181,7 @@ class AppStateSocialNav(AppState):
             self._episode_found_obj_ids.add(closest_object_id)
 
         walk_dir = None
-        distance_multiplier = 0.0
+        distance_multiplier = 1.0
         if not self._camera_helper._first_person_mode:
             (
                 candidate_walk_dir,


### PR DESCRIPTION
## Motivation and Context

Fixes `distance_multiplier` default value for rearrange and socialnav tasks. Follow-up PR to https://github.com/facebookresearch/habitat-lab/pull/1546.

## How Has This Been Tested

Launching app locally on MacBook Pro 2021.

## Types of changes

- **Bug Fix**  PR into SIRo_hitl

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
