### PR TITLE
Manual keyframe recording (SIRo_dev)

### DIFF
--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -1101,6 +1101,13 @@ class SandboxDriver(GuiAppDriver):
             for keyframe in keyframes:
                 self._recording_keyframes.append(keyframe)
 
+        # Manually save recorded gfx-replay keyframes.
+        if (
+            self._gui_input.get_key_down(GuiInput.KeyNS.EQUAL)
+            and self._save_gfx_replay_keyframes
+        ):
+            self._save_recorded_keyframes_to_file()
+
         if self._args.hide_humanoid_in_gui:
             # Hack to hide skinned humanoids in the GUI viewport. Specifically, this
             # hides all render instances with a filepath starting with


### PR DESCRIPTION
[Cherry-pick from SIRo-hitl](https://github.com/facebookresearch/habitat-lab/pull/1571)

## Motivation and Context

This adds a way to record keyframes manually (pressing `=`). The intent is to enable the HITL tool to be used to generate keyframes for taking figures and videos.

Usage:
* Launch with the following arguments: `--save-gfx-replay-keyframes --save-filepath-base file`
* The application will immediately begin recording.
* Press `=` to record the keyframe file.

## How Has This Been Tested

Manually tested.
