### PR TITLE
[bugfix]: remove joint motors when converting objects to MotionType.KINEMATIC

### DIFF
--- a/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
+++ b/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
@@ -11,7 +11,7 @@ import numpy as np
 from habitat.articulated_agents.articulated_agent_interface import (
     ArticulatedAgentInterface,
 )
-from habitat_sim.physics import JointMotorSettings
+from habitat_sim.physics import JointMotorSettings, MotionType
 from habitat_sim.simulator import Simulator
 
 
@@ -224,8 +224,10 @@ class ArticulatedAgentBase(ArticulatedAgentInterface):
 
             joint_positions = self.sim_obj.joint_positions
 
+            mt = self.sim_obj.motion_type
             for i, jidx in enumerate(self.params.leg_joints):
-                self._set_motor_pos(jidx, ctrl[i])
+                if mt == MotionType.DYNAMIC:
+                    self._set_motor_pos(jidx, ctrl[i])
                 joint_positions[self.joint_pos_indices[jidx]] = ctrl[i]
             self.sim_obj.joint_positions = joint_positions
         else:

--- a/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
+++ b/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
@@ -127,6 +127,9 @@ class KinematicHumanoid(MobileManipulator):
         """Instantiates the human in the scene. Loads the URDF, sets initial state of parameters, joints, motors, etc..."""
         super().reconfigure()
         self.sim_obj.motion_type = habitat_sim.physics.MotionType.KINEMATIC
+        # remove any remaining joint motors
+        for motor_id in self.sim_obj.existing_joint_motor_ids:
+            self.sim_obj.remove_joint_motor(motor_id)
 
     def set_joint_transform(
         self,

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -613,6 +613,9 @@ class RearrangeSim(HabitatSim):
                 ao = ao_mgr.get_object_by_handle(aoi_handle)
                 if self._kinematic_mode:
                     ao.motion_type = habitat_sim.physics.MotionType.KINEMATIC
+                    # remove any existing motors when converting to kinematic AO
+                    for motor_id in ao.existing_joint_motor_ids:
+                        ao.remove_joint_motor(motor_id)
                 self.art_objs.append(ao)
 
     def _create_recep_info(


### PR DESCRIPTION
## Motivation and Context

JointMotors created for ArticulatedObjects stick around in the Bullet backend when the AO is removed from the simulation world (set to KINEMATIC). These motors undergo costly constrain row computation every physics step but do nothing. Instead, they should be removed for kinematic mode.

NOTE: This assumes we won't switch back to dynamic mode later (JointMotors would need to be re-created)

## How Has This Been Tested

Locally via benchmark.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
