### PR TITLE
Replace deprecated torch.norm

### DIFF
--- a/habitat-baselines/habitat_baselines/common/obs_transformers.py
+++ b/habitat-baselines/habitat_baselines/common/obs_transformers.py
@@ -400,7 +400,7 @@ class PerspectiveProjection(CameraProjection):
         z = torch.full_like(x, self.f, dtype=torch.float)
         unproj_pts = torch.stack([x, y, z], dim=-1)
         # Project on unit shpere
-        unproj_pts /= torch.norm(unproj_pts, dim=-1, keepdim=True)
+        unproj_pts /= torch.linalg.norm(unproj_pts, dim=-1, keepdim=True)
         # All points in image are valid
         valid_mask = torch.full(unproj_pts.shape[:2], True, dtype=torch.bool)
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/art_obj.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/art_obj.py
@@ -43,7 +43,7 @@ class ArtObjSkillPolicy(NnSkillPolicy):
         cur_resting_pos = observations[RelativeRestingPositionSensor.cls_uuid]
 
         did_leave_start_zone = (
-            torch.norm(
+            torch.linalg.vector_norm(
                 cur_resting_pos - self._episode_start_resting_pos, dim=-1
             )
             > self._config.start_zone_radius
@@ -52,7 +52,7 @@ class ArtObjSkillPolicy(NnSkillPolicy):
             self._did_leave_start_zone, did_leave_start_zone
         )
 
-        cur_resting_dist = torch.norm(
+        cur_resting_dist = torch.linalg.vector_norm(
             observations[RelativeRestingPositionSensor.cls_uuid], dim=-1
         )
         is_within_thresh = cur_resting_dist < self._config.at_resting_threshold

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/pick.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/pick.py
@@ -23,7 +23,7 @@ class PickSkillPolicy(NnSkillPolicy):
     ) -> torch.BoolTensor:
         # Is the agent holding the object and is the end-effector at the
         # resting position?
-        rel_resting_pos = torch.norm(
+        rel_resting_pos = torch.linalg.vector_norm(
             observations[RelativeRestingPositionSensor.cls_uuid], dim=-1
         )
         is_within_thresh = rel_resting_pos < self._config.at_resting_threshold

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/place.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/place.py
@@ -35,7 +35,7 @@ class PlaceSkillPolicy(PickSkillPolicy):
     ) -> torch.BoolTensor:
         # Is the agent not holding an object and is the end-effector at the
         # resting position?
-        rel_resting_pos = torch.norm(
+        rel_resting_pos = torch.linalg.vector_norm(
             observations[RelativeRestingPositionSensor.cls_uuid], dim=-1
         )
         is_within_thresh = rel_resting_pos < self._config.at_resting_threshold

--- a/test/test_rnn_state_encoder.py
+++ b/test/test_rnn_state_encoder.py
@@ -87,8 +87,8 @@ def test_rnn_state_encoder():
                 )
 
                 assert (
-                    torch.norm(reference_outputs - outputs) < 0.001
+                    torch.linalg.norm(reference_outputs - outputs) < 0.001
                 ), "Failed on (T={}, N={})".format(T, N)
                 assert (
-                    torch.norm(reference_hiddens - out_hiddens) < 0.001
+                    torch.linalg.norm(reference_hiddens - out_hiddens) < 0.001
                 ), "Failed on (T={}, N={})".format(T, N)


### PR DESCRIPTION
## Motivation and Context

Replace deprecated torch.norm with torch.linalg methods (from issue #1460).

## How Has This Been Tested

Ran ```pytest test``` (includes tests for changed modules).

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Small change into main.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
