### PR TITLE
Send signal when episode changes so that the client can react.

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -185,6 +185,7 @@ class AppStateFetch(AppState):
             self._sandbox_service.client_message_manager.change_humanoid_position(
                 self._gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
             )
+            self._sandbox_service.client_message_manager.signal_episode_change()
 
         # Get the scene id
         scene_id = (

--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -185,7 +185,7 @@ class AppStateFetch(AppState):
             self._sandbox_service.client_message_manager.change_humanoid_position(
                 self._gui_agent_ctrl._humanoid_controller.obj_transform_base.translation
             )
-            self._sandbox_service.client_message_manager.signal_episode_change()
+            self._sandbox_service.client_message_manager.signal_scene_change()
 
         # Get the scene id
         scene_id = (

--- a/examples/siro_sandbox/server/client_message_manager.py
+++ b/examples/siro_sandbox/server/client_message_manager.py
@@ -46,8 +46,8 @@ class ClientMessageManager:
         """
         self._message["teleportAvatarBasePosition"] = [pos[0], pos[1], pos[2]]
 
-    def signal_episode_change(self) -> None:
+    def signal_scene_change(self) -> None:
         r"""
-        Signals the client that the episode is being changed during this frame.
+        Signals the client that the scene is being changed during this frame.
         """
-        self._message["episodeChanged"] = True
+        self._message["sceneChanged"] = True

--- a/examples/siro_sandbox/server/client_message_manager.py
+++ b/examples/siro_sandbox/server/client_message_manager.py
@@ -45,3 +45,9 @@ class ClientMessageManager:
         Used to synchronize the humanoid position in the client when changing scene.
         """
         self._message["teleportAvatarBasePosition"] = [pos[0], pos[1], pos[2]]
+
+    def signal_episode_change(self) -> None:
+        r"""
+        Signals the client that the episode is being changed during this frame.
+        """
+        self._message["episodeChanged"] = True


### PR DESCRIPTION
## Motivation and Context

This sends a signal to the client when the episode has changed so that it can react accordingly.
Used to implement an effect in the Unity client here: https://github.com/eundersander/siro_hitl_unity_client/pull/16