### PR TITLE
Add server->client messaging to the sandbox app + object highlights.

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -514,16 +514,12 @@ class AppStateFetch(AppState):
             )
 
     def _get_target_object_position(self, target_obj_idx):
-        sim = self.get_sim()
-        rom = sim.get_rigid_object_manager()
-        object_id = self._target_obj_ids[target_obj_idx]
-        return rom.get_object_by_id(object_id).translation
+        return self._get_target_rigid_object(target_obj_idx).translation
 
     def _get_target_object_bounding_box(self, target_obj_idx) -> mn.Range3D:
-        sim = self.get_sim()
-        rom = sim.get_rigid_object_manager()
-        object_id = self._target_obj_ids[target_obj_idx]
-        return rom.get_object_by_id(object_id).collision_shape_aabb
+        return self._get_target_rigid_object(
+            target_obj_idx
+        ).collision_shape_aabb
 
     def _get_target_object_positions(self):
         sim = self.get_sim()

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -557,14 +557,10 @@ class AppStateFetch(AppState):
             )
             # color = mn.Color4(color.r, color.g, color.b, 1.0 - self._sandbox_service.get_anim_fraction())
 
-        num_segments = 24
+        if self._sandbox_service.messaging_service:
+            self._sandbox_service.messaging_service.add_highlight(pos)
 
-        self._sandbox_service.line_render.draw_circle(
-            pos,
-            radius,
-            color,
-            num_segments,
-        )
+        self._draw_circle(pos, color, radius)
 
     def _viz_objects(self):
         # grasped_objects_idxs = get_grasped_objects_idxs(self.get_sim())

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -560,11 +560,11 @@ class AppStateFetch(AppState):
             # color = mn.Color4(color.r, color.g, color.b, 1.0 - self._sandbox_service.get_anim_fraction())
 
         if self._sandbox_service.messaging_service:
-            # Radius is defined as the largest bounding box extent.
+            # Radius is defined as half the largest bounding box extent.
             bb: mn.Range3D = self._get_target_object_bounding_box(
                 target_obj_idx
             )
-            radius = max(bb.size_x(), bb.size_y(), bb.size_z())
+            radius = max(bb.size_x(), bb.size_y(), bb.size_z()) / 2
             self._sandbox_service.messaging_service.add_highlight(pos, radius)
 
         self._draw_circle(pos, color, radius)

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -518,7 +518,7 @@ class AppStateFetch(AppState):
         rom = sim.get_rigid_object_manager()
         object_id = self._target_obj_ids[target_obj_idx]
         return rom.get_object_by_id(object_id).translation
-    
+
     def _get_target_object_bounding_box(self, target_obj_idx) -> mn.Range3D:
         sim = self.get_sim()
         rom = sim.get_rigid_object_manager()
@@ -565,7 +565,9 @@ class AppStateFetch(AppState):
 
         if self._sandbox_service.messaging_service:
             # Radius is defined as the largest bounding box extent.
-            bb: mn.Range3D = self._get_target_object_bounding_box(target_obj_idx)
+            bb: mn.Range3D = self._get_target_object_bounding_box(
+                target_obj_idx
+            )
             radius = max(bb.size_x(), bb.size_y(), bb.size_z())
             self._sandbox_service.messaging_service.add_highlight(pos, radius)
 

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -518,6 +518,12 @@ class AppStateFetch(AppState):
         rom = sim.get_rigid_object_manager()
         object_id = self._target_obj_ids[target_obj_idx]
         return rom.get_object_by_id(object_id).translation
+    
+    def _get_target_object_bounding_box(self, target_obj_idx) -> mn.Range3D:
+        sim = self.get_sim()
+        rom = sim.get_rigid_object_manager()
+        object_id = self._target_obj_ids[target_obj_idx]
+        return rom.get_object_by_id(object_id).collision_shape_aabb
 
     def _get_target_object_positions(self):
         sim = self.get_sim()
@@ -558,7 +564,10 @@ class AppStateFetch(AppState):
             # color = mn.Color4(color.r, color.g, color.b, 1.0 - self._sandbox_service.get_anim_fraction())
 
         if self._sandbox_service.messaging_service:
-            self._sandbox_service.messaging_service.add_highlight(pos)
+            # Radius is defined as the largest bounding box extent.
+            bb: mn.Range3D = self._get_target_object_bounding_box(target_obj_idx)
+            radius = max(bb.size_x(), bb.size_y(), bb.size_z())
+            self._sandbox_service.messaging_service.add_highlight(pos, radius)
 
         self._draw_circle(pos, color, radius)
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -64,6 +64,7 @@ from sandbox_service import SandboxService
 from server.interprocess_record import InterprocessRecord
 from server.remote_gui_input import RemoteGuiInput
 from server.server import launch_server_process, terminate_server_process
