### PR TITLE
Disable frustum culling in HITL tool.

### DIFF
--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -56,7 +56,7 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         cfg.gpu_device_id = 0  # todo
         cfg.force_separate_semantic_scene_graph = False
         cfg.leave_context_with_background_renderer = False
-        cfg.enable_frustum_culling = False
+        cfg.enable_frustum_culling = False # TODO: Circumvents culling issues
         self._replay_renderer = (
             ReplayRenderer.create_batch_replay_renderer(cfg)
             if use_batch_renderer

--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -56,6 +56,7 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         cfg.gpu_device_id = 0  # todo
         cfg.force_separate_semantic_scene_graph = False
         cfg.leave_context_with_background_renderer = False
+        cfg.enable_frustum_culling = False
         self._replay_renderer = (
             ReplayRenderer.create_batch_replay_renderer(cfg)
             if use_batch_renderer

--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -56,7 +56,9 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         cfg.gpu_device_id = 0  # todo
         cfg.force_separate_semantic_scene_graph = False
         cfg.leave_context_with_background_renderer = False
-        cfg.enable_frustum_culling = False  # TODO: Circumvents culling issues
+        # TODO:  Reenable frustum culling when replay renderer issues are solved.
+        if hasattr(cfg, "enable_frustum_culling"):
+            cfg.enable_frustum_culling = False
         self._replay_renderer = (
             ReplayRenderer.create_batch_replay_renderer(cfg)
             if use_batch_renderer

--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -56,7 +56,7 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         cfg.gpu_device_id = 0  # todo
         cfg.force_separate_semantic_scene_graph = False
         cfg.leave_context_with_background_renderer = False
-        cfg.enable_frustum_culling = False # TODO: Circumvents culling issues
+        cfg.enable_frustum_culling = False  # TODO: Circumvents culling issues
         self._replay_renderer = (
             ReplayRenderer.create_batch_replay_renderer(cfg)
             if use_batch_renderer


### PR DESCRIPTION
## Motivation and Context

This disables frustum culling in the HITL loop to work around culling issues while the underlying issue is being fixed.

Video of the issue:
https://github.com/facebookresearch/habitat-lab/assets/110583667/89e0b249-2541-49c0-883e-839acf1c331d

Depends on: https://github.com/facebookresearch/habitat-sim/pull/2199

## How Has This Been Tested

Tested manually in HSSD scenes.
