### PR TITLE
Sync client player on episode change.

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -111,6 +111,10 @@ class AppStateFetch(AppState):
         self._camera_helper.update(self._get_camera_lookat_pos(), dt=0)
         self.count_tsteps_stop = 0
 
+        self._sandbox_service.client_message_manager.change_humanoid_position(
+            self._gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+        )
+
     def get_sim(self):
         return self._sandbox_service.sim
 
@@ -559,13 +563,15 @@ class AppStateFetch(AppState):
             )
             # color = mn.Color4(color.r, color.g, color.b, 1.0 - self._sandbox_service.get_anim_fraction())
 
-        if self._sandbox_service.messaging_service:
+        if self._sandbox_service.client_message_manager:
             # Radius is defined as half the largest bounding box extent.
             bb: mn.Range3D = self._get_target_object_bounding_box(
                 target_obj_idx
             )
             radius = max(bb.size_x(), bb.size_y(), bb.size_z()) / 2
-            self._sandbox_service.messaging_service.add_highlight(pos, radius)
+            self._sandbox_service.client_message_manager.add_highlight(
+                pos, radius
+            )
 
         self._draw_circle(pos, color, radius)
 

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -111,9 +111,10 @@ class AppStateFetch(AppState):
         self._camera_helper.update(self._get_camera_lookat_pos(), dt=0)
         self.count_tsteps_stop = 0
 
-        self._sandbox_service.client_message_manager.change_humanoid_position(
-            self._gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
-        )
+        if self._sandbox_service.client_message_manager:
+            self._sandbox_service.client_message_manager.change_humanoid_position(
+                self._gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
+            )
 
     def get_sim(self):
         return self._sandbox_service.sim

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -353,7 +353,7 @@ class SandboxDriver(GuiAppDriver):
         self._obs, self._metrics = self.gym_habitat_env.reset(return_info=True)
 
         if self.do_network_server:
-            self._remote_gui_input.on_reset()
+            self._remote_gui_input.clear_history()
 
         self.ctrl_helper.on_environment_reset()
 

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -352,6 +352,9 @@ class SandboxDriver(GuiAppDriver):
     def _reset_environment(self):
         self._obs, self._metrics = self.gym_habitat_env.reset(return_info=True)
 
+        if self.do_network_server:
+            self._remote_gui_input.on_reset()
+
         self.ctrl_helper.on_environment_reset()
 
         if self._save_episode_record:

--- a/examples/siro_sandbox/sandbox_service.py
+++ b/examples/siro_sandbox/sandbox_service.py
@@ -25,7 +25,7 @@ class SandboxService:
         set_cursor_style,
         episode_helper,
         get_observation_as_debug_image,
-        messaging_service,
+        client_message_manager,
     ):
         self._args = args
         self._config = config
@@ -43,7 +43,7 @@ class SandboxService:
         self._set_cursor_style = set_cursor_style
         self._episode_helper = episode_helper
         self._get_observation_as_debug_image = get_observation_as_debug_image
-        self._messaging_service = messaging_service
+        self._client_message_manager = client_message_manager
 
     @property
     def args(self):
@@ -110,5 +110,5 @@ class SandboxService:
         return self._get_observation_as_debug_image
 
     @property
-    def messaging_service(self):
-        return self._messaging_service
+    def client_message_manager(self):
+        return self._client_message_manager

--- a/examples/siro_sandbox/server/client_message_manager.py
+++ b/examples/siro_sandbox/server/client_message_manager.py
@@ -38,3 +38,10 @@ class ClientMessageManager:
         self._message["highlights"].append(
             {"t": [pos[0], pos[1], pos[2]], "r": radius}
         )
+
+    def change_humanoid_position(self, pos: List[float]) -> None:
+        r"""
+        Change the position of the humanoid.
+        Used to synchronize the humanoid position in the client when changing scene.
+        """
+        self._message["humanoidPosition"] = [pos[0], pos[1], pos[2]]

--- a/examples/siro_sandbox/server/client_message_manager.py
+++ b/examples/siro_sandbox/server/client_message_manager.py
@@ -44,4 +44,4 @@ class ClientMessageManager:
         Change the position of the humanoid.
         Used to synchronize the humanoid position in the client when changing scene.
         """
-        self._message["humanoidPosition"] = [pos[0], pos[1], pos[2]]
+        self._message["teleportAvatarBasePosition"] = [pos[0], pos[1], pos[2]]

--- a/examples/siro_sandbox/server/remote_gui_input.py
+++ b/examples/siro_sandbox/server/remote_gui_input.py
@@ -260,3 +260,6 @@ class RemoteGuiInput:
 
     def on_frame_end(self):
         self._gui_input.on_frame_end()
+
+    def on_reset(self):
+        self._recent_client_states.clear()

--- a/examples/siro_sandbox/server/remote_gui_input.py
+++ b/examples/siro_sandbox/server/remote_gui_input.py
@@ -261,5 +261,5 @@ class RemoteGuiInput:
     def on_frame_end(self):
         self._gui_input.on_frame_end()
 
-    def on_reset(self):
+    def clear_history(self):
         self._recent_client_states.clear()


### PR DESCRIPTION
## Motivation and Context

This sends the position of the humanoid to the client to that it can reposition the VR controller.
This avoid spawning the VR controller outside of the scene, or forcing the humanoid to catch back the controller at the start of an episode.

## How Has This Been Tested

Tested locally.
