### PR TITLE
Support for headless HITL apps, first pass

### DIFF
--- a/examples/hitl/pick_throw_vr/README.md
+++ b/examples/hitl/pick_throw_vr/README.md
@@ -10,6 +10,7 @@ This is an example HITL application that allows a user to interact with a scene,
 - [Pick\_throw\_vr HITL application](#pick_throw_vr-hitl-application)
   - [Installing and using HITL apps](#installing-and-using-hitl-apps)
   - [Example launch command (mouse/keyboard)](#example-launch-command-mousekeyboard)
+  - [Configuration](#configuration)
 - [VR](#vr)
   - [Installation](#installation)
     - [Requirements](#requirements)
@@ -39,6 +40,9 @@ See [habitat-hitl/README.md](../../../habitat-hitl/README.md).
 HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
 python examples/hitl/pick_throw_vr/pick_throw_vr.py
 ```
+
+## Configuration
+See `config/pick_throw_vr.yaml`. You can also use the configs in `experiment` as overrides, e.g. `python examples/hitl/pick_throw_vr/pick_throw_vr.py +experiment=headless_server`.
 
 # VR
 
@@ -79,6 +83,13 @@ HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
 python examples/hitl/pick_throw_vr/pick_throw_vr.py \
 habitat_hitl.remote_gui_mode=True
 ```
+
+We also have an experimental headless server:
+```
+python examples/hitl/pick_throw_vr/pick_throw_vr.py \
++experiment=headless_server
+```
+
 
 ## Unity Data Folder
 

--- a/examples/hitl/pick_throw_vr/config/experiment/headless_server.yaml
+++ b/examples/hitl/pick_throw_vr/config/experiment/headless_server.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+habitat_hitl:
+  window: ~
+  experimental:
+    headless:
+      do_headless: True
+      # reference for debugging
+      # debug_video_writer:
+      #   num_frames_to_save: 50
+      #   filepath_base: "./debug_video"
+      # exit_after: 40
+  remote_gui_mode: True

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -639,7 +639,14 @@ class AppStatePickThrowVr(AppState):
         # hand-picked episodes from hitl_vr_sample_episodes.json.gz
         episode_id_by_scene_index = ["0", "5", "10", "15", "20"]
         for scene_idx in range(num_fetch_scenes):
-            key = GuiInput.KeyNS(GuiInput.KeyNS.ONE.value + scene_idx)
+            key_map = [
+                GuiInput.KeyNS.ONE,
+                GuiInput.KeyNS.TWO,
+                GuiInput.KeyNS.THREE,
+                GuiInput.KeyNS.FOUR,
+                GuiInput.KeyNS.FIVE,
+            ]
+            key = key_map[scene_idx]
             if self._app_service.gui_input.get_key_down(key):
                 self._app_service.episode_helper.set_next_episode_by_id(
                     episode_id_by_scene_index[scene_idx]

--- a/habitat-hitl/habitat_hitl/_internal/gui_application.py
+++ b/habitat-hitl/habitat_hitl/_internal/gui_application.py
@@ -15,13 +15,6 @@ from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.text_drawer import TextOnScreenAlignment
 
 
-class GuiAppDriver:
-    # todo: rename to just "update"?
-    @abc.abstractmethod
-    def sim_update(self, dt):
-        pass
-
-
 class GuiAppRenderer:
     @abc.abstractmethod
     def post_sim_update(self, keyframe):
@@ -138,7 +131,6 @@ class GuiApplication(InputHandlerApplication):
         return self._sim_input
 
     def set_driver_and_renderer(self, driver, app_renderer):
-        assert isinstance(driver, GuiAppDriver)
         assert isinstance(app_renderer, GuiAppRenderer)
         self._driver = driver
         self._app_renderer = app_renderer

--- a/habitat-hitl/habitat_hitl/_internal/networking/average_rate_tracker.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/average_rate_tracker.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import time
+from typing import Union
 
 
 class AverageRateTracker:
@@ -12,17 +13,24 @@ class AverageRateTracker:
         self._recent_count: int = 0
         self._recent_time: float = time.time()
         self._duration_window: float = duration_window
-        self._recent_rate: float = 0.0
+        self._recent_rate: Union[float, None] = None
 
-    def increment(self, inc: int) -> None:
+    def increment(self, inc: int = 1):
+        """
+        Increments count for the purpose of tracking rate over time.
+
+        If a new smoothed rate was calculated, it is returned. This is a convenience in case the user wants to regularly log the smoothed framerate. See also get_smoothed_rate.
+        """
         self._recent_count += inc
-
-    def get_smoothed_rate(self) -> float:
         current_time = time.time()
         elapsed_time = current_time - self._recent_time
         if elapsed_time > self._duration_window:
             self._recent_rate = self._recent_count / elapsed_time
             self._recent_count = 0
             self._recent_time = current_time
+            return self._recent_rate
+        else:
+            return None
 
+    def get_smoothed_rate(self) -> float:
         return self._recent_rate

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -21,9 +21,18 @@ habitat_hitl:
   experimental:
     # Choose between classic and batch renderer. This is an experimental feature aimed at those of us building the batch renderer.
     use_batch_renderer: False
+    headless:
+      # Run without a GUI window. For unit-testing or use with remote_gui_mode as a headless server.
+      do_headless: False
+      # Shortly after app startup, write debug images from the first K steps to video files. See debug_third_person_viewport and debug_images.
+      debug_video_writer:
+        num_frames_to_save: 0
+        filepath_base: "./debug_video"
+      # force app exit after K steps
+      exit_after: ~
 
   debug_third_person_viewport:
-    # If specified, enable the debug third-person camera (habitat.simulator.debug_render) with specified viewport width. If height (below) is not specified, assume square aspect ratio (height==width).
+    # If specified, enable the debug third-person camera (habitat.simulator.debug_render) with specified viewport width. If height (below) is not specified, assume square aspect ratio (height==width). This is considered an additional debug image (see also debug_images below).
     width: ~
     # If specified, use the specified viewport height for the debug third-person camera.
     height: ~

--- a/habitat-hitl/habitat_hitl/core/debug_video_writer.py
+++ b/habitat-hitl/habitat_hitl/core/debug_video_writer.py
@@ -6,6 +6,13 @@
 
 
 class DebugVideoWriter:
+    """
+    Helper class to write debug images to video files.
+
+    This is a thin wrapper over habitat_sim.utils.viz_utils.make_video. The expected
+    input is exactly HitlDriver's post_sim_update_dict["debug_images"].
+    """
+
     def __init__(self, fps=10):
         self._cached_images = None
         self._fps = fps

--- a/habitat-hitl/habitat_hitl/core/debug_video_writer.py
+++ b/habitat-hitl/habitat_hitl/core/debug_video_writer.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class DebugVideoWriter:
+    def __init__(self, fps=10):
+        self._cached_images = None
+        self._fps = fps
+
+    def add_frame(self, debug_images_for_frame):
+        if self._cached_images is None:
+            self._cached_images = []
+            for image in debug_images_for_frame:
+                self._cached_images.append([image])
+        else:
+            for image_idx, image in enumerate(debug_images_for_frame):
+                assert self._cached_images[image_idx][0].shape == image.shape
+                self._cached_images[image_idx].append(image)
+
+    def write(self, filepath_base):
+        if self._cached_images is not None:
+            import numpy as np
+
+            from habitat_sim.utils import viz_utils as vut
+
+            for image_idx, images in enumerate(self._cached_images):
+                np_images = np.array(images)
+                np_images = np_images[:, ::-1, :, :]  # flip vertically
+                np_images = np.expand_dims(
+                    np_images, 1
+                )  # add dummy dimension required by vut.make_video
+                vut.make_video(
+                    np_images,
+                    0,
+                    "color",
+                    f"{filepath_base}{image_idx}",
+                    fps=self._fps,
+                    open_vid=False,
+                )

--- a/habitat-hitl/habitat_hitl/core/gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/gui_input.py
@@ -4,13 +4,44 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from magnum.platform.glfw import Application
+# GuiInput relies on the magnum.platform.glfw.Application.KeyEvent.Key enum and similar for mouse buttons. On headless systems, we may be unable to import magnum.platform.glfw.Application. Fall back to a stub implementation of GuiInput in that case.
+do_stub_gui_input = False
+try:
+    from magnum.platform.glfw import Application
+except ImportError:
+    print(
+        "GuiInput warning: Failed to magnum.platform.glfw. Falling back to stub implementation. Local keyboard/mouse input won't work."
+    )
+    do_stub_gui_input = True
+
+if do_stub_gui_input:
+
+    class StubNSMeta(type):
+        def __getattr__(cls, name):
+            return None
+
+    # Stub version of Application.KeyEvent.Key
+    class StubKeyNS(metaclass=StubNSMeta):
+        pass
+
+    # Stub version of Application.MouseEvent.Button
+    class StubMouseNS(metaclass=StubNSMeta):
+        pass
 
 
-# This key and mouse-button is API based loosely on https://docs.unity3d.com/ScriptReference/Input.html
 class GuiInput:
-    KeyNS = Application.KeyEvent.Key
-    MouseNS = Application.MouseEvent.Button
+    """
+    Container to hold the state of keyboard/mouse input.
+
+    This class isn't usable by itself for getting input from the underlying OS. I.e. it won't self-populate from underlying OS input APIs. See also gui_application.py InputHandlerApplication.
+    """
+
+    if do_stub_gui_input:
+        KeyNS = StubKeyNS
+        MouseNS = StubMouseNS
+    else:
+        KeyNS = Application.KeyEvent.Key
+        MouseNS = Application.MouseEvent.Button
 
     def __init__(self):
         self._key_held = set()
@@ -25,8 +56,16 @@ class GuiInput:
         self._mouse_scroll_offset = 0
         self._mouse_ray = None
 
+    @property
+    def is_stub_implementation(self):
+        """
+        Indicates whether this is a stub implementation. If so, it'll return False for all queries like get_key_down(...).
+        """
+        return do_stub_gui_input
+
     def validate_key(key):
-        assert isinstance(key, Application.KeyEvent.Key)
+        if not do_stub_gui_input:
+            assert isinstance(key, Application.KeyEvent.Key)
 
     def get_key(self, key):
         GuiInput.validate_key(key)
@@ -44,7 +83,8 @@ class GuiInput:
         return key in self._key_up
 
     def validate_mouse_button(mouse_button):
-        assert isinstance(mouse_button, Application.MouseEvent.Button)
+        if not do_stub_gui_input:
+            assert isinstance(mouse_button, Application.MouseEvent.Button)
 
     def get_mouse_button(self, mouse_button):
         GuiInput.validate_mouse_button(mouse_button)

--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -5,19 +5,21 @@
 # LICENSE file in the root directory of this source tree.
 
 import magnum as mn
-from magnum.platform.glfw import Application
 
 from habitat_hitl._internal.config_helper import update_config
-from habitat_hitl._internal.gui_application import GuiApplication
 from habitat_hitl._internal.hitl_driver import HitlDriver
-from habitat_hitl._internal.replay_gui_app_renderer import ReplayGuiAppRenderer
+from habitat_hitl._internal.networking.average_rate_tracker import (
+    AverageRateTracker,
+)
+from habitat_hitl._internal.networking.frequency_limiter import (
+    FrequencyLimiter,
+)
+from habitat_hitl.core.gui_input import GuiInput
+from habitat_hitl.core.hydra_utils import omegaconf_to_object
 
 
-def _parse_debug_third_person(hitl_config, framebuffer_size):
-    viewport_multiplier = mn.Vector2(
-        framebuffer_size.x / hitl_config.window.width,
-        framebuffer_size.y / hitl_config.window.height,
-    )
+def _parse_debug_third_person(hitl_config, viewport_multiplier=(1, 1)):
+    assert viewport_multiplier[0] > 0 and viewport_multiplier[1] > 0
 
     do_show = hitl_config.debug_third_person_viewport.width is not None
 
@@ -30,8 +32,8 @@ def _parse_debug_third_person(hitl_config, framebuffer_size):
             else width
         )
 
-        width = int(width * viewport_multiplier.x)
-        height = int(height * viewport_multiplier.y)
+        width = int(width * viewport_multiplier[0])
+        height = int(height * viewport_multiplier[1])
     else:
         width = 0
         height = 0
@@ -39,8 +41,23 @@ def _parse_debug_third_person(hitl_config, framebuffer_size):
     return do_show, width, height
 
 
-def hitl_main(config, create_app_state_lambda=None):
-    hitl_config = config.habitat_hitl
+def hitl_main(app_config, create_app_state_lambda=None):
+    hitl_config = omegaconf_to_object(app_config.habitat_hitl)
+
+    if hitl_config.experimental.headless.do_headless:
+        hitl_headless_main(hitl_config, app_config, create_app_state_lambda)
+    else:
+        hitl_headed_main(hitl_config, app_config, create_app_state_lambda)
+
+
+def hitl_headed_main(hitl_config, app_config, create_app_state_lambda):
+    from magnum.platform.glfw import Application
+
+    from habitat_hitl._internal.gui_application import GuiApplication
+    from habitat_hitl._internal.replay_gui_app_renderer import (
+        ReplayGuiAppRenderer,
+    )
+
     glfw_config = Application.Configuration()
     glfw_config.title = hitl_config.window.title
     glfw_config.size = (hitl_config.window.width, hitl_config.window.height)
@@ -48,11 +65,16 @@ def hitl_main(config, create_app_state_lambda=None):
     # on Mac Retina displays, this will be 2x the window size
     framebuffer_size = gui_app_wrapper.get_framebuffer_size()
 
+    viewport_multiplier = (
+        framebuffer_size.x // hitl_config.window.width,
+        framebuffer_size.y // hitl_config.window.height,
+    )
+
     (
         show_debug_third_person,
         debug_third_person_width,
         debug_third_person_height,
-    ) = _parse_debug_third_person(hitl_config, framebuffer_size)
+    ) = _parse_debug_third_person(hitl_config, viewport_multiplier)
 
     viewport_rect = None
     if show_debug_third_person:
@@ -74,14 +96,14 @@ def hitl_main(config, create_app_state_lambda=None):
     )
 
     update_config(
-        config,
+        app_config,
         show_debug_third_person=show_debug_third_person,
         debug_third_person_width=debug_third_person_width,
         debug_third_person_height=debug_third_person_height,
     )
 
     driver = HitlDriver(
-        config,
+        app_config,
         gui_app_wrapper.get_sim_input(),
         app_renderer._replay_renderer.debug_line_render(0),
         app_renderer._text_drawer,
@@ -90,8 +112,9 @@ def hitl_main(config, create_app_state_lambda=None):
 
     # sanity check if there are no agents with camera sensors
     if (
-        len(config.habitat.simulator.agents) == 1
-        and config.habitat_hitl.gui_controlled_agent.agent_index is not None
+        len(app_config.habitat.simulator.agents) == 1
+        and app_config.habitat_hitl.gui_controlled_agent.agent_index
+        is not None
     ):
         assert driver.get_sim().renderer is None
 
@@ -102,6 +125,104 @@ def hitl_main(config, create_app_state_lambda=None):
     driver.close()
 
 
-if __name__ == "__main__":
-    raise RuntimeError("not implemented")
-    # hitl_main(None, None)
+def _headless_app_loop(hitl_config, driver):
+    headless_config = hitl_config.experimental.headless
+    frequency_limiter = FrequencyLimiter(hitl_config.target_sps)
+    rate_tracker = AverageRateTracker(1.0)
+    dt = 1.0 / hitl_config.target_sps
+
+    step_count = 0
+
+    video_config = headless_config.debug_video_writer
+    video_helper = None
+    if video_config.num_frames_to_save > 0:
+        from habitat_hitl.core.debug_video_writer import DebugVideoWriter
+
+        video_helper = DebugVideoWriter()
+
+    while True:
+        post_sim_update_dict = driver.sim_update(dt)
+
+        if "application_exit" in post_sim_update_dict:
+            break
+
+        if step_count < video_config.num_frames_to_save:
+            video_helper.add_frame(post_sim_update_dict["debug_images"])
+            if step_count == video_config.num_frames_to_save - 1:
+                video_helper.write(video_config.filepath_base)
+                video_helper = None
+
+        frequency_limiter.limit_frequency()
+
+        new_rate = rate_tracker.increment()
+        if new_rate is not None:
+            print(f"SPS: {new_rate:.1f}")
+
+        step_count += 1
+        if (
+            headless_config.exit_after is not None
+            and step_count == headless_config.exit_after
+        ):
+            break
+
+    if video_helper:
+        video_helper.write(video_config.filepath_base)
+
+    driver.close()
+
+
+def hitl_headless_main(hitl_config, config, create_app_state_lambda=None):
+    from habitat_hitl.core.text_drawer import StubTextDrawer
+
+    if hitl_config.window is not None:
+        raise ValueError(
+            "For habitat_hitl.headless.do_headless=True, habitat_hitl.window should be None."
+        )
+
+    (
+        show_debug_third_person,
+        debug_third_person_width,
+        debug_third_person_height,
+    ) = _parse_debug_third_person(hitl_config)
+
+    update_config(
+        config,
+        show_debug_third_person=show_debug_third_person,
+        debug_third_person_width=debug_third_person_width,
+        debug_third_person_height=debug_third_person_height,
+    )
+
+    class StubLineRender:
+        """
+        Stub version of DebugLineRender that does nothing.
+
+        DebugLineRender has a large public interface. Rather than duplicate it, let's just
+        allow any method to be called.
+        """
+
+        def __getattr__(self, name):
+            # This method is called for any attribute not found on the object
+            def any_method(*args, **kwargs):
+                # This function accepts any arguments and does nothing
+                return None
+
+            return any_method
+
+    driver = HitlDriver(
+        config,
+        GuiInput(),
+        StubLineRender(),
+        StubTextDrawer(),
+        create_app_state_lambda,
+    )
+
+    # sanity check if there are no agents with camera sensors
+    if (
+        len(config.habitat.simulator.agents) == 1
+        and config.habitat_hitl.gui_controlled_agent.agent_index is not None
+    ):
+        assert driver.get_sim().renderer is None
+
+    _headless_app_loop(hitl_config, driver)
+
+    driver.close()

--- a/habitat-hitl/habitat_hitl/core/text_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/text_drawer.py
@@ -6,11 +6,20 @@
 
 import os
 import string
+from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, Tuple
 
 import magnum as mn
-from magnum import shaders, text
+
+disable_text_drawer = False
+try:
+    from magnum import shaders, text
+except ImportError:
+    print(
+        "text_drawer.py warning: Failed to magnum.shaders,text. TextDrawer isn't available."
+    )
+    disable_text_drawer = True
 
 DEFAULT_FONT_PATH = "./fonts/ProggyClean.ttf"
 
@@ -44,46 +53,8 @@ class TextOnScreenAlignment(Enum):
     BOTTOM_RIGHT = (-TEXT_DELTA_FROM_CENTER, TEXT_DELTA_FROM_CENTER / 2)
 
 
-class TextDrawer:
-    def __init__(
-        self,
-        framebuffer_size: mn.Vector2i,
-        relative_path_to_font: str = DEFAULT_FONT_PATH,
-        max_display_text_chars: int = MAX_DISPLAY_TEXT_CHARS,
-        display_font_size: float = DISPLAY_FONT_SIZE,
-    ) -> None:
-        self._text_transform_pairs: List[Tuple[str, mn.Matrix3]] = []
-        self._framebuffer_size = framebuffer_size
-
-        # Load a TrueTypeFont plugin and open the font file
-        self._display_font = text.FontManager().load_and_instantiate(
-            "TrueTypeFont"
-        )
-        self._display_font.open_file(
-            os.path.join(os.path.dirname(__file__), relative_path_to_font),
-            13,
-        )
-        self._display_font_size = display_font_size
-        self._max_display_text_chars = max_display_text_chars
-
-        # Glyphs we need to render everything
-        self._glyph_cache = text.GlyphCache(mn.Vector2i(256))
-        self._display_font.fill_glyph_cache(
-            self._glyph_cache,
-            string.ascii_lowercase
-            + string.ascii_uppercase
-            + string.digits
-            + ":-_+,.! %µ",
-        )
-        self._shader = shaders.VectorGL2D()
-        self._window_text = text.Renderer2D(
-            self._display_font,
-            self._glyph_cache,
-            display_font_size,
-            text.Alignment.TOP_LEFT,
-        )
-        self._window_text.reserve(self._max_display_text_chars)
-
+class AbstractTextDrawer(ABC):
+    @abstractmethod
     def add_text(
         self,
         text_to_add,
@@ -92,45 +63,114 @@ class TextDrawer:
         text_delta_y: int = 0,
     ):
         """
-        Adds `text_to_add` and corresponding window text transform to `self._text_transform_pairs`.
-            :param text_to_add: text to be added to `self._text_transform_pairs` for drawing
-            :param alignment: window text anchor of type TextOnScreenAlignment, defaults to top left corner
-            :param text_delta_x: pixels delta to move/adjust window text anchor along X axis,
-            :param text_delta_y: pixels delta to move/adjust window text anchor along Y axis,
+        Draw text on-screen.
         """
 
-        # text object transform in window space is Projection matrix times Translation Matrix
-        # put text in top left of window
-        align_y, align_x = alignment.value
-        window_text_transform = mn.Matrix3.projection(
-            self._framebuffer_size
-        ) @ mn.Matrix3.translation(
-            mn.Vector2(self._framebuffer_size) * mn.Vector2(align_x, align_y)
-            + mn.Vector2(text_delta_x, text_delta_y)
-        )
-        self._text_transform_pairs.append((text_to_add, window_text_transform))
 
-    def draw_text(self):
-        # make magnum text background transparent
-        mn.gl.Renderer.enable(mn.gl.Renderer.Feature.BLENDING)
-        mn.gl.Renderer.set_blend_function(
-            mn.gl.Renderer.BlendFunction.ONE,
-            mn.gl.Renderer.BlendFunction.ONE_MINUS_SOURCE_ALPHA,
-        )
-        mn.gl.Renderer.set_blend_equation(
-            mn.gl.Renderer.BlendEquation.ADD, mn.gl.Renderer.BlendEquation.ADD
-        )
+class StubTextDrawer(AbstractTextDrawer):
+    def add_text(
+        self,
+        text_to_add,
+        alignment: TextOnScreenAlignment = TextOnScreenAlignment.TOP_LEFT,
+        text_delta_x: int = 0,
+        text_delta_y: int = 0,
+    ):
+        pass
 
-        """Draws collected text on the screen"""
-        self._shader.bind_vector_texture(self._glyph_cache.texture)
-        for text_to_draw, transform in self._text_transform_pairs:
-            self._shader.transformation_projection_matrix = transform
-            self._shader.color = [1.0, 1.0, 1.0]
-            self._window_text.render(text_to_draw)
-            self._shader.draw(self._window_text.mesh)
-        self._text_transform_pairs.clear()
 
-        # sloppy: disable blending here so that other rendering subsystems (e.g.
-        # DebugLineRender) will be forced to enable and configure blending when they
-        # render
-        mn.gl.Renderer.disable(mn.gl.Renderer.Feature.BLENDING)
+if not disable_text_drawer:
+
+    class TextDrawer(AbstractTextDrawer):
+        def __init__(
+            self,
+            framebuffer_size: mn.Vector2i,
+            relative_path_to_font: str = DEFAULT_FONT_PATH,
+            max_display_text_chars: int = MAX_DISPLAY_TEXT_CHARS,
+            display_font_size: float = DISPLAY_FONT_SIZE,
+        ) -> None:
+            self._text_transform_pairs: List[Tuple[str, mn.Matrix3]] = []
+            self._framebuffer_size = framebuffer_size
+
+            # Load a TrueTypeFont plugin and open the font file
+            self._display_font = text.FontManager().load_and_instantiate(
+                "TrueTypeFont"
+            )
+            self._display_font.open_file(
+                os.path.join(os.path.dirname(__file__), relative_path_to_font),
+                13,
+            )
+            self._display_font_size = display_font_size
+            self._max_display_text_chars = max_display_text_chars
+
+            # Glyphs we need to render everything
+            self._glyph_cache = text.GlyphCache(mn.Vector2i(256))
+            self._display_font.fill_glyph_cache(
+                self._glyph_cache,
+                string.ascii_lowercase
+                + string.ascii_uppercase
+                + string.digits
+                + ":-_+,.! %µ",
+            )
+            self._shader = shaders.VectorGL2D()
+            self._window_text = text.Renderer2D(
+                self._display_font,
+                self._glyph_cache,
+                display_font_size,
+                text.Alignment.TOP_LEFT,
+            )
+            self._window_text.reserve(self._max_display_text_chars)
+
+        def add_text(
+            self,
+            text_to_add,
+            alignment: TextOnScreenAlignment = TextOnScreenAlignment.TOP_LEFT,
+            text_delta_x: int = 0,
+            text_delta_y: int = 0,
+        ):
+            """
+            Adds `text_to_add` and corresponding window text transform to `self._text_transform_pairs`.
+                :param text_to_add: text to be added to `self._text_transform_pairs` for drawing
+                :param alignment: window text anchor of type TextOnScreenAlignment, defaults to top left corner
+                :param text_delta_x: pixels delta to move/adjust window text anchor along X axis,
+                :param text_delta_y: pixels delta to move/adjust window text anchor along Y axis,
+            """
+
+            # text object transform in window space is Projection matrix times Translation Matrix
+            # put text in top left of window
+            align_y, align_x = alignment.value
+            window_text_transform = mn.Matrix3.projection(
+                self._framebuffer_size
+            ) @ mn.Matrix3.translation(
+                mn.Vector2(self._framebuffer_size)
+                * mn.Vector2(align_x, align_y)
+                + mn.Vector2(text_delta_x, text_delta_y)
+            )
+            self._text_transform_pairs.append(
+                (text_to_add, window_text_transform)
+            )
+
+        def draw_text(self):
+            # make magnum text background transparent
+            mn.gl.Renderer.enable(mn.gl.Renderer.Feature.BLENDING)
+            mn.gl.Renderer.set_blend_function(
+                mn.gl.Renderer.BlendFunction.ONE,
+                mn.gl.Renderer.BlendFunction.ONE_MINUS_SOURCE_ALPHA,
+            )
+            mn.gl.Renderer.set_blend_equation(
+                mn.gl.Renderer.BlendEquation.ADD,
+                mn.gl.Renderer.BlendEquation.ADD,
+            )
+
+            """Draws collected text on the screen"""
+            self._shader.bind_vector_texture(self._glyph_cache.texture)
+            for text_to_draw, transform in self._text_transform_pairs:
+                self._shader.transformation_projection_matrix = transform
+                self._shader.color = [1.0, 1.0, 1.0]
+                self._window_text.render(text_to_draw)
+                self._shader.draw(self._window_text.mesh)
+            self._text_transform_pairs.clear()
+
+            # sloppy: disable blending here so that other rendering subsystems (e.g.
+            # DebugLineRender) will be forced to enable and configure blending when they
+            # render
+            mn.gl.Renderer.disable(mn.gl.Renderer.Feature.BLENDING)

--- a/habitat-hitl/habitat_hitl/core/text_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/text_drawer.py
@@ -68,6 +68,12 @@ class AbstractTextDrawer(ABC):
 
 
 class StubTextDrawer(AbstractTextDrawer):
+    """
+    Stub TextDrawer class. Has no effect but allows user code to run without error.
+
+    This is intended for use with habitat_hitl.headless. See also TextDrawer.
+    """
+
     def add_text(
         self,
         text_to_add,


### PR DESCRIPTION
## Motivation and Context

"Headless" means no attached local display. A headless mode is useful for (1) unit-testing on headless CI machines, and (2) the client/server model, with Pick_throw_vr running as a server (`remote_gui_mode`) on e.g. a headless cloud machine.

With this PR, the Unity client can connect to the headless server and e.g. view the animated scene. However, as a first pass, this doesn't actually 100% work with clients yet because of the way I've completely stubbed out GuiInput (which RemoteGuiInput needs).

## How Has This Been Tested

Locally tested on Macbook. Tested on headless Ubuntu EC2 instance with Unity client connected.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[HITL Framework\]** 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
