### PR TITLE
Fix cross-platform context creation in HITL app

### DIFF
--- a/examples/siro_sandbox/hitl_main.py
+++ b/examples/siro_sandbox/hitl_main.py
@@ -4,6 +4,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Must call this before importing habitat or magnum!
+# Avoids EGL_BAD_ACCESS error on some platforms
+# {
+import ctypes
+import sys
+flags = sys.getdlopenflags()
+sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
+# }
+
 import magnum as mn
 from hb_config_helper import update_config_and_args
 from magnum.platform.glfw import Application

--- a/examples/siro_sandbox/hitl_main.py
+++ b/examples/siro_sandbox/hitl_main.py
@@ -9,6 +9,7 @@
 # {
 import ctypes
 import sys
+
 flags = sys.getdlopenflags()
 sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
 # }

--- a/examples/siro_sandbox/sandbox_app.py
+++ b/examples/siro_sandbox/sandbox_app.py
@@ -8,14 +8,6 @@
 See README.md in this directory.
 """
 
-import ctypes
-
-# must call this before importing habitat or magnum! avoids EGL_BAD_ACCESS error on some platforms
-import sys
-
-flags = sys.getdlopenflags()
-sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
-
 import json
 from datetime import datetime
 from functools import wraps


### PR DESCRIPTION
## Motivation and Context

This changeset moves initialization code required for cross-platform context creation from `sandbox_app.py` to `hitl_main.py`.
The code must be called before importing magnum or habitat - otherwise HITL fails on Linux (or at least, on my Fedora machine).

The code was there before, but it wasn't moved to the new entry point when the HITL app was refactored (#1738).

## How Has This Been Tested

Tested locally on Fedora.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
