### PR TITLE
[BE] - Deprecate colab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
       - run:
           name: run black
           command: |
-              black --exclude '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)|examples/tutorials/(colabs|nb_python)' habitat-lab/. habitat-baselines/. examples/. test/. --diff
-              black --exclude '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)|examples/tutorials/(colabs|nb_python)' habitat-lab/. habitat-baselines/. examples/. test/. --check
+              black --exclude '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)|examples/tutorials/(notebooks|nb_python)' habitat-lab/. habitat-baselines/. examples/. test/. --diff
+              black --exclude '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)|examples/tutorials/(notebooks|nb_python)' habitat-lab/. habitat-baselines/. examples/. test/. --check
       - run:
           name: run isort
           command: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,14 +41,14 @@ repos:
     rev: 5.11.5
     hooks:
     -   id: isort
-        exclude: docs/|examples/tutorials/(colabs|nb_python)/(.*\.py|.*\.ipynb)$
+        exclude: docs/|examples/tutorials/(notebooks|nb_python)/(.*\.py|.*\.ipynb)$
         additional_dependencies: [toml]
 
 -   repo: https://github.com/ambv/black
     rev: 23.1.0
     hooks:
     - id: black
-      exclude: ^examples/tutorials/(nb_python|colabs)
+      exclude: ^examples/tutorials/(nb_python|notebooks)
 
 -   repo: https://github.com/myint/autoflake
     rev: v1.4
@@ -95,8 +95,8 @@ repos:
     rev: v1.13.8
     hooks:
     -   id: jupytext
-        files: '^examples/tutorials/(colabs|nb_python)/(.*\.py|.*\.ipynb)$'
-        args: [--update-metadata, '{"jupytext":{"notebook_metadata_filter":"all", "cell_metadata_filter":"-all"}, "accelerator":"GPU"}', --set-formats, 'nb_python//py:percent,colabs//ipynb,', --pipe, black, --pipe, 'isort - --treat-comment-as-code "# %%"', --pipe-fmt, 'py:percent', --sync]
+        files: '^examples/tutorials/(notebooks|nb_python)/(.*\.py|.*\.ipynb)$'
+        args: [--update-metadata, '{"jupytext":{"notebook_metadata_filter":"all", "cell_metadata_filter":"-all"}, "accelerator":"GPU"}', --set-formats, 'nb_python//py:percent,notebooks//ipynb,', --pipe, black, --pipe, 'isort - --treat-comment-as-code "# %%"', --pipe-fmt, 'py:percent', --sync]
         additional_dependencies:
             - 'nbformat<=5.0.8'
             - black==23.1.0

--- a/docs/pages/habitat-lab-tdmap-viz.rst
+++ b/docs/pages/habitat-lab-tdmap-viz.rst
@@ -4,9 +4,7 @@ Habitat Lab TopdownMap Visualization Examples
 .. contents::
     :class: m-block m-default
 
-The example code below is available on `Colab`_, or runnable via:
-
-.. _Colab: https://colab.research.google.com/github/facebookresearch/habitat-lab/blob/main/examples/tutorials/colabs/Habitat_Lab_TopdownMap_Visualization.ipynb
+The example code below is available as a Jupyter notebook, or directly runnable via:
 
 .. code:: shell-session
 

--- a/docs/pages/habitat2.rst
+++ b/docs/pages/habitat2.rst
@@ -5,7 +5,7 @@ Habitat 2.0 Overview
 
 `Quick Start`_
 ========================
-To get started with Habitat 2.0, see the `quick start Colab tutorial <https://colab.research.google.com/github/facebookresearch/habitat-lab/blob/main/examples/tutorials/colabs/Habitat2_Quickstart.ipynb>`__ and the `Gym API tutorial <https://colab.research.google.com/github/facebookresearch/habitat-lab/blob/main/examples/tutorials/colabs/habitat2_gym_tutorial.ipynb>`__.
+To get started with Habitat 2.0, see the `quick start Jupyter notebook tutorial <https://github.com/facebookresearch/habitat-lab/blob/main/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb>`__ and the `Gym API tutorial <https://github.com/facebookresearch/habitat-lab/blob/main/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb>`__.
 
 `Local Installation`_
 ======================

--- a/docs/pages/index.rst
+++ b/docs/pages/index.rst
@@ -14,9 +14,9 @@ Quickstart                                          :ref:`Page <std:doc:quicksta
 
 Habitat Lab Demo                                    :ref:`Page <std:doc:habitat-lab-demo>`
 
-Habitat Lab TopdownMap Visualization                :ref:`Page <std:doc:habitat-lab-tdmap-viz>`                                                                                                                `Interactive Colab <https://colab.research.google.com/github/facebookresearch/habitat-lab/blob/main/examples/tutorials/colabs/Habitat_Lab_TopdownMap_Visualization.ipynb>`__
+Habitat Lab TopdownMap Visualization                :ref:`Page <std:doc:habitat-lab-tdmap-viz>`                                                                                                                :gh:`Jupyter Notebook <facebookresearch/habitat-lab/blob/main/examples/tutorials/notebooks/Habitat_Lab_TopdownMap_Visualization.ipynb>`
 
