### PR TITLE
Current episode reset

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -92,7 +92,9 @@ class AppStateFetch(AppState):
         return self._is_remote_active_toggle
 
     def on_environment_reset(self, episode_recorder_dict):
-        self._current_episode = self._sandbox_service.env.current_episode
+        self._current_episode = (
+            self._sandbox_service.episode_helper.current_episode
+        )
         self._held_target_obj_idx = None
 
         sim = self.get_sim()

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -91,9 +91,6 @@ class AppStateFetch(AppState):
     def _is_remote_active(self):
         return self._is_remote_active_toggle
 
-    def get_num_agents(self):
-        return len(self.get_sim().agents_mgr._all_agent_data)
-
     def on_environment_reset(self, episode_recorder_dict):
         # cache the current episode and the initial agent states
         self._current_episode = self._sandbox_service.env.current_episode

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -92,7 +92,6 @@ class AppStateFetch(AppState):
         return self._is_remote_active_toggle
 
     def on_environment_reset(self, episode_recorder_dict):
-        # cache the current episode and the initial agent states
         self._current_episode = self._sandbox_service.env.current_episode
         self._held_target_obj_idx = None
 

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -17,7 +17,11 @@ from gui_avatar_switch_helper import GuiAvatarSwitchHelper
 from gui_navigation_helper import GuiNavigationHelper
 from gui_pick_helper import GuiPickHelper
 from gui_throw_helper import GuiThrowHelper
-from hablab_utils import get_agent_art_obj_transform, get_grasped_objects_idxs
+from hablab_utils import (
+    get_agent_art_obj_transform,
+    get_articulated_agent,
+    get_grasped_objects_idxs,
+)
 
 from habitat.gui.gui_input import GuiInput
 from habitat.gui.text_drawer import TextOnScreenAlignment
@@ -49,6 +53,8 @@ class AppStateFetch(AppState):
 
         self._cam_transform = None
 
+        self._current_episode = None
+        self._init_agent_states = None
         self._held_target_obj_idx = None
         self._held_hand_idx = None  # currently only used with remote_gui_input
         self._recent_reach_pos = None
@@ -90,10 +96,24 @@ class AppStateFetch(AppState):
     def _is_remote_active(self):
         return self._is_remote_active_toggle
 
+    def get_num_agents(self):
+        return len(self.get_sim().agents_mgr._all_agent_data)
+
     def on_environment_reset(self, episode_recorder_dict):
+        sim = self.get_sim()
+
+        # cache the current episode and the initial agent states
+        self._current_episode = self._sandbox_service.env.current_episode
+        self._init_agent_states = {}
+        for agent_idx in range(self.get_num_agents()):
+            articulated_agent = get_articulated_agent(sim, agent_idx)
+            self._init_agent_states[agent_idx] = (
+                articulated_agent.base_pos,
+                articulated_agent.base_rot,
+            )
+
         self._held_target_obj_idx = None
 
-        sim = self.get_sim()
         # temp_ids, _ = sim.get_targets()
         # self._target_obj_ids = [
         #     sim._scene_obj_ids[temp_id] for temp_id in temp_ids
@@ -607,6 +627,7 @@ class AppStateFetch(AppState):
         controls_str: str = ""
         if not self._hide_gui_text:
             controls_str += "ESC: exit\n"
+            controls_str += "X: reset episode\n"
             controls_str += "M: change scene\n"
             controls_str += "R + drag: rotate camera\n"
             controls_str += "Scroll: zoom\n"
@@ -742,13 +763,43 @@ class AppStateFetch(AppState):
                 )
             )
 
+    def _reset_current_episode(self):
+        # save initial agent states
+        prev_init_agent_states = self._init_agent_states
+        self._init_agent_states = {}
+
+        # reset current episode
+        # env's current_episode setter will set internal attribute
+        # _episode_from_iter_on_reset to False as a result reset
+        # will be called without the episode changing
+        self._sandbox_service.env.current_episode = self._current_episode
+        self._sandbox_service.end_episode(do_reset=True)
+
+        # restore initial agent states
+        sim = self.get_sim()
+        for agent_idx in range(self.get_num_agents()):
+            articulated_agent = get_articulated_agent(sim, agent_idx)
+            prev_pos, prev_rot = prev_init_agent_states[agent_idx]
+            articulated_agent.base_pos = prev_pos
+            articulated_agent.base_rot = float(prev_rot)
+        self._init_agent_states = prev_init_agent_states
+
+    def _set_next_episode(self):
+        self._sandbox_service.end_episode(do_reset=True)
+
+    def _end_episode(self):
+        self._sandbox_service.end_episode(do_reset=False)
+
     def sim_update(self, dt, post_sim_update_dict):
         if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.ESC):
