### PR TITLE
Unoccluded navmesh snap

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
+++ b/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
@@ -44,12 +44,17 @@ def snap_point_is_occluded(
         if (
             raycast_results.has_hits()
             and raycast_results.hits[0].ray_distance < 1
-            and target_object_id is not None
         ):
-            if raycast_results.hits[0].object_id == target_object_id:
+            if (
+                target_object_id is not None
+                and raycast_results.hits[0].object_id == target_object_id
+            ):
+                # we hit an allowed object (i.e., the target object), so not occluded
                 return False
+            # the ray hit a not-allowed object and is occluded
             continue
         else:
+            # ray hit nothing, so not occluded
             return False
     return True
 

--- a/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
+++ b/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
@@ -10,6 +10,137 @@ from habitat.tasks.utils import get_angle
 from habitat_sim.physics import VelocityControl
 
 
+def snap_point_is_occluded(
+    target: mn.Vector3,
+    snap_point: mn.Vector3,
+    height: float,
+    sim: habitat_sim.Simulator,
+    granularity: float = 0.2,
+    target_object_id: Optional[int] = None,
+) -> bool:
+    """
+    Uses raycasting to check whether a target is occluded given a navmesh snap point.
+
+    :property target: The 3D position whic should be unoccluded from the snap point.
+    :property snap_point: The navmesh snap point under consideration.
+    :property height: The height of the agent. Given navmesh snap point is grounded, the maximum height from which a visibility check should indicate non-occlusion. First check starts from this height.
+    :property sim: The Simulator instance.
+    :property granularity: The distance between raycast samples. Finer granularity is more accurate, but more expensive.
+    :property target_object_id: An optional object id which should be ignored in occlusion check.
+
+    NOTE: If agent's eye height is known and only that height should be considered, provide eye height and granulatiry > height for fastest check.
+
+    :return: whether or not the target is considered occluded from the snap_point.
+    """
+    # start from the top, assuming the agent's eyes are not at the bottom.
+    cur_height = height
+    while cur_height > 0:
+        ray = habitat_sim.geo.Ray()
+        ray.origin = snap_point + mn.Vector3(0, cur_height, 0)
+        cur_height -= granularity
+        ray.direction = target - ray.origin
+        raycast_results = sim.cast_ray(ray)
+        # distance of 1 is the displacement between the two points
+        if (
+            raycast_results.has_hits()
+            and raycast_results.hits[0].ray_distance < 1
+            and target_object_id is not None
+        ):
+            if raycast_results.hits[0].object_id == target_object_id:
+                return False
+            continue
+        else:
+            return False
+    return True
+
+
+def unoccluded_navmesh_snap(
+    pos: mn.Vector3,
+    height: float,
+    pathfinder: habitat_sim.nav.PathFinder,
+    sim: habitat_sim.Simulator,
+    target_object_id: Optional[int] = None,
+    island_id: int = -1,
+    search_offset: float = 1.5,
+    test_batch_size: int = 20,
+    max_samples: int = 200,
+    min_sample_dist: float = 0.5,
+) -> Optional[mn.Vector3]:
+    """
+    Snap a point to the navmesh considering point visibilty via raycasting.
+
+    :property pos: The 3D position to snap.
+    :property height: The height of the agent. Given navmesh snap point is grounded, the maximum height from which a visibility check should indicate non-occlusion. First check starts from this height.
+    :property pathfinder: The PathFinder defining the NavMesh to use.
+    :property sim: The Simulator instance.
+    :property target_object_id: An optional object_id which should be ignored in the occlusion check. For example, when pos is an object's COM, that object should not occlude the point.
+    :property island_id: Optionally restrict the search to a single navmesh island. Default -1 is the full navmesh.
+    :property search_offset: The additional radius to search for navmesh points around the target position. Added to the minimum distance from pos to navmesh.
+    :property test_batch_size: The number of sample navmesh points to consider when testing for occlusion.
+    :property max_samples: The maximum number of attempts to sample navmesh points for the test batch.
+    :property min_sample_dist: The minimum allowed L2 distance between samples in the test batch.
+
+    NOTE: this function is based on smapling and does not guarantee the closest point.
+
+    :return: An approximation of the closest unoccluded snap point to pos or None if an unoccluded point could not be found.
+    """
+
+    # first try the closest snap point
+    snap_point = pathfinder.snap_point(pos, island_id)
+    is_occluded = snap_point_is_occluded(
+        target=pos,
+        snap_point=snap_point,
+        height=height,
+        sim=sim,
+        target_object_id=target_object_id,
+    )
+
+    # now sample and try different snap options
+    if is_occluded:
+        # distance to closest snap point is the absolute minimum
+        min_radius = (snap_point - pos).length()
+        # expand the search radius
+        search_radius = min_radius + search_offset
+
+        # gather a test batch
+        test_batch: List[Tuple[mn.Vector3, float]] = []
+        sample_count = 0
+        while len(test_batch) < test_batch_size and sample_count < max_samples:
+            sample = pathfinder.get_random_navigable_point_near(
+                circle_center=pos, radius=search_radius, island_index=island_id
+            )
+            reject = False
+            for batch_sample in test_batch:
+                if np.linalg.norm(sample - batch_sample[0]) < min_sample_dist:
+                    reject = True
+                    break
+            if not reject:
+                test_batch.append(
+                    (sample, float(np.linalg.norm(sample - pos)))
+                )
+            sample_count += 1
+
+        # sort the test batch points by distance to the target
+        test_batch.sort(key=lambda s: s[1])
+
+        # find the closest unoccluded point in the test batch
+        for batch_sample in test_batch:
+            if not snap_point_is_occluded(
+                pos,
+                batch_sample[0],
+                height,
+                sim,
+                target_object_id=target_object_id,
+            ):
+                return batch_sample[0]
+
+        # unable to find an unoccluded point
+        return None
+
+    # the true closest snap point is unoccluded
+    return snap_point
+
+
 def is_collision(
     pathfinder: habitat_sim.nav.PathFinder,
     trans: mn.Matrix4,
@@ -377,23 +508,40 @@ def path_is_navigable_given_robot(
 def is_accessible(
     sim: habitat_sim.Simulator,
     point: mn.Vector3,
+    height: float,
     nav_to_min_distance: float,
-    nav_island: int,
+    nav_island: int = -1,
+    target_object_id: Optional[int] = None,
 ) -> bool:
     """
-    Return True if the point is within a threshold distance (in XZ plane) of the nearest navigable point on the selected island.
+    Return True if the point is within a threshold distance (in XZ plane) of the nearest unoccluded navigable point on the selected island.
 
     :param sim: Habitat Simulaton instance.
     :param point: The query point.
+    :property height: The height of the agent. Given navmesh snap point is grounded, the maximum height from which a visibility check should indicate non-occlusion. First check starts from this height.
     :param nav_to_min_distance: Minimum distance threshold. -1 opts out of the test and returns True (i.e. no minumum distance).
-    :param nav_island: The NavMesh island on which to check accessibility. -1 is the full NavMesh.
+    :param nav_island: The NavMesh island on which to check accessibility. Default -1 is the full NavMesh.
+    :param target_object_id: An optional object_id which should be ignored in the occlusion check. For example, when checking accessibility of an object's COM, that object should not occlude.
 
-    Note that this might not catch all edge cases since the nearest navigable point may be separated from the point by an obstacle.
+    TODO: target_object_id should be a list to correctly support ArticulatedObjects (e.g. the fridge body should not occlude the fridge drawer for this check.)
+
+    :return: Whether or not the point is accessible.
     """
     if nav_to_min_distance == -1:
         return True
 
-    snapped = sim.pathfinder.snap_point(point, island_index=nav_island)
+    snapped = unoccluded_navmesh_snap(
+        pos=point,
+        height=height,
+        pathfinder=sim.pathfinder,
+        sim=sim,
+        target_object_id=target_object_id,
+        island_id=nav_island,
+        search_offset=nav_to_min_distance,
+    )
+
+    if snapped is None:
+        return False
 
     horizontal_dist = float(
         np.linalg.norm(np.array((snapped - point))[[0, 2]])

--- a/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
+++ b/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
@@ -23,7 +23,7 @@ def snap_point_is_occluded(
 
     :property target: The 3D position which should be unoccluded from the snap point.
     :property snap_point: The navmesh snap point under consideration.
-    :property height: The height of the agent. Given navmesh snap point is grounded, the maximum height from which a visibility check should indicate non-occlusion. First check starts from this height.
+    :property height: The height of the agent above the navmesh. Assumes the navmesh snap point is on the ground. Should be the maximum relative distance from navmesh ground to which a visibility check should indicate non-occlusion. The first check starts from this height. (E.g. agent_eyes_y - agent_base_y)
     :property sim: The Simulator instance.
     :property granularity: The distance between raycast samples. Finer granularity is more accurate, but more expensive.
     :property target_object_id: An optional object id which should be ignored in occlusion check.
@@ -75,7 +75,7 @@ def unoccluded_navmesh_snap(
     Snap a point to the navmesh considering point visibilty via raycasting.
 
     :property pos: The 3D position to snap.
-    :property height: The height of the agent. Given navmesh snap point is grounded, the maximum height from which a visibility check should indicate non-occlusion. First check starts from this height.
+    :property height: The height of the agent above the navmesh. Assumes the navmesh snap point is on the ground. Should be the maximum relative distance from navmesh ground to which a visibility check should indicate non-occlusion. The first check starts from this height. (E.g. agent_eyes_y - agent_base_y)
     :property pathfinder: The PathFinder defining the NavMesh to use.
     :property sim: The Simulator instance.
     :property target_object_id: An optional object_id which should be ignored in the occlusion check. For example, when pos is an object's COM, that object should not occlude the point.

--- a/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
+++ b/habitat-lab/habitat/datasets/rearrange/navmesh_utils.py
@@ -21,7 +21,7 @@ def snap_point_is_occluded(
     """
     Uses raycasting to check whether a target is occluded given a navmesh snap point.
 
-    :property target: The 3D position whic should be unoccluded from the snap point.
+    :property target: The 3D position which should be unoccluded from the snap point.
     :property snap_point: The navmesh snap point under consideration.
     :property height: The height of the agent. Given navmesh snap point is grounded, the maximum height from which a visibility check should indicate non-occlusion. First check starts from this height.
     :property sim: The Simulator instance.

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -461,12 +461,12 @@ class RearrangeEpisodeGenerator:
         if verbose:
             pbar = tqdm(total=num_episodes)
         while len(generated_episodes) < num_episodes:
-            # try:
-            self._scene_sampler.set_cur_episode(len(generated_episodes))
-            new_episode = self.generate_single_episode()
-            # except Exception:
-            #    new_episode = None
-            #    logger.error("Generation failed with exception...")
+            try:
+                self._scene_sampler.set_cur_episode(len(generated_episodes))
+                new_episode = self.generate_single_episode()
+            except Exception:
+                new_episode = None
+                logger.error("Generation failed with exception...")
             if new_episode is None:
                 failed_episodes += 1
                 continue
@@ -479,9 +479,6 @@ class RearrangeEpisodeGenerator:
         logger.info(
             f"Generated {num_episodes} episodes in {num_episodes+failed_episodes} tries."
         )
-
-        for ep in generated_episodes:
-            print(f"ep scene = {ep.scene_id}")
 
         return generated_episodes
 

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -461,12 +461,12 @@ class RearrangeEpisodeGenerator:
         if verbose:
             pbar = tqdm(total=num_episodes)
         while len(generated_episodes) < num_episodes:
-            try:
-                self._scene_sampler.set_cur_episode(len(generated_episodes))
-                new_episode = self.generate_single_episode()
-            except Exception:
-                new_episode = None
-                logger.error("Generation failed with exception...")
+            # try:
+            self._scene_sampler.set_cur_episode(len(generated_episodes))
+            new_episode = self.generate_single_episode()
+            # except Exception:
+            #    new_episode = None
+            #    logger.error("Generation failed with exception...")
             if new_episode is None:
                 failed_episodes += 1
                 continue
@@ -479,6 +479,9 @@ class RearrangeEpisodeGenerator:
         logger.info(
             f"Generated {num_episodes} episodes in {num_episodes+failed_episodes} tries."
         )
+
+        for ep in generated_episodes:
+            print(f"ep scene = {ep.scene_id}")
 
         return generated_episodes
 

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -327,10 +327,13 @@ class ObjectSampler:
                         f"Successfully sampled (snapped) object placement in {num_placement_tries} tries."
                     )
                     if not is_accessible(
-                        sim,
-                        new_object.translation,
-                        self.nav_to_min_distance,
-                        self.largest_island_id,
+                        sim=sim,
+                        point=new_object.translation,
+                        # TODO: this height is hardcoded for expected robot height and should be passed down from config
+                        height=1.3,
+                        nav_to_min_distance=self.nav_to_min_distance,
+                        nav_island=self.largest_island_id,
+                        target_object_id=new_object.object_id,
                     ):
                         logger.info(
                             "   - object is not accessible from navmesh, rejecting placement."
@@ -343,10 +346,13 @@ class ObjectSampler:
                     f"Successfully sampled object placement in {num_placement_tries} tries."
                 )
                 if not is_accessible(
-                    sim,
-                    new_object.translation,
-                    self.nav_to_min_distance,
-                    self.largest_island_id,
+                    sim=sim,
+                    point=new_object.translation,
+                    # TODO: this height is hardcoded for expected robot height and should be passed down from config
+                    height=1.3,
+                    nav_to_min_distance=self.nav_to_min_distance,
+                    nav_island=self.largest_island_id,
+                    target_object_id=new_object.object_id,
                 ):
                     logger.info(
                         "   - object is not accessible from navmesh, rejecting placement."

--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -940,6 +940,8 @@ def get_navigable_receptacles(
 
     :return: The list of heuristic passing Receptacle instances.
     """
+    # The receptacle should be unoccluded from this height
+    max_access_height = 1.3
     navigable_receptacles: List[Receptacle] = []
     for receptacle in receptacles:
         obj_mgr = get_obj_manager_for_receptacle(sim, receptacle)
@@ -969,7 +971,14 @@ def get_navigable_receptacles(
         corners_accessible = True
         corners_accessible = (
             sum(
-                is_accessible(sim, point, nav_to_min_distance, nav_island)
+                is_accessible(
+                    sim=sim,
+                    point=point,
+                    height=max_access_height,
+                    nav_to_min_distance=nav_to_min_distance,
+                    nav_island=nav_island,
+                    target_object_id=receptacle_obj.object_id,
+                )
                 for point in recep_points
             )
             >= 2

--- a/habitat-lab/habitat/datasets/rearrange/samplers/scene_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/scene_sampler.py
@@ -116,5 +116,5 @@ class BalancedSceneSampler(SceneSampler):
         """
         self.cur_episode = cur_episode
         assert (
-            self.cur_episode >= self.num_episodes
+            self.cur_episode <= self.num_episodes
         ), f"Current episode index {self.cur_episode} is out of initially configured range {self.num_episodes}. BalancedSceneSampler behavior is not defined in these conditions. Initially configured number of episodes must be accurate."

--- a/scripts/hab2_bench/assert_bench.py
+++ b/scripts/hab2_bench/assert_bench.py
@@ -31,7 +31,7 @@ MINIMUM_PERFORMANCE_1_PROCESS = {
     # "idle_render": "[Idle Render Only]",
     "idle_single_camera_all": 465,
     "idle_single_camera_noconcur": 430,
-    "idle_single_camera_nosleep": 150,
+    "idle_single_camera_nosleep": 145,
     # "idle_single_camera_render": "[Idle (head-RGB) Render Only]",
     "interact_all": 40,
     "interact_noconcur": 39,


### PR DESCRIPTION
## Motivation and Context

**TL;DR:** This PR introduces a rejection sampling based approach to generate unoccluded snap points.

### Context: 
Snapping a target point to the navmesh is used in many ways throughout the rearrangement task including:
- as an accessibility check when generating object placements
- to generate nav location targets from which and agent should pick an object
- to check whether an object can be picked from an agent's position

However, standard navmesh snapping can result in a snapped point on the wrong side of obstacles (e.g. on the other side of a wall in another room) especially when snapping clutter object locations which sit off the navmesh on furniture. For example, a bowl on the back of a counter may actually be closer to the navmesh in the room sharing a wall with the counter than the kitchen floor. These error manifest in infeasible object placements and pick/place artifacts which hinder the realism of the task.

### New feature:

Adds the `unoccluded_navmesh_snap` and `snap_point_is_occluded` utility functions.
The new approach is slower than standard snapping, but still fast enough to be used within the generator loop.  

- `snap_point_is_occluded` - uses raycasting to check whether a provided point (assumed to be on the floor) has an unoccluded line to the target point. Uses a configurable height and search granularity to match agent constraints and compute limitations.
- `unoccluded_navmesh_snap` - uses `get_random_navigable_point_near` sim API call and rejection sampling with `snap_point_is_occluded` to find an approximation to the closest unoccluded snap point for a given target position. Relies on [sim PR 2221](https://github.com/facebookresearch/habitat-sim/pull/2221) for accuracy. See test section below for examples of the variance using this approximation.

### NOTE:

TODO: This PR currently includes changes in the generator to produce better episodes, but does not refactor rearrange_task or rearrange_sim to use the new functions for snapping.

## How Has This Been Tested

Local episode generation and interactive testing application.

Examples of different results returned by `unoccluded_navmesh_snap` to demonstrate approximation variance. This variance is decreased by increasing max samples and decreasing minimum distance between samples (at the cost of compute):
![unoccluded_snap_1](https://github.com/facebookresearch/habitat-lab/assets/1445143/42eb9983-ee4e-4860-ad27-ea0feb20fae1)

![unoccluded_snap_2](https://github.com/facebookresearch/habitat-lab/assets/1445143/339d4dba-a364-414b-971d-f23557b8fe87)



## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