-Habitat 2.0 Overview                                :ref:`Page <std:doc:habitat2>`                                                                                                                             `Interactive Colab 1 <https://colab.research.google.com/github/facebookresearch/habitat-lab/blob/main/examples/tutorials/colabs/Habitat2_Quickstart.ipynb>`__, `Interactive Colab 2 <https://colab.research.google.com/github/facebookresearch/habitat-lab/blob/main/examples/tutorials/colabs/habitat2_gym_tutorial.ipynb>`__
+Habitat 2.0 Overview                                :ref:`Page <std:doc:habitat2>`                                                                                                                             :gh:`Jupyter Notebook 1 <facebookresearch/habitat-lab/blob/main/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb>` :gh:`Jupyter Notebook 2 <facebookresearch/habitat-lab/blob/main/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb>`
 
 View, Transform and Warp                            :ref:`Page <std:doc:view-transform-warp>`
 =================================================== ========================================================================================================================================================== ======================

--- a/examples/tutorials/nb_python/Habitat2_Quickstart.py
+++ b/examples/tutorials/nb_python/Habitat2_Quickstart.py
@@ -7,7 +7,7 @@
 #     provenance: []
 #   jupytext:
 #     cell_metadata_filter: -all
-#     formats: nb_python//py:percent,colabs//ipynb
+#     formats: nb_python//py:percent,notebooks//ipynb
 #     notebook_metadata_filter: all
 #     text_representation:
 #       extension: .py

--- a/examples/tutorials/nb_python/Habitat2_Quickstart.py
+++ b/examples/tutorials/nb_python/Habitat2_Quickstart.py
@@ -15,8 +15,19 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.13.8
 #   kernelspec:
-#     display_name: Python 3
+#     display_name: Python 3 (ipykernel)
+#     language: python
 #     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.9.17
 # ---
 
 # %% [markdown]
@@ -36,40 +47,23 @@ from habitat.config.default_structured_configs import (
 )
 
 try:
-    from IPython.display import HTML
+    from IPython.display import IFrame
 