-            self._sandbox_service.end_episode()
+            self._end_episode()
             post_sim_update_dict["application_exit"] = True
 
         if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.M):
-            self._sandbox_service.end_episode(do_reset=True)
+            self._set_next_episode()
+
+        if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.X):
+            self._reset_current_episode()
 
         if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.P):
             self._paused = not self._paused

--- a/examples/siro_sandbox/configs/fetch.yaml
+++ b/examples/siro_sandbox/configs/fetch.yaml
@@ -112,6 +112,10 @@ habitat:
 
   environment:
     max_episode_steps: 1000
+    iterator_options:
+        cycle: True
+        group_by_scene: True
+        max_scene_repeat_episodes: 1
   gym:
     obs_keys:
       # - agent_0_head_depth

--- a/examples/siro_sandbox/episode_helper.py
+++ b/examples/siro_sandbox/episode_helper.py
@@ -2,12 +2,17 @@ class EpisodeHelper:
     def __init__(self, habitat_env):
         self._habitat_env = habitat_env
 
-        self._num_iter_episodes: int = len(self._habitat_env.episode_iterator.episodes)  # type: ignore
+        self._episode_iterator_cycle = habitat_env.episode_iterator.cycle
+        self._num_iter_episodes: int = len(habitat_env.episode_iterator.episodes)  # type: ignore
         self._num_episodes_done: int = 0
 
     @property
     def num_iter_episodes(self):
-        return self._num_iter_episodes
+        return (
+            self._num_iter_episodes
+            if not self._episode_iterator_cycle
+            else float("inf")
+        )
 
     @property
     def num_episodes_done(self):
@@ -18,8 +23,8 @@ class EpisodeHelper:
         return self._habitat_env.current_episode
 
     def next_episode_exists(self):
-        return self._num_episodes_done < self._num_iter_episodes - 1
+        return self.num_episodes_done < self.num_iter_episodes - 1
 
     def increment_done_episode_counter(self):
         self._num_episodes_done += 1
-        assert self._num_episodes_done <= self._num_iter_episodes
+        assert self.num_episodes_done <= self.num_iter_episodes

--- a/examples/siro_sandbox/hablab_utils.py
+++ b/examples/siro_sandbox/hablab_utils.py
@@ -7,15 +7,18 @@
 # Utilities built on top of Habitat-lab
 
 
-def get_agent_art_obj(sim, agent_idx):
+def get_articulated_agent(sim, agent_idx):
     assert agent_idx is not None
-    art_obj = sim.agents_mgr[agent_idx].articulated_agent.sim_obj
-    return art_obj
+    return sim.agents_mgr[agent_idx].articulated_agent
+
+
+def get_agent_art_obj(sim, agent_idx):
+    articulated_agent = get_articulated_agent(sim, agent_idx)
+    return articulated_agent.sim_obj
 
 
 def get_agent_art_obj_transform(sim, agent_idx):
-    assert agent_idx is not None
-    art_obj = sim.agents_mgr[agent_idx].articulated_agent.sim_obj
+    art_obj = get_agent_art_obj(sim, agent_idx)
     return art_obj.transformation
 
 


### PR DESCRIPTION
## Motivation and Context

Adds current episode reset functionality ([Asana task](https://app.asana.com/0/1205684818278379/1205617988863636)). 
- M to go to next episode (new episode with new scene), with cycling
- X to restart (same exact episode). Note, that at reset agents positions are set randomly (this is Habitat-lab reset works).

## How Has This Been Tested
Launching SandboxApp locally on MacBook Pro 2021.

https://github.com/facebookresearch/habitat-lab/assets/37709869/77ef1939-dcc2-4423-8eb9-722b5b93a246

First part of the video - current episode reset (X), second part of the video - new episode with new scene reset (M).

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **Development:** PR into  `eundersander/SIRo_hitl_Sep5_demo_refactored`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
