### PR TITLE
Enable HBAO in the sandbox tool.

### DIFF
--- a/habitat-lab/habitat/gui/replay_gui_app_renderer.py
+++ b/habitat-lab/habitat/gui/replay_gui_app_renderer.py
@@ -59,6 +59,8 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
         # TODO:  Reenable frustum culling when replay renderer issues are solved.
         if hasattr(cfg, "enable_frustum_culling"):
             cfg.enable_frustum_culling = False
+        if hasattr(cfg, "enable_hbao"):
+            cfg.enable_hbao = True
         self._replay_renderer = (
             ReplayRenderer.create_batch_replay_renderer(cfg)
             if use_batch_renderer


### PR DESCRIPTION
## Motivation and Context

This enables HBAO in the sandbox tool.
Depends on: https://github.com/facebookresearch/habitat-sim/pull/2223

![HITL_HBAO](https://github.com/facebookresearch/habitat-lab/assets/110583667/7f0ce2ab-d0ac-4034-86e8-d55c8cf0cff0)

## How Has This Been Tested

Tested locally.