-    HTML(
-        '<iframe src="https://drive.google.com/file/d/1ltrse38i8pnJPGAXlThylcdy8PMjUMKh/preview" width="640" height="480" allow="autoplay"></iframe>'
+    # NOTE: this file is unreachable
+    IFrame(
+        src="https://drive.google.com/file/d/1ltrse38i8pnJPGAXlThylcdy8PMjUMKh/preview",
+        width=640,
+        height=480,
     )
+
 except Exception:
     pass
 
 # %%
-# %%capture
-# @title Install Dependencies (if on Colab) { display-mode: "form" }
-# @markdown (double click to show code)
-
-import os
-
-# Colab installation
-if "COLAB_GPU" in os.environ:
-    print("Setting up Habitat")
-    # !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s
-# %%
 # Imports
 import os
 
-if "COLAB_GPU" in os.environ:
-    print("Setting Habitat base path")
-    # %env HABLAB_BASE_CFG_PATH=/content/habitat-lab
-    import importlib
-
-    import PIL
-
-    importlib.reload(PIL.TiffTags)  # type:ignore
-
-import os
-
+import git
 import gym
 import numpy as np
 from hydra.core.config_store import ConfigStore
@@ -112,6 +106,15 @@ importlib.reload(
     PIL.TiffTags  # type: ignore[attr-defined]
 )  # To potentially avoid PIL problem
 
+repo = git.Repo(".", search_parent_directories=True)
+dir_path = repo.working_tree_dir
+data_path = os.path.join(dir_path, "data")
+output_path = os.path.join(
+    dir_path, "examples/tutorials/habitat_lab_visualization/"
+)
+os.makedirs(output_path, exist_ok=True)
+os.chdir(dir_path)
+
 
 # %% [markdown]
 # # Local installation
@@ -128,7 +131,10 @@ importlib.reload(
 with habitat.Env(
     config=insert_render_options(
         habitat.get_config(
-            "benchmark/rearrange/skills/pick.yaml",
+            os.path.join(
+                dir_path,
+                "habitat-lab/habitat/config/benchmark/rearrange/skills/pick.yaml",
+            ),
         )
     )
 ) as env:
@@ -137,7 +143,7 @@ with habitat.Env(
     print("Agent acting inside environment.")
     count_steps = 0
     # To save the video
-    video_file_path = "data/example_interact.mp4"
+    video_file_path = os.path.join(output_path, "example_interact.mp4")
     video_writer = vut.get_fast_video_writer(video_file_path, fps=30)
 
     while not env.episode_over:
@@ -164,7 +170,7 @@ with habitat.Env(
 # %%
 env = gym.make("HabitatRenderPick-v0")
 
-video_file_path = "data/example_interact.mp4"
+video_file_path = os.path.join(output_path, "example_interact.mp4")
 video_writer = vut.get_fast_video_writer(video_file_path, fps=30)
 
 done = False
@@ -476,7 +482,7 @@ habitat:
     data_path: data/datasets/replica_cad/rearrange/v1/{split}/all_receptacles_10k_1k.json.gz
     scenes_dir: "data/replica_cad/"
 """
-nav_pick_cfg_path = "data/nav_pick_demo.yaml"
+nav_pick_cfg_path = os.path.join(data_path, "nav_pick_demo.yaml")
 with open(nav_pick_cfg_path, "w") as f:
     f.write(cfg_txt)
 
@@ -492,7 +498,7 @@ with habitat.Env(
     print("Agent acting inside environment.")
     count_steps = 0
     # To save the video
-    video_file_path = "data/example_interact.mp4"
+    video_file_path = os.path.join(output_path, "example_interact.mp4")
     video_writer = vut.get_fast_video_writer(video_file_path, fps=30)
 
     while not env.episode_over:
@@ -579,12 +585,12 @@ object_target_samplers:
       num_samples: [1, 1]
       orientation_sampling: "up"
 """
-nav_pick_cfg_path = "data/nav_pick_dataset.yaml"
+nav_pick_cfg_path = os.path.join(data_path, "nav_pick_dataset.yaml")
 with open(nav_pick_cfg_path, "w") as f:
     f.write(dataset_cfg_txt)
 
 # %%
-# !python -m habitat.datasets.rearrange.run_episode_generator --run --config data/nav_pick_dataset.yaml --num-episodes 10 --out data/nav_pick.json.gz
+# !python -m habitat.datasets.rearrange.run_episode_generator --run --config {nav_pick_cfg_path} --num-episodes 10 --out data/nav_pick.json.gz
 
 # %% [markdown]
 # To use this dataset set `dataset.data_path = data/nav_pick.json.gz` in the task config. See the full set of possible objects, receptacles, and scenes with `python -m habitat.datasets.rearrange.run_episode_generator --list`

--- a/examples/tutorials/nb_python/Habitat_Lab.py
+++ b/examples/tutorials/nb_python/Habitat_Lab.py
@@ -7,7 +7,7 @@
 #     provenance: []
 #   jupytext:
 #     cell_metadata_filter: -all
-#     formats: nb_python//py:percent,colabs//ipynb
+#     formats: nb_python//py:percent,notebooks//ipynb
 #     notebook_metadata_filter: all
 #     text_representation:
 #       extension: .py

--- a/examples/tutorials/nb_python/Habitat_Lab.py
+++ b/examples/tutorials/nb_python/Habitat_Lab.py
@@ -15,15 +15,20 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.13.8
 #   kernelspec:
-#     display_name: Python 3
+#     display_name: Python 3 (ipykernel)
+#     language: python
 #     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.9.17
 # ---
-
-# %%
-# @title Installation
-
-# !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s
-# !wget -c http://dl.fbaipublicfiles.com/habitat/mp3d_example.zip && unzip -o mp3d_example.zip -d /content/habitat-sim/data/scene_datasets/mp3d/
 
 # %%
 # !pip uninstall --yes pyopenssl
@@ -35,7 +40,6 @@
 
 import os
 import random
-import sys
 
 import git
 import numpy as np
@@ -44,15 +48,10 @@ from gym import spaces
 # %matplotlib inline
 from matplotlib import pyplot as plt
 
-# %cd "/content/habitat-lab"
-
-
-if "google.colab" in sys.modules:
-    # This tells imageio to use the system FFMPEG that has hardware acceleration.
-    os.environ["IMAGEIO_FFMPEG_EXE"] = "/usr/bin/ffmpeg"
 repo = git.Repo(".", search_parent_directories=True)
 dir_path = repo.working_tree_dir
-# %cd $dir_path
+data_path = os.path.join(dir_path, "data")
+os.chdir(dir_path)
 
 from PIL import Image
 
@@ -63,6 +62,9 @@ from habitat.sims.habitat_simulator.actions import HabitatSimActions
 from habitat.tasks.nav.nav import NavigationTask
 from habitat_baselines.common.baseline_registry import baseline_registry
 from habitat_baselines.config.default import get_config as get_baselines_config
+
+# %%
+# !python -m habitat_sim.utils.datasets_download --uids mp3d_example_scene --data-path {data_path} --no-replace
 
 # %%
 # @title Define Observation Display Utility Function { display-mode: "form" }
@@ -114,7 +116,10 @@ def display_sample(
 # %%
 if __name__ == "__main__":
     config = habitat.get_config(
-        config_path="benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        config_path=os.path.join(
+            dir_path,
+            "habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        ),
         overrides=[
             "habitat.environment.max_episode_steps=10",
             "habitat.environment.iterator_options.shuffle=False",
@@ -246,7 +251,10 @@ except ImportError:
 # %%
 if __name__ == "__main__":
     config = habitat.get_config(
-        config_path="benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        config_path=os.path.join(
+            dir_path,
+            "habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        ),
         overrides=[
             "habitat.environment.max_episode_steps=10",
             "habitat.environment.iterator_options.shuffle=False",
@@ -344,7 +352,10 @@ class AgentPositionSensor(habitat.Sensor):
 # %%
 if __name__ == "__main__":
     config = habitat.get_config(
-        config_path="benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        config_path=os.path.join(
+            dir_path,
+            "habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        ),
         overrides=[
             "habitat.environment.max_episode_steps=10",
             "habitat.environment.iterator_options.shuffle=False",

--- a/examples/tutorials/nb_python/Habitat_Lab_TopdownMap_Visualization.py
+++ b/examples/tutorials/nb_python/Habitat_Lab_TopdownMap_Visualization.py
@@ -6,7 +6,7 @@
 #   gpuClass: standard
 #   jupytext:
 #     cell_metadata_filter: -all
-#     formats: nb_python//py:percent,colabs//ipynb
+#     formats: nb_python//py:percent,notebooks//ipynb
 #     notebook_metadata_filter: all
 #     text_representation:
 #       extension: .py

--- a/examples/tutorials/nb_python/Habitat_Lab_TopdownMap_Visualization.py
+++ b/examples/tutorials/nb_python/Habitat_Lab_TopdownMap_Visualization.py
@@ -26,32 +26,20 @@
 #     name: python
 #     nbconvert_exporter: python
 #     pygments_lexer: ipython3
-#     version: 3.10.4
+#     version: 3.9.17
 # ---
 
-# %%
-# %%capture
-# @title Install Dependencies { display-mode: "form" }
-
-# !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=false bash -s
-
 # %% [markdown]
-# Download (testing) 3D scenes:
-
-# %%
-# !python -m habitat_sim.utils.datasets_download --uids habitat_test_scenes --data-path data/
-
-# %% [markdown]
-# Download point-goal navigation episodes for the test scenes:
-
-# %%
-# !python -m habitat_sim.utils.datasets_download --uids habitat_test_pointnav_dataset --data-path data/
+# # Habitat Lab: Topdown Map Visualization
+#
+# ## Initial setup and imports:
 
 # %%
 # [setup]
 import os
 from typing import TYPE_CHECKING, Union, cast
 
+import git
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -80,11 +68,28 @@ if TYPE_CHECKING:
     from habitat.core.simulator import Observations
     from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
 
-
-output_path = "examples/tutorials/habitat_lab_visualization/"
-if not os.path.exists(output_path):
-    os.makedirs(output_path)
+repo = git.Repo(".", search_parent_directories=True)
+dir_path = repo.working_tree_dir
+data_path = os.path.join(dir_path, "data")
+output_path = os.path.join(
+    dir_path, "examples/tutorials/habitat_lab_visualization/"
+)
+os.makedirs(output_path, exist_ok=True)
+os.chdir(dir_path)
 # [/setup]
+
+
+# %% [markdown]
+# ### Download (testing) 3D scenes:
+
+# %%
+# !python -m habitat_sim.utils.datasets_download --uids habitat_test_scenes --data-path {data_path} --no-replace
+
+# %% [markdown]
+# ### Download point-goal navigation episodes for the test scenes:
+
+# %%
+# !python -m habitat_sim.utils.datasets_download --uids habitat_test_pointnav_dataset --data-path {data_path} --no-replace
 
 
 # %%
@@ -169,7 +174,10 @@ def example_pointnav_draw_target_birdseye_view_agent_on_border():
 def example_get_topdown_map():
     # Create habitat config
     config = habitat.get_config(
-        config_path="benchmark/nav/pointnav/pointnav_habitat_test.yaml"
+        config_path=os.path.join(
+            dir_path,
+            "habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        )
     )
     # Create dataset
     dataset = habitat.make_dataset(
@@ -228,7 +236,10 @@ class ShortestPathFollowerAgent(Agent):
 def example_top_down_map_measure():
     # Create habitat config
     config = habitat.get_config(
-        config_path="benchmark/nav/pointnav/pointnav_habitat_test.yaml"
+        config_path=os.path.join(
+            dir_path,
+            "habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml",
+        )
     )
     # Add habitat.tasks.nav.nav.TopDownMap and habitat.tasks.nav.nav.Collisions measures
     with habitat.config.read_write(config):

--- a/examples/tutorials/nb_python/habitat2_gym_tutorial.py
+++ b/examples/tutorials/nb_python/habitat2_gym_tutorial.py
@@ -15,8 +15,19 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.13.8
 #   kernelspec:
-#     display_name: Python 3
+#     display_name: Python 3 (ipykernel)
+#     language: python
 #     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.9.17
 # ---
 
 # %% [markdown]
@@ -25,17 +36,9 @@
 # See [here for Habitat 2.0 installation instructions and more tutorials.](https://aihabitat.org/docs/habitat2/)
 
 # %%
-# %%capture
-# @title Install Dependencies (if on Colab) { display-mode: "form" }
-# @markdown (double click to show code)
-
 import os
 
-if "COLAB_GPU" in os.environ:
-    print("Setting up Habitat")
-    # !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s
-# %%
-import os
+import git
 
 if "COLAB_GPU" in os.environ:
     print("Setting Habitat base path")
@@ -53,7 +56,13 @@ from habitat_sim.utils import viz_utils as vut
 os.environ["MAGNUM_LOG"] = "quiet"
 os.environ["HABITAT_SIM_LOG"] = "quiet"
 
-
+repo = git.Repo(".", search_parent_directories=True)
+dir_path = repo.working_tree_dir
+output_path = os.path.join(
+    dir_path, "examples/tutorials/habitat_lab_visualization/"
+)
+os.makedirs(output_path, exist_ok=True)
+os.chdir(dir_path)
 # If the import block below fails due to an error like "'PIL.TiffTags' has no attribute
 # 'IFD'", then restart the Colab runtime instance and rerun this cell and the previous cell.
 
@@ -71,7 +80,7 @@ import habitat.gym
 # %%
 env = gym.make("HabitatRenderPick-v0")
 
-video_file_path = "data/example_interact.mp4"
+video_file_path = os.path.join(output_path, "example_interact.mp4")
 video_writer = vut.get_fast_video_writer(video_file_path, fps=30)
 
 done = False

--- a/examples/tutorials/nb_python/habitat2_gym_tutorial.py
+++ b/examples/tutorials/nb_python/habitat2_gym_tutorial.py
@@ -7,7 +7,7 @@
 #     provenance: []
 #   jupytext:
 #     cell_metadata_filter: -all
-#     formats: nb_python//py:percent,colabs//ipynb
+#     formats: nb_python//py:percent,notebooks//ipynb
 #     notebook_metadata_filter: all
 #     text_representation:
 #       extension: .py

--- a/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb
+++ b/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb
@@ -684,7 +684,7 @@
   },
   "jupytext": {
    "cell_metadata_filter": "-all",
-   "formats": "nb_python//py:percent,colabs//ipynb",
+   "formats": "nb_python//py:percent,notebooks//ipynb",
    "main_language": "python",
    "notebook_metadata_filter": "all"
   },

--- a/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb
+++ b/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb
@@ -26,33 +26,17 @@
     ")\n",
     "\n",
     "try:\n",
-    "    from IPython.display import HTML\n",
+    "    from IPython.display import IFrame\n",
     "\n",
-    "    HTML(\n",
-    "        '<iframe src=\"https://drive.google.com/file/d/1ltrse38i8pnJPGAXlThylcdy8PMjUMKh/preview\" width=\"640\" height=\"480\" allow=\"autoplay\"></iframe>'\n",
+    "    # NOTE: this file is unreachable\n",
+    "    IFrame(\n",
+    "        src=\"https://drive.google.com/file/d/1ltrse38i8pnJPGAXlThylcdy8PMjUMKh/preview\",\n",
+    "        width=640,\n",
+    "        height=480,\n",
     "    )\n",
+    "\n",
     "except Exception:\n",
     "    pass"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "# @title Install Dependencies (if on Colab) { display-mode: \"form\" }\n",
-    "# @markdown (double click to show code)\n",
-    "\n",
-    "import os\n",
-    "\n",
-    "# Colab installation\n",
-    "if \"COLAB_GPU\" in os.environ:\n",
-    "    print(\"Setting up Habitat\")\n",
-    "    !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s"
    ]
   },
   {
@@ -66,17 +50,7 @@
     "# Imports\n",
     "import os\n",
     "\n",
-    "if \"COLAB_GPU\" in os.environ:\n",
-    "    print(\"Setting Habitat base path\")\n",
-    "    %env HABLAB_BASE_CFG_PATH=/content/habitat-lab\n",
-    "    import importlib\n",
-    "\n",
-    "    import PIL\n",
-    "\n",
-    "    importlib.reload(PIL.TiffTags)  # type:ignore\n",
-    "\n",
-    "import os\n",
-    "\n",
+    "import git\n",
     "import gym\n",
     "import numpy as np\n",
     "from hydra.core.config_store import ConfigStore\n",
@@ -117,7 +91,16 @@
     "\n",
     "importlib.reload(\n",
     "    PIL.TiffTags  # type: ignore[attr-defined]\n",
-    ")  # To potentially avoid PIL problem"
+    ")  # To potentially avoid PIL problem\n",
+    "\n",
+    "repo = git.Repo(\".\", search_parent_directories=True)\n",
+    "dir_path = repo.working_tree_dir\n",
+    "data_path = os.path.join(dir_path, \"data\")\n",
+    "output_path = os.path.join(\n",
+    "    dir_path, \"examples/tutorials/habitat_lab_visualization/\"\n",
+    ")\n",
+    "os.makedirs(output_path, exist_ok=True)\n",
+    "os.chdir(dir_path)"
    ]
   },
   {
@@ -150,7 +133,10 @@
     "with habitat.Env(\n",
     "    config=insert_render_options(\n",
     "        habitat.get_config(\n",
-    "            \"benchmark/rearrange/skills/pick.yaml\",\n",
+    "            os.path.join(\n",
+    "                dir_path,\n",
+    "                \"habitat-lab/habitat/config/benchmark/rearrange/skills/pick.yaml\",\n",
+    "            ),\n",
     "        )\n",
     "    )\n",
     ") as env:\n",
@@ -159,7 +145,7 @@
     "    print(\"Agent acting inside environment.\")\n",
     "    count_steps = 0\n",
     "    # To save the video\n",
-    "    video_file_path = \"data/example_interact.mp4\"\n",
+    "    video_file_path = os.path.join(output_path, \"example_interact.mp4\")\n",
     "    video_writer = vut.get_fast_video_writer(video_file_path, fps=30)\n",
     "\n",
     "    while not env.episode_over:\n",
@@ -197,7 +183,7 @@
    "source": [
     "env = gym.make(\"HabitatRenderPick-v0\")\n",
     "\n",
-    "video_file_path = \"data/example_interact.mp4\"\n",
+    "video_file_path = os.path.join(output_path, \"example_interact.mp4\")\n",
     "video_writer = vut.get_fast_video_writer(video_file_path, fps=30)\n",
     "\n",
     "done = False\n",
@@ -530,7 +516,7 @@
     "    data_path: data/datasets/replica_cad/rearrange/v1/{split}/all_receptacles_10k_1k.json.gz\n",
     "    scenes_dir: \"data/replica_cad/\"\n",
     "\"\"\"\n",
-    "nav_pick_cfg_path = \"data/nav_pick_demo.yaml\"\n",
+    "nav_pick_cfg_path = os.path.join(data_path, \"nav_pick_demo.yaml\")\n",
     "with open(nav_pick_cfg_path, \"w\") as f:\n",
     "    f.write(cfg_txt)"
    ]
@@ -556,7 +542,7 @@
     "    print(\"Agent acting inside environment.\")\n",
     "    count_steps = 0\n",
     "    # To save the video\n",
-    "    video_file_path = \"data/example_interact.mp4\"\n",
+    "    video_file_path = os.path.join(output_path, \"example_interact.mp4\")\n",
     "    video_writer = vut.get_fast_video_writer(video_file_path, fps=30)\n",
     "\n",
     "    while not env.episode_over:\n",
@@ -653,7 +639,7 @@
     "      num_samples: [1, 1]\n",
     "      orientation_sampling: \"up\"\n",
     "\"\"\"\n",
-    "nav_pick_cfg_path = \"data/nav_pick_dataset.yaml\"\n",
+    "nav_pick_cfg_path = os.path.join(data_path, \"nav_pick_dataset.yaml\")\n",
     "with open(nav_pick_cfg_path, \"w\") as f:\n",
     "    f.write(dataset_cfg_txt)"
    ]
@@ -664,7 +650,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m habitat.datasets.rearrange.run_episode_generator --run --config data/nav_pick_dataset.yaml --num-episodes 10 --out data/nav_pick.json.gz"
+    "!python -m habitat.datasets.rearrange.run_episode_generator --run --config {nav_pick_cfg_path} --num-episodes 10 --out data/nav_pick.json.gz"
    ]
   },
   {
@@ -685,12 +671,24 @@
   "jupytext": {
    "cell_metadata_filter": "-all",
    "formats": "nb_python//py:percent,notebooks//ipynb",
-   "main_language": "python",
    "notebook_metadata_filter": "all"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/examples/tutorials/notebooks/Habitat_Lab.ipynb
+++ b/examples/tutorials/notebooks/Habitat_Lab.ipynb
@@ -6,18 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# @title Installation\n",
-    "\n",
-    "!curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s\n",
-    "!wget -c http://dl.fbaipublicfiles.com/habitat/mp3d_example.zip && unzip -o mp3d_example.zip -d /content/habitat-sim/data/scene_datasets/mp3d/"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "!pip uninstall --yes pyopenssl\n",
     "!pip install pyopenssl"
    ]
@@ -33,7 +21,6 @@
     "\n",
     "import os\n",
     "import random\n",
-    "import sys\n",
     "\n",
     "import git\n",
     "import numpy as np\n",
@@ -42,15 +29,10 @@
     "%matplotlib inline\n",
     "from matplotlib import pyplot as plt\n",
     "\n",
-    "%cd \"/content/habitat-lab\"\n",
-    "\n",
-    "\n",
-    "if \"google.colab\" in sys.modules:\n",
-    "    # This tells imageio to use the system FFMPEG that has hardware acceleration.\n",
-    "    os.environ[\"IMAGEIO_FFMPEG_EXE\"] = \"/usr/bin/ffmpeg\"\n",
     "repo = git.Repo(\".\", search_parent_directories=True)\n",
     "dir_path = repo.working_tree_dir\n",
-    "%cd $dir_path\n",
+    "data_path = os.path.join(dir_path, \"data\")\n",
+    "os.chdir(dir_path)\n",
     "\n",
     "from PIL import Image\n",
     "\n",
@@ -61,6 +43,15 @@
     "from habitat.tasks.nav.nav import NavigationTask\n",
     "from habitat_baselines.common.baseline_registry import baseline_registry\n",
     "from habitat_baselines.config.default import get_config as get_baselines_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python -m habitat_sim.utils.datasets_download --uids mp3d_example_scene --data-path {data_path} --no-replace"
    ]
   },
   {
@@ -127,7 +118,10 @@
    "source": [
     "if __name__ == \"__main__\":\n",
     "    config = habitat.get_config(\n",
-    "        config_path=\"benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        config_path=os.path.join(\n",
+    "            dir_path,\n",
+    "            \"habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        ),\n",
     "        overrides=[\n",
     "            \"habitat.environment.max_episode_steps=10\",\n",
     "            \"habitat.environment.iterator_options.shuffle=False\",\n",
@@ -316,7 +310,10 @@
    "source": [
     "if __name__ == \"__main__\":\n",
     "    config = habitat.get_config(\n",
-    "        config_path=\"benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        config_path=os.path.join(\n",
+    "            dir_path,\n",
+    "            \"habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        ),\n",
     "        overrides=[\n",
     "            \"habitat.environment.max_episode_steps=10\",\n",
     "            \"habitat.environment.iterator_options.shuffle=False\",\n",
@@ -437,7 +434,10 @@
    "source": [
     "if __name__ == \"__main__\":\n",
     "    config = habitat.get_config(\n",
-    "        config_path=\"benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        config_path=os.path.join(\n",
+    "            dir_path,\n",
+    "            \"habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        ),\n",
     "        overrides=[\n",
     "            \"habitat.environment.max_episode_steps=10\",\n",
     "            \"habitat.environment.iterator_options.shuffle=False\",\n",
@@ -592,12 +592,24 @@
   "jupytext": {
    "cell_metadata_filter": "-all",
    "formats": "nb_python//py:percent,notebooks//ipynb",
-   "main_language": "python",
    "notebook_metadata_filter": "all"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/examples/tutorials/notebooks/Habitat_Lab.ipynb
+++ b/examples/tutorials/notebooks/Habitat_Lab.ipynb
@@ -591,7 +591,7 @@
   },
   "jupytext": {
    "cell_metadata_filter": "-all",
-   "formats": "nb_python//py:percent,colabs//ipynb",
+   "formats": "nb_python//py:percent,notebooks//ipynb",
    "main_language": "python",
    "notebook_metadata_filter": "all"
   },

--- a/examples/tutorials/notebooks/Habitat_Lab_TopdownMap_Visualization.ipynb
+++ b/examples/tutorials/notebooks/Habitat_Lab_TopdownMap_Visualization.ipynb
@@ -366,7 +366,7 @@
   "gpuClass": "standard",
   "jupytext": {
    "cell_metadata_filter": "-all",
-   "formats": "nb_python//py:percent,colabs//ipynb",
+   "formats": "nb_python//py:percent,notebooks//ipynb",
    "notebook_metadata_filter": "all"
   },
   "kernelspec": {

--- a/examples/tutorials/notebooks/Habitat_Lab_TopdownMap_Visualization.ipynb
+++ b/examples/tutorials/notebooks/Habitat_Lab_TopdownMap_Visualization.ipynb
@@ -1,47 +1,12 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "%%capture\n",
-    "# @title Install Dependencies { display-mode: \"form\" }\n",
+    "# Habitat Lab: Topdown Map Visualization\n",
     "\n",
-    "!curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=false bash -s"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Download (testing) 3D scenes:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!python -m habitat_sim.utils.datasets_download --uids habitat_test_scenes --data-path data/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Download point-goal navigation episodes for the test scenes:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!python -m habitat_sim.utils.datasets_download --uids habitat_test_pointnav_dataset --data-path data/"
+    "## Initial setup and imports:"
    ]
   },
   {
@@ -56,6 +21,7 @@
     "import os\n",
     "from typing import TYPE_CHECKING, Union, cast\n",
     "\n",
+    "import git\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
@@ -84,11 +50,49 @@
     "    from habitat.core.simulator import Observations\n",
     "    from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim\n",
     "\n",
-    "\n",
-    "output_path = \"examples/tutorials/habitat_lab_visualization/\"\n",
-    "if not os.path.exists(output_path):\n",
-    "    os.makedirs(output_path)\n",
+    "repo = git.Repo(\".\", search_parent_directories=True)\n",
+    "dir_path = repo.working_tree_dir\n",
+    "data_path = os.path.join(dir_path, \"data\")\n",
+    "output_path = os.path.join(\n",
+    "    dir_path, \"examples/tutorials/habitat_lab_visualization/\"\n",
+    ")\n",
+    "os.makedirs(output_path, exist_ok=True)\n",
+    "os.chdir(dir_path)\n",
     "# [/setup]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download (testing) 3D scenes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python -m habitat_sim.utils.datasets_download --uids habitat_test_scenes --data-path {data_path} --no-replace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download point-goal navigation episodes for the test scenes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "!python -m habitat_sim.utils.datasets_download --uids habitat_test_pointnav_dataset --data-path {data_path} --no-replace"
    ]
   },
   {
@@ -194,7 +198,10 @@
     "def example_get_topdown_map():\n",
     "    # Create habitat config\n",
     "    config = habitat.get_config(\n",
-    "        config_path=\"benchmark/nav/pointnav/pointnav_habitat_test.yaml\"\n",
+    "        config_path=os.path.join(\n",
+    "            dir_path,\n",
+    "            \"habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        )\n",
     "    )\n",
     "    # Create dataset\n",
     "    dataset = habitat.make_dataset(\n",
@@ -260,7 +267,10 @@
     "def example_top_down_map_measure():\n",
     "    # Create habitat config\n",
     "    config = habitat.get_config(\n",
-    "        config_path=\"benchmark/nav/pointnav/pointnav_habitat_test.yaml\"\n",
+    "        config_path=os.path.join(\n",
+    "            dir_path,\n",
+    "            \"habitat-lab/habitat/config/benchmark/nav/pointnav/pointnav_habitat_test.yaml\",\n",
+    "        )\n",
     "    )\n",
     "    # Add habitat.tasks.nav.nav.TopDownMap and habitat.tasks.nav.nav.Collisions measures\n",
     "    with habitat.config.read_write(config):\n",
@@ -384,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb
+++ b/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb
@@ -183,7 +183,7 @@
   },
   "jupytext": {
    "cell_metadata_filter": "-all",
-   "formats": "nb_python//py:percent,colabs//ipynb",
+   "formats": "nb_python//py:percent,notebooks//ipynb",
    "main_language": "python",
    "notebook_metadata_filter": "all"
   },

--- a/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb
+++ b/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb
@@ -12,29 +12,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "# @title Install Dependencies (if on Colab) { display-mode: \"form\" }\n",
-    "# @markdown (double click to show code)\n",
-    "\n",
-    "import os\n",
-    "\n",
-    "if \"COLAB_GPU\" in os.environ:\n",
-    "    print(\"Setting up Habitat\")\n",
-    "    !curl -L https://raw.githubusercontent.com/facebookresearch/habitat-sim/main/examples/colab_utils/colab_install.sh | NIGHTLY=true bash -s"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
+    "import git\n",
     "\n",
     "if \"COLAB_GPU\" in os.environ:\n",
     "    print(\"Setting Habitat base path\")\n",
@@ -52,7 +35,13 @@
     "os.environ[\"MAGNUM_LOG\"] = \"quiet\"\n",
     "os.environ[\"HABITAT_SIM_LOG\"] = \"quiet\"\n",
     "\n",
-    "\n",
+    "repo = git.Repo(\".\", search_parent_directories=True)\n",
+    "dir_path = repo.working_tree_dir\n",
+    "output_path = os.path.join(\n",
+    "    dir_path, \"examples/tutorials/habitat_lab_visualization/\"\n",
+    ")\n",
+    "os.makedirs(output_path, exist_ok=True)\n",
+    "os.chdir(dir_path)\n",
     "# If the import block below fails due to an error like \"'PIL.TiffTags' has no attribute\n",
     "# 'IFD'\", then restart the Colab runtime instance and rerun this cell and the previous cell."
    ]
@@ -86,7 +75,7 @@
    "source": [
     "env = gym.make(\"HabitatRenderPick-v0\")\n",
     "\n",
-    "video_file_path = \"data/example_interact.mp4\"\n",
+    "video_file_path = os.path.join(output_path, \"example_interact.mp4\")\n",
     "video_writer = vut.get_fast_video_writer(video_file_path, fps=30)\n",
     "\n",
     "done = False\n",
@@ -184,12 +173,24 @@
   "jupytext": {
    "cell_metadata_filter": "-all",
    "formats": "nb_python//py:percent,notebooks//ipynb",
-   "main_language": "python",
    "notebook_metadata_filter": "all"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = '''
     | \.venv
     | _build
     | buck-out
-    | ^examples/tutorials/colabs
+    | ^examples/tutorials/notebooks
     | ^examples/tutorials/nb_python
     | build
     | dist


### PR DESCRIPTION
## Motivation and Context

Colab is a shifting foundtation for hosting tutorials. Back-end changes require updates to installers and scripts resulting in tutorial downtime and extra developer bandwidth load. Instead, we opt to deprecate Colab support and convert existing tutorials to locally-executable Jupyter notebooks.

examples/tutorials/colabs/ directory renamed to examples/tutorials/notebooks/

NOTE: partner habitat-sim PR: https://github.com/facebookresearch/habitat-sim/pull/2298

## How Has This Been Tested

Locally ran the Jupyter notebooks

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
