### PR TITLE
WIP HITL multiprocessing speedup

### DIFF
--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -584,6 +584,176 @@ def _parse_debug_third_person(args, framebuffer_size):
     return do_show, width, height
 
 
+# todo: move all MultiprocessDriverWrapper-related code (below) to separate file
+import threading
+
+# This import is needed to register pickle functions for types, even though we don't
+# reference it here.
+import serialize_utils  # noqa: F401
+from server import multiprocessing_config
+from server.multiprocessing_config import Queue
+
+
+class DummyClass:
+    def __getattr__(self, attr):
+        # Define a default method that does nothing
+        def dummy_method(*args, **kwargs):
+            pass
+
+        return dummy_method
+
+
+class MyInterprocessRecord:
+    def __init__(self):
+        self.post_sim_update_dict_queue = Queue()
+        self.sim_input_queue = Queue()
+
+
+class MultiprocessDriverWrapper(GuiAppDriver):
+    """
+    This is a wrapper intended to be used with SandboxDriver (or any GuiAppDriver).
+    It creates a separate "sim process" to run the driver, with the goal to overlap
+    (1) sim-updating and (2) rendering in ReplayGuiAppRenderer (used by GuiApplication).
+
+    "sim-updating" here refers to everything that SandboxDriver does: AppState logic,
+    habitat-lab model inference, habitat-sim simulation-stepping, habitat-sim rendering,
+    etc. "rendering in ReplayGuiAppRenderer" refers to rendering the main HITL tool
+    viewport. Note that sim-updating is currently much more expensive than rendering
+    in ReplayGuiAppRenderer, so the runtime bottleneck is currently the sim process.
+
+    A note about OpenGL and rendering: it is generally unsafe to use OpenGL in multiple
+    threads in the same process (habitat-sim does it by carefully protecting and
+    sharing the OpenGL context). However, MultiprocessDriverWrapper completely avoids
+    this complexity because we are spawning a separate *process*.
+
+    Let's review how a GuiApplication frame is executed with MultiprocessDriverWrapper:
+    1. We have a "main" process and a "sim" process (spawned in
+        MultiprocessDriverWrapper.__init__).
+    2. Interprocess comms here are (a) a sim_input_queue for pushing GuiInput from the
+        main process to the sim process, and (b) a post_sim_update_dict_queue for
+        pushing gfx-replay keyframes and other sim outputs from the sim process to
+        the main process.
+    3. At startup, MultiprocessDriverWrapper pushes an empty/dummy GuiInput to
+        sim_input_queue.
+    4. The sim process initializes (sim_process_main), including constructing a
+        SandboxDriver.
+    5. sim_process_main will enter its core loop. It will immediately get its first
+        GuiInput from sim_input_queue, do a single sim update, and push a single
+        post_sim_update_dict. It will then block and wait for another GuiInput.
+    6. On the main process, every frame starts with GuiApplication.draw_event. At this
+        point, the latest GuiInput has been updated on the main process due to other
+        GuiApplication callbacks that ran earlier based on OS input events.
+    7. Here, we call into MultiprocessDriverWrapper.sim_update. We push the latest
+        GuiInput immediately. Then we block and wait for a new post_sim_update_dict
+        from the sim process. Here, a side note: the order of these two may feel
+        conceptually wrong; a new post_sim_update_dict should *already* be available,
+        so why should we first push a new GuiInput? Empirically, we get a much better
+        speedup doing things in this order. One explanation is that pushing/getting on
+        python multiprocess queues is actually quite slow (due to required
+        serialization), so somehow doing things in this order prevents a stall on the
+        sim process.
+    8. On the main process, the post_sim_update_dict is returned to GuiApplication
+        and eventually used for rendering in ReplayGuiAppRenderer. Meanwhile, on the
+        sim process, the next sim update is executing concurrently.
+    """
+
+    def __init__(self, args, config, gui_input):
+        # multiprocessing.dummy.Process is actually a thread and requires special logic
+        # to terminate it.
+        self._exit_event: Any = (
+            threading.Event() if multiprocessing_config.use_dummy else None
+        )
+
+        # This code is untested with dummy multiprocessing. I anticipate problems with
+        # using OpenGL on 2+ threads in the same process. We probably just can't
+        # support using MultiprocessDriverWrapper with dummy multiprocessing (which
+        # is fine; dummy multiprocessing is more for debugging).
+        assert not multiprocessing_config.use_dummy
+
+        self._interprocess_record = MyInterprocessRecord()
+
+        self._server_process = multiprocessing_config.Process(
+            target=self.sim_process_main,
+            args=(args, config, self._interprocess_record, self._exit_event),
+        )
+        self._server_process.start()
+
+        self._main_process_gui_input = gui_input
+
+        self._interprocess_record.sim_input_queue.put(
+            self._main_process_gui_input
+        )
+
+    @classmethod
+    def sim_process_main(cls, args, config, interprocess_record, exit_event):
+        pass
+
+        sim_gui_input = GuiInput()
+
+        # todo: figure out text-drawing and line-rendering. Unlike the single-threaded
+        # case, we can't directly share ReplayGuiAppRenderer's TextDrawer and
+        # DebugLineRenderer. For now, these dummy classes will allow SandboxDriver
+        # to run without error, but text and debug lines won't be rendered.
+        dummy_text_drawer = DummyClass()
+        dummy_line_renderer = DummyClass()
+        # todo: the user/caller of MultiprocessDriverWrapper should pass in a factory
+        # method or similar to construct their preferred GuiAppDriver.
+        # MultiprocessDriverWrapper and SandboxDriver shouldn't be tightly coupled.
+        wrapped_driver = SandboxDriver(
+            args,
+            config,
+            sim_gui_input,
+            dummy_text_drawer,
+            dummy_line_renderer,
+        )
+
+        while True:
+            if exit_event and exit_event.is_set():
+                break
+
+            latest_gui_input = interprocess_record.sim_input_queue.get(
+                block=True
+            )
+
+            sim_gui_input.shallow_copy_from(latest_gui_input)
+
+            sim_dt = 1 / 30.0  # todo: get correct sim_dt
+            post_sim_update_dict = wrapped_driver.sim_update(sim_dt)
+
+            # If you get a runtime error about "unable to pickle", it is probably
+            # a magnum object in the dict. See serialize_utils where we are manually
+            # adding pickle support to selected magnum types like Vector3.
+            interprocess_record.post_sim_update_dict_queue.put(
+                post_sim_update_dict
+            )
+
+    def sim_update(self, sim_dt):
+        # this is GuiInput for the next sim update; the current sim update should already be in progress
+        self._interprocess_record.sim_input_queue.put(
+            self._main_process_gui_input
+        )
+
+        post_sim_update_dict = (
+            self._interprocess_record.post_sim_update_dict_queue.get(
+                block=True
+            )
+        )
+
+        return post_sim_update_dict
+
+    # todo: call this correctly at shutdown. See also our calls to terminate_server_process
+    # for a reference for how to clean up a child process.
+    def close(self):
+        if multiprocessing_config.use_dummy:
+            assert self._exit_event
+            self._exit_event.set()
+            self._exit_event = None
+        else:
+            assert self._server_process
+            self._server_process.terminate()
+            self._server_process = None
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -950,13 +1120,22 @@ if __name__ == "__main__":
                 agent_index=args.gui_controlled_agent_index
             )
 
