### PR TITLE
Reduce network send rate to 10 Hz

### DIFF
--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -234,7 +234,8 @@ class SandboxDriver(GuiAppDriver):
             # How many frames we can simulate "ahead" of what keyframes have been sent.
             # A larger value increases lag on the client, while ensuring a more reliable
             # simulation rate in the presence of unreliable network comms.
-            max_steps_ahead = 3
+            # See also server.py max_send_rate
+            max_steps_ahead = 5
             self._interprocess_record = InterprocessRecord(max_steps_ahead)
             launch_server_process(self._interprocess_record)
             self._remote_gui_input = RemoteGuiInput(


### PR DESCRIPTION
## Motivation and Context

This feature gives us the ability to choose the send rate, and I set to 10 Hz for now. See also [this PR](https://github.com/eundersander/siro_hitl_unity_client/pull/15) that introduces interpolation on the client, which very effectively hides a low keyframe send rate.

## How Has This Been Tested

Testing with VR emulator and Quest Pro

## Types of changes

PR into demo branch

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
