### PR TITLE
DDP Fix For Torchrun Compatibility

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/ddppo/ddp_utils.py
+++ b/habitat-baselines/habitat_baselines/rl/ddppo/ddp_utils.py
@@ -265,7 +265,7 @@ def get_distrib_size() -> Tuple[int, int, int]:
 
 
 def get_main_addr() -> str:
-    return os.environ.get("MAIN_ADDR", DEFAULT_MAIN_ADDR)
+    return os.environ.get("MASTER_ADDR", DEFAULT_MAIN_ADDR)
 
 
 def init_distrib_slurm(
@@ -292,10 +292,10 @@ def init_distrib_slurm(
 
     local_rank, world_rank, world_size = get_distrib_size()
 
-    main_port = int(os.environ.get("MAIN_PORT", DEFAULT_PORT))
+    main_port = int(os.environ.get("MASTER_PORT", DEFAULT_PORT))
     if SLURM_JOBID is not None:
         main_port += int(SLURM_JOBID) % int(
-            os.environ.get("MAIN_PORT_RANGE", DEFAULT_PORT_RANGE)
+            os.environ.get("MASTER_PORT_RANGE", DEFAULT_PORT_RANGE)
         )
     main_addr = get_main_addr()
 

--- a/habitat-baselines/habitat_baselines/rl/ddppo/multi_node_slurm.sh
+++ b/habitat-baselines/habitat_baselines/rl/ddppo/multi_node_slurm.sh
@@ -19,8 +19,8 @@
 export GLOG_minloglevel=2
 export MAGNUM_LOG=quiet
 
-MAIN_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
-export MAIN_ADDR
+MASTER_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
+export MASTER_ADDR
 
 set -x
 srun python -u -m habitat_baselines.run \

--- a/habitat-baselines/habitat_baselines/rl/ver/preemption_decider.py
+++ b/habitat-baselines/habitat_baselines/rl/ver/preemption_decider.py
@@ -329,7 +329,7 @@ class PreemptionDeciderProcess(ProcessBase):
 
     def run(self):
         if self.world_size > 1:
-            os.environ["MAIN_PORT"] = str(self.port)
+            os.environ["MASTER_PORT"] = str(self.port)
             init_distrib_slurm(backend="gloo")
             torch.distributed.barrier()
 

--- a/habitat-baselines/habitat_baselines/rl/ver/report_worker.py
+++ b/habitat-baselines/habitat_baselines/rl/ver/report_worker.py
@@ -314,7 +314,7 @@ class ReportWorkerProcess(ProcessBase):
     def run(self):
         self.device = torch.device("cpu")
         if get_distrib_size()[2] > 1:
-            os.environ["MAIN_PORT"] = str(self.port)
+            os.environ["MASTER_PORT"] = str(self.port)
             init_distrib_slurm(backend="gloo")
             torch.distributed.barrier()
 

--- a/scripts/generate_profile_shell_scripts.py
+++ b/scripts/generate_profile_shell_scripts.py
@@ -211,8 +211,8 @@ fi
 #SBATCH --open-mode=append
 export GLOG_minloglevel=2
 export MAGNUM_LOG=quiet
-MAIN_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
-export MAIN_ADDR
+MASTER_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
+export MASTER_ADDR
 set -x
 srun bash capture_profile_slurm_task.sh
 """

--- a/test/test_baseline_trainers.py
+++ b/test/test_baseline_trainers.py
@@ -78,7 +78,7 @@ def test_trainers(
     test_cfg_path, gpu2gpu, observation_transforms_overrides, mode
 ):
     # For testing with world_size=1
-    os.environ["MAIN_PORT"] = str(find_free_port())
+    os.environ["MASTER_PORT"] = str(find_free_port())
 
     test_cfg_cleaned_path = test_cfg_path.replace(
         "habitat-baselines/habitat_baselines/config/", ""
@@ -134,7 +134,7 @@ def test_ver_trainer(
     overlap_rollouts_and_learn,
 ):
     # For testing with world_size=1
-    os.environ["MAIN_PORT"] = str(find_free_port())
+    os.environ["MASTER_PORT"] = str(find_free_port())
     try:
         baselines_config = get_config(
             test_cfg_path,


### PR DESCRIPTION
## Motivation and Context

Torchrun sets `MASTER_ADDR` and `MASTER_PORT` environment variables (see [here](https://pytorch.org/docs/stable/elastic/run.html#environment-variables) for details), but Habitat sets `MAIN_ADDR` and `MAIN_PORT`. To fully work with torchrun, we need to set these same environment variables.

## How Has This Been Tested

Local testing.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!