+from server.messaging_service import MessagingService
 
 # Please reach out to the paper authors to obtain this file
 DEFAULT_POSE_PATH = (
@@ -151,6 +152,10 @@ class SandboxDriver(GuiAppDriver):
         def local_end_episode(do_reset=False):
             self._end_episode(do_reset)
 
+        self._messaging_service = None
+        if self.do_network_server:
+            self._messaging_service = MessagingService()
+
         self._sandbox_service = SandboxService(
             args,
             config,
@@ -168,6 +173,7 @@ class SandboxDriver(GuiAppDriver):
             partial(self._set_cursor_style),
             self._episode_helper,
             partial(self._get_observation_as_debug_image),
+            self._messaging_service,
         )
 
         self._app_states: List[AppState]
@@ -528,6 +534,7 @@ class SandboxDriver(GuiAppDriver):
                 obj = json.loads(keyframe_json)
                 assert "keyframe" in obj
                 keyframe_obj = obj["keyframe"]
+                self._messaging_service.add_message_to_keyframe(keyframe_obj)
                 self._interprocess_record.send_keyframe_to_networking_thread(
                     keyframe_obj
                 )

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -61,8 +61,8 @@ from app_states.app_state_rearrange import AppStateRearrange
 from app_states.app_state_socialnav import AppStateSocialNav
 from app_states.app_state_tutorial import AppStateTutorial
 from sandbox_service import SandboxService
+from server.client_message_manager import ClientMessageManager
 from server.interprocess_record import InterprocessRecord
-from server.messaging_service import MessagingService
 from server.remote_gui_input import RemoteGuiInput
 from server.server import launch_server_process, terminate_server_process
 
@@ -152,9 +152,9 @@ class SandboxDriver(GuiAppDriver):
         def local_end_episode(do_reset=False):
             self._end_episode(do_reset)
 
-        self._messaging_service = None
+        self._client_message_manager = None
         if self.do_network_server:
-            self._messaging_service = MessagingService()
+            self._client_message_manager = ClientMessageManager()
 
         self._sandbox_service = SandboxService(
             args,
@@ -173,7 +173,7 @@ class SandboxDriver(GuiAppDriver):
             partial(self._set_cursor_style),
             self._episode_helper,
             partial(self._get_observation_as_debug_image),
-            self._messaging_service,
+            self._client_message_manager,
         )
 
         self._app_states: List[AppState]
@@ -534,7 +534,12 @@ class SandboxDriver(GuiAppDriver):
                 obj = json.loads(keyframe_json)
                 assert "keyframe" in obj
                 keyframe_obj = obj["keyframe"]
-                self._messaging_service.add_message_to_keyframe(keyframe_obj)
+                # Insert server->client message into the keyframe
+                message = self._client_message_manager.get_message_dict()
+                if len(message) > 0:
+                    keyframe_obj["message"] = message
+                    self._client_message_manager.clear_message_dict()
+                # Send the keyframe
                 self._interprocess_record.send_keyframe_to_networking_thread(
                     keyframe_obj
                 )

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -62,9 +62,9 @@ from app_states.app_state_socialnav import AppStateSocialNav
 from app_states.app_state_tutorial import AppStateTutorial
 from sandbox_service import SandboxService
 from server.interprocess_record import InterprocessRecord
+from server.messaging_service import MessagingService
 from server.remote_gui_input import RemoteGuiInput
 from server.server import launch_server_process, terminate_server_process
-from server.messaging_service import MessagingService
 
 # Please reach out to the paper authors to obtain this file
 DEFAULT_POSE_PATH = (

--- a/examples/siro_sandbox/sandbox_service.py
+++ b/examples/siro_sandbox/sandbox_service.py
@@ -25,7 +25,7 @@ class SandboxService:
         set_cursor_style,
         episode_helper,
         get_observation_as_debug_image,
-        messaging_service
+        messaging_service,
     ):
         self._args = args
         self._config = config
@@ -108,7 +108,7 @@ class SandboxService:
     @property
     def get_observation_as_debug_image(self):
         return self._get_observation_as_debug_image
-    
+
     @property
     def messaging_service(self):
         return self._messaging_service

--- a/examples/siro_sandbox/sandbox_service.py
+++ b/examples/siro_sandbox/sandbox_service.py
@@ -25,6 +25,7 @@ class SandboxService:
         set_cursor_style,
         episode_helper,
         get_observation_as_debug_image,
+        messaging_service
     ):
         self._args = args
         self._config = config
@@ -42,6 +43,7 @@ class SandboxService:
         self._set_cursor_style = set_cursor_style
         self._episode_helper = episode_helper
         self._get_observation_as_debug_image = get_observation_as_debug_image
+        self._messaging_service = messaging_service
 
     @property
     def args(self):
@@ -106,3 +108,7 @@ class SandboxService:
     @property
     def get_observation_as_debug_image(self):
         return self._get_observation_as_debug_image
+    
+    @property
+    def messaging_service(self):
+        return self._messaging_service

