### PR TITLE
[bugfix]: handle the case where a scene has no indoor navmesh islands

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
+++ b/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
@@ -472,6 +472,8 @@ def get_largest_island_index(
     Optionally exclude outdoor islands.
 
     NOTE: outdoor heuristic may need to be tuned, but parameters are default here.
+
+    If no islands exist satisfying the indoor constraints, then the entire navmesh -1 is returned.
     """
 
     assert pathfinder.is_loaded, "PathFinder is not loaded."
@@ -490,6 +492,8 @@ def get_largest_island_index(
             is_outdoor(pathfinder, sim, island_info[0])
             for island_info in island_areas
         ]
+        if False not in island_outdoor_classifications:
+            return -1
         # select the largest outdoor island
         largest_indoor_island = island_areas[
             island_outdoor_classifications.index(False)


### PR DESCRIPTION
## Motivation and Context

Some scenes have no ceilings and therefore largest indoor island computation will fail.
This patch handles this edge case, returning the full navmesh (-1) when the indoor constraint cannot be satisfied.

Alternative would be to instead return the largest outdoor island, but -1 seemed easier to catch downstream to validate in user code. Open to opinions.

## How Has This Been Tested

locally on benchmark

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
