### PR TITLE
Flag to enable hbao in experiments

### DIFF
--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1389,6 +1389,7 @@ class HabitatSimV0Config(HabitatBaseConfig):
     allow_sliding: bool = True
     frustum_culling: bool = True
     enable_physics: bool = False
+    enable_hbao: bool = False
     physics_config_file: str = "./data/default.physics_config.json"
     # Possibly unstable optimization for extra performance
     # with concurrent rendering


### PR DESCRIPTION
## Motivation and Context

Allows to turn on/off HBAO in the sim experiments via a new sim flag. This way we can control HBAO for experiments in habitat 3.

## How Has This Been Tested

Tested with test_rearrange, saving the observations with and without the flag turned.

## Types of changes

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!

## Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required.
