### PR TITLE
Oracle social nav for HITL study

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -906,6 +906,7 @@ class AppStateFetch(AppState):
             or self.state_machine_agent_ctrl.current_state == FetchState.BRING
             or self.state_machine_agent_ctrl.current_state
             == FetchState.BRING_TIMEOUT_WAIT
+            or self.state_machine_agent_ctrl.current_state == FetchState.FOLLOW
         ):
             if (
                 self.state_machine_agent_ctrl.current_state
@@ -916,9 +917,17 @@ class AppStateFetch(AppState):
                 self.state_machine_agent_ctrl.current_state = (
                     FetchState.SEARCH_ORACLE_NAV
                 )
-            else:
+            elif (
+                self.state_machine_agent_ctrl.current_state == FetchState.BRING
+                or self.state_machine_agent_ctrl.current_state
+                == FetchState.BRING_TIMEOUT_WAIT
+            ):
                 self.state_machine_agent_ctrl.current_state = (
                     FetchState.BRING_ORACLE_NAV
+                )
+            else:
+                self.state_machine_agent_ctrl.current_state = (
+                    FetchState.FOLLOW_ORACLE
                 )
 
         if self._sandbox_service.gui_input.get_key_up(GuiInput.KeyNS.O) and (
@@ -926,14 +935,21 @@ class AppStateFetch(AppState):
             == FetchState.SEARCH_ORACLE_NAV
             or self.state_machine_agent_ctrl.current_state
             == FetchState.BRING_ORACLE_NAV
+            or self.state_machine_agent_ctrl.current_state
+            == FetchState.FOLLOW_ORACLE
         ):
             if (
                 self.state_machine_agent_ctrl.current_state
                 == FetchState.SEARCH_ORACLE_NAV
             ):
                 self.state_machine_agent_ctrl.current_state = FetchState.SEARCH
-            else:
+            elif (
+                self.state_machine_agent_ctrl.current_state
+                == FetchState.BRING_ORACLE_NAV
+            ):
                 self.state_machine_agent_ctrl.current_state = FetchState.BRING
+            else:
+                self.state_machine_agent_ctrl.current_state = FetchState.FOLLOW
 
     def sim_update(self, dt, post_sim_update_dict):
         if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.ESC):


### PR DESCRIPTION
- Introduce a new state called `FOLLOW_ORACLE` that calls oracle nav to follow human
- For consistency, we use the same key "O" to activate the oracle social nav as the same hot key we used for search_oracle and bring_oracle
- Same CLI, nothing changed
- See the video (holding the key "O"): https://drive.google.com/file/d/1kBktMm6c2X8qzCsX9dbRjCdQ54dXAs4B/view?usp=sharing
