### PR TITLE
[CI] - ignore all hab3 bench configs in tests

### DIFF
--- a/test/test_rearrange_task.py
+++ b/test/test_rearrange_task.py
@@ -157,6 +157,8 @@ NO_TEST_CONFIGS = [
     "habitat-lab/habitat/config/benchmark/rearrange/hab3_bench/multi_agent_bench.yaml",
     "habitat-lab/habitat/config/benchmark/rearrange/hab3_bench/spot_spot_oracle.yaml",
     "habitat-lab/habitat/config/benchmark/rearrange/hab3_bench/spot_oracle.yaml",
+    "habitat-lab/habitat/config/benchmark/rearrange/hab3_bench/humanoid_oracle.yaml",
+    "habitat-lab/habitat/config/benchmark/rearrange/hab3_bench/spot_humanoid_oracle.yaml",
 ]
 for config_file_name in NO_TEST_CONFIGS:
     TEST_CFG_PATHS.remove(config_file_name)


### PR DESCRIPTION
## Motivation and Context

All hab3 bench configs have some defaults or dataset requirements which fail tests on CI. Removing remaining configs from test config list.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