--- a/examples/siro_sandbox/server/client_message_manager.py
+++ b/examples/siro_sandbox/server/client_message_manager.py
@@ -7,7 +7,7 @@
 from typing import Dict, List
 
 
-class MessagingService:
+class ClientMessageManager:
     r"""
     Extends gfx-replay keyframes to include server messages to be interpreted by the client.
     """
@@ -19,6 +19,12 @@ class MessagingService:
         Add a field to this dict to send a message to the client at the end of the frame.
         """
         return self._message
+
+    def clear_message_dict(self) -> None:
+        r"""
+        Resets the message dict.
+        """
+        self._message = {}
 
     def add_highlight(self, pos: List[float], radius: float) -> None:
         r"""
@@ -32,11 +38,3 @@ class MessagingService:
         self._message["highlights"].append(
             {"t": [pos[0], pos[1], pos[2]], "r": radius}
         )
-
-    def add_message_to_keyframe(self, keyframe_obj) -> None:
-        r"""
-        Adds the server message to the specified keyframe.
-        Clears the server message.
-        """
-        keyframe_obj["message"] = self._message
-        self._message = {}

--- a/examples/siro_sandbox/server/messaging_service.py
+++ b/examples/siro_sandbox/server/messaging_service.py
@@ -27,7 +27,7 @@ class MessagingService:
         assert pos
         assert len(pos) == 3
 
-        if not "highlights" in self._message:
+        if "highlights" not in self._message:
             self._message["highlights"] = []
         self._message["highlights"].append(
             {"t": [pos[0], pos[1], pos[2]], "r": radius}

--- a/examples/siro_sandbox/server/messaging_service.py
+++ b/examples/siro_sandbox/server/messaging_service.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, List
+
+class MessagingService():
+    r"""
+    Extends gfx-replay keyframes to include server messages to be interpreted by the client.
+    """
+    _message: Dict = {}
+
+    def get_message_dict(self) -> Dict:
+        r"""
+        Get the server message to be communicated to the client.
+        Add a field to this dict to send a message to the client at the end of the frame.
+        """
+        return self._message
+
+    def add_highlight(self, pos: List[float]) -> None:
+        r"""
+        Draw a highlight circle around the specified position.
+        """
+        assert pos
+        assert len(pos) == 3
+
+        if not "highlights" in self._message:
+            self._message["highlights"] = []
+        self._message["highlights"].append({"t": [pos[0], pos[1], pos[2]]})
+
+    def add_message_to_keyframe(self, keyframe_obj) -> None:
+        r"""
+        Adds the server message to the specified keyframe.
+        Clears the server message.
+        """
+        keyframe_obj["message"] = self._message
+        self._message = {}

--- a/examples/siro_sandbox/server/messaging_service.py
+++ b/examples/siro_sandbox/server/messaging_service.py
@@ -6,7 +6,8 @@
 
 from typing import Dict, List
 
-class MessagingService():
+
+class MessagingService:
     r"""
     Extends gfx-replay keyframes to include server messages to be interpreted by the client.
     """
@@ -28,7 +29,9 @@ class MessagingService():
 
         if not "highlights" in self._message:
             self._message["highlights"] = []
-        self._message["highlights"].append({"t": [pos[0], pos[1], pos[2]], "r": radius})
+        self._message["highlights"].append(
+            {"t": [pos[0], pos[1], pos[2]], "r": radius}
+        )
 
     def add_message_to_keyframe(self, keyframe_obj) -> None:
         r"""

--- a/examples/siro_sandbox/server/messaging_service.py
+++ b/examples/siro_sandbox/server/messaging_service.py
@@ -19,7 +19,7 @@ class MessagingService():
         """
         return self._message
 
-    def add_highlight(self, pos: List[float]) -> None:
+    def add_highlight(self, pos: List[float], radius: float) -> None:
         r"""
         Draw a highlight circle around the specified position.
         """
@@ -28,7 +28,7 @@ class MessagingService():
 
         if not "highlights" in self._message:
             self._message["highlights"] = []
-        self._message["highlights"].append({"t": [pos[0], pos[1], pos[2]]})
+        self._message["highlights"].append({"t": [pos[0], pos[1], pos[2]], "r": radius})
 
     def add_message_to_keyframe(self, keyframe_obj) -> None:
         r"""


### PR DESCRIPTION
## Motivation and Context

This changeset adds the capability to send custom messages from the server to the client.

This works by extending the `gfx-replay` keyframe with a custom `message` dict. This dict can be mutated via the `MessagingService` class in the sandbox app.

A first message is implemented, which adds object highlights. Here's the feature shown from the Unity client:
![image](https://github.com/facebookresearch/habitat-lab/assets/110583667/c8e944c1-112b-43de-bf10-4a85a73d9b4e)
Video:
https://github.com/facebookresearch/habitat-lab/assets/110583667/ce35f6e3-ab47-49a2-ac85-1b746b610fc8

## How Has This Been Tested

Tested locally.