### PR TITLE
[bugfix v0.3.0]: check for MotionType.DYNAMIC before trying to set joint motors

### DIFF
--- a/habitat-lab/habitat/articulated_agents/manipulator.py
+++ b/habitat-lab/habitat/articulated_agents/manipulator.py
@@ -312,13 +312,16 @@ class Manipulator(ArticulatedAgentInterface):
 
     def set_gripper_target_state(self, gripper_state: float) -> None:
         """Set the gripper motors to a desired symmetric state of the gripper [0,1] -> [open, closed]"""
-        for i, jidx in enumerate(self.params.gripper_joints):
-            delta = (
-                self.params.gripper_closed_state[i]
-                - self.params.gripper_open_state[i]
-            )
-            target = self.params.gripper_open_state[i] + delta * gripper_state
-            self._set_motor_pos(jidx, target)
+        if self.sim_obj.motion_type == MotionType.DYNAMIC:
+            for i, jidx in enumerate(self.params.gripper_joints):
+                delta = (
+                    self.params.gripper_closed_state[i]
+                    - self.params.gripper_open_state[i]
+                )
+                target = (
+                    self.params.gripper_open_state[i] + delta * gripper_state
+                )
+                self._set_motor_pos(jidx, target)
 
     def close_gripper(self) -> None:
         """Set gripper to the close state"""
@@ -418,9 +421,9 @@ class Manipulator(ArticulatedAgentInterface):
     def arm_motor_pos(self, ctrl: List[float]) -> None:
         """Set the desired target of the arm joint motors."""
         self._validate_arm_ctrl_input(ctrl)
-
-        for i, jidx in enumerate(self.params.arm_joints):
-            self._set_motor_pos(jidx, ctrl[i])
+        if self.sim_obj.motion_type == MotionType.DYNAMIC:
+            for i, jidx in enumerate(self.params.arm_joints):
+                self._set_motor_pos(jidx, ctrl[i])
 
     @property
     def arm_motor_forces(self) -> np.ndarray:

--- a/habitat-lab/habitat/tasks/rearrange/actions/actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/actions.py
@@ -29,6 +29,7 @@ from habitat.tasks.rearrange.actions.grip_actions import (
 )
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
 from habitat.tasks.rearrange.utils import rearrange_collision, rearrange_logger
+from habitat_sim.physics import MotionType
 
 
 @registry.register_task_action
@@ -146,9 +147,13 @@ class ArmRelPosAction(ArticulatedAgentAction):
 
         # The actual joint positions
         self._sim: RearrangeSim
-        self.cur_articulated_agent.arm_motor_pos = (
-            delta_pos + self.cur_articulated_agent.arm_motor_pos
-        )
+        if (
+            self.cur_articulated_agent.sim_obj.motion_type
+            == MotionType.DYNAMIC
+        ):
+            self.cur_articulated_agent.arm_motor_pos = (
+                delta_pos + self.cur_articulated_agent.arm_motor_pos
+            )
 
 
 @registry.register_task_action


### PR DESCRIPTION
## Motivation and Context

#1639 added an optimization to remove joint motors for kinematic mode. However, some actions expect joint motors to function and some social rearrangement configs were mixing dynamic actions with kinematic mode causing errors.

This PR introduces MotionType checks gating joint setters in the erroneous actions.

Future refactor TODO:
Ideally, this kind of motor-only action space should never be configured in kinematic mode since it does nothing. Config action validation could check for this mix of modes and assert instead of silently working.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
