### PR TITLE
enable server sim to run even when no clients are connected

### DIFF
--- a/examples/siro_sandbox/app_states/app_state_fetch.py
+++ b/examples/siro_sandbox/app_states/app_state_fetch.py
@@ -1002,11 +1002,19 @@ class AppStateFetch(AppState):
         if self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.H):
             self._hide_gui_text = not self._hide_gui_text
 
-        # toggle remote/local on keypress, if not holding anything
+        # toggle remote/local under certain conditions:
+        # - must not be holding anything
+        # - toggle on T keypress OR switch to remote if any remote button is pressed
         if (
-            self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.T)
-            and self._sandbox_service.args.remote_gui_mode
+            self._sandbox_service.args.remote_gui_mode
             and self._held_target_obj_idx is None
+            and (
+                self._sandbox_service.gui_input.get_key_down(GuiInput.KeyNS.T)
+                or (
+                    not self._is_remote_active_toggle
+                    and self._sandbox_service.remote_gui_input.get_gui_input().get_any_key_down()
+                )
+            )
         ):
             self._is_remote_active_toggle = not self._is_remote_active_toggle
 

--- a/habitat-lab/habitat/gui/gui_input.py
+++ b/habitat-lab/habitat/gui/gui_input.py
@@ -32,6 +32,9 @@ class GuiInput:
         GuiInput.validate_key(key)
         return key in self._key_held
 
+    def get_any_key_down(self):
+        return len(self._key_down) > 0
+
     def get_key_down(self, key):
         GuiInput.validate_key(key)
         return key in self._key_down


### PR DESCRIPTION
## Motivation and Context

* Enable server sim to run even when no clients are connected. This makes it easier for the demo host to run the demo even when the client is disconnected.
* Better toggle for VR-vs-keyboard (remote/local) control

## How Has This Been Tested

Local testing with Macbook and Quest 3

## Types of changes

PR into non-main branch

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