-    driver = SandboxDriver(
-        args,
-        config,
-        gui_app_wrapper.get_sim_input(),
-        app_renderer._replay_renderer.debug_line_render(0),
-        app_renderer._text_drawer,
-    )
+    # todo: hook up to a command-line arg or config, and make multiprocessing the
+    # default (assuming we're happy with its robustness)
+    use_multiprocess_for_driver = True
+    driver: Any = None
+    if use_multiprocess_for_driver:
+        driver = MultiprocessDriverWrapper(
+            args, config, gui_app_wrapper.get_sim_input()
+        )
+    else:
+        driver = SandboxDriver(
+            args,
+            config,
+            gui_app_wrapper.get_sim_input(),
+            app_renderer._replay_renderer.debug_line_render(0),
+            app_renderer._text_drawer,
+        )
 
     # sanity check if there are no agents with camera sensors
     if (

--- a/examples/siro_sandbox/serialize_utils.py
+++ b/examples/siro_sandbox/serialize_utils.py
@@ -16,6 +16,8 @@ from typing import Any, List
 import magnum as mn
 import numpy as np
 
+import habitat_sim
+
 
 def unpickle_vector3(data):
     return mn.Vector3(data)
@@ -26,8 +28,38 @@ def pickle_vector3(obj):
     return unpickle_vector3, (pickled_data,)
 
 
+def unpickle_vector2i(data):
+    return mn.Vector2i(data)
+
+
+def pickle_vector2i(obj):
+    pickled_data = list(obj)
+    return unpickle_vector2i, (pickled_data,)
+
+
+def unpickle_matrix4(data):
+    return mn.Matrix4(data)
+
+
+def pickle_matrix4(obj):
+    pickled_data = [list(column_tuple) for column_tuple in obj]
+    return unpickle_matrix4, (pickled_data,)
+
+
+def unpickle_ray(data):
+    return habitat_sim.geo.Ray(data[0], data[1])
+
+
+def pickle_ray(obj):
+    pickled_data = [list(obj.origin), list(obj.direction)]
+    return unpickle_ray, (pickled_data,)
+
+
 # fix for unpickable type; run once at startup
 copyreg.pickle(mn.Vector3, pickle_vector3)
+copyreg.pickle(mn.Vector2i, pickle_vector2i)
+copyreg.pickle(mn.Matrix4, pickle_matrix4)
+copyreg.pickle(habitat_sim.geo.Ray, pickle_ray)
 
 
 def convert_to_json_friendly(obj):

--- a/habitat-lab/habitat/gui/gui_input.py
+++ b/habitat-lab/habitat/gui/gui_input.py
@@ -25,6 +25,19 @@ class GuiInput:
         self._mouse_scroll_offset = 0
         self._mouse_ray = None
 
+    def shallow_copy_from(self, other):
+        self._key_held = other._key_held
+        self._mouse_button_held = other._mouse_button_held
+        self._mouse_position = other._mouse_position
+
+        self._key_down = other._key_down
+        self._key_up = other._key_up
+        self._mouse_button_down = other._mouse_button_down
+        self._mouse_button_up = other._mouse_button_up
+        self._relative_mouse_position = other._relative_mouse_position
+        self._mouse_scroll_offset = other._mouse_scroll_offset
+        self._mouse_ray = other._mouse_ray
+
     def validate_key(key):
         assert isinstance(key, Application.KeyEvent.Key)
 


### PR DESCRIPTION
## Motivation and Context

MultiprocessDriverWrapper is a wrapper intended to be used with SandboxDriver (or any GuiAppDriver). It creates a separate "sim process" to run the driver, with the goal to overlap (1) sim-updating and (2) rendering in ReplayGuiAppRenderer (used by GuiApplication). The ultimate goal is runtime speedup.

Using the [Oct 18 snapshot](https://docs.google.com/document/d/1cvKuXXE2cKchi-C_O7GGVFZ5x0QU7J9gHTIETzpVKJU/edit#bookmark=kix.jj43fzh3297x), in scene 2, on 2021 Macbook, I see the minimum FPS improve from 26 to 31. Note the minimum FPS is usually when Spot is busy, particularly when it's backing up.

This is a work in progress. Various todos are listed in the code. I'll try to summarize here:
[] Text-drawing and Line-rendering are unsolved. In the old single-threaded code, we directly share these objects between the driver and GuiApplication. In this multiprocessing paradigm, we need to utilize a MP data structure like Queue to transmit the requests for text-drawing and line-rendering from the sim process to the main process.
[] GuiInput is partially broken, in particular, zooming with mouse-scroll. I suspect I'm calling GuiInput.on_frame_end at the wrong time on the main process, causing some input events to be lost instead of sent to the sim process.
[] Better cleanup for the sim process on shutdown.
[] More robust testing. We should make sure we haven't overlooked a way for sim_update to get called without a GuiInput having been provided via the queue; this would cause the app to hang, as the main process would be waiting for a post_sim_update_dict and the sim process would be waiting for a GuiInput.

## How Has This Been Tested

Local testing on 2021 Macbook. Note I haven't tested with `--remote-gui-mode` but I don't anticipate problems.

## Types of changes

PR into a non-main branch.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
