### PR TITLE
[BE] Fix the env pause issue

### DIFF
--- a/habitat-baselines/habitat_baselines/rl/hrl/hl/fixed_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hl/fixed_policy.py
@@ -139,3 +139,20 @@ class FixedHighLevelPolicy(HighLevelPolicy):
                 self._next_sol_idxs[batch_idx] += 1
 
         return next_skill, skill_args_data, immediate_end, PolicyActionData()
+
+    def filter_envs(self, curr_envs_to_keep_active):
+        """
+        Cleans up stateful variables of the policy so that
+        they match with the active environments
+        """
+        self._next_sol_idxs = self._next_sol_idxs[curr_envs_to_keep_active]
+        parse_solution_actions = [
+            self._parse_solution_actions() for _ in range(self._num_envs)
+        ]
+        self._update_solution_actions(
+            [
+                parse_solution_actions[i]
+                for i in range(curr_envs_to_keep_active.shape[0])
+                if curr_envs_to_keep_active[i]
+            ]
+        )

--- a/habitat-baselines/habitat_baselines/rl/multi_agent/pop_play_wrappers.py
+++ b/habitat-baselines/habitat_baselines/rl/multi_agent/pop_play_wrappers.py
@@ -115,9 +115,9 @@ class MultiPolicy(Policy):
     def set_active(self, active_policies):
         self._active_policies = active_policies
 
-    def pause_envs(self, envs_to_pause):
+    def on_envs_pause(self, envs_to_pause):
         for policy in self._active_policies:
-            policy.pause_envs(envs_to_pause)
+            policy.on_envs_pause(envs_to_pause)
 
     @property
     def hidden_state_shape_lens(self):

--- a/habitat-baselines/habitat_baselines/rl/ppo/evaluator.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/evaluator.py
@@ -86,7 +86,8 @@ def pause_envs(
         for k, v in batch.items():
             batch[k] = v[state_index]
 
-        rgb_frames = [rgb_frames[i] for i in state_index]
+        if rgb_frames is not None:
+            rgb_frames = [rgb_frames[i] for i in state_index]
         # actor_critic.do_pause(state_index)
 
     return (

--- a/habitat-baselines/habitat_baselines/rl/ppo/habitat_evaluator.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/habitat_evaluator.py
@@ -302,6 +302,10 @@ class HabitatEvaluator(Evaluator):
                 rgb_frames,
             )
 
+            # We pause the statefull parameters in the policy
+            if any(envs_to_pause):
+                agent.actor_critic.on_envs_pause(envs_to_pause)
+
         pbar.close()
         assert (
             len(ep_eval_count) >= number_of_eval_episodes

--- a/habitat-baselines/habitat_baselines/rl/ppo/habitat_evaluator.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/habitat_evaluator.py
@@ -302,7 +302,10 @@ class HabitatEvaluator(Evaluator):
                 rgb_frames,
             )
 
-            # We pause the statefull parameters in the policy
+            # We pause the statefull parameters in the policy.
+            # We only do this if there are envs to pause to reduce the overhead.
+            # In addition, HRL policy requires the solution_actions to be non-empty, and
+            # empty list of envs_to_pause will raise an error.
             if any(envs_to_pause):
                 agent.actor_critic.on_envs_pause(envs_to_pause)
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? --> This is to fix the issue when doing an evaluation on the HRL policy, the size of internal stateful parameters does not match the number of active skills. The issue has been known in multiple places:
(1) our team's slack channel
(2) github issues: https://github.com/facebookresearch/habitat-lab/issues/1718
(3) myself 
<img width="1081" alt="issue_be" src="https://github.com/facebookresearch/habitat-lab/assets/55121504/b9e1bfd2-dc0a-4bfb-bcb0-2edcf49b5b82">


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. --> Loading the social nav checkpoint and run full dataset evaluation

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
