### PR TITLE
Add habitat_hitl.disable_agents_and_stepping config param

### DIFF
--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -22,6 +22,9 @@ habitat_hitl:
     # Choose between classic and batch renderer. This is an experimental feature aimed at those of us building the batch renderer.
     use_batch_renderer: False
 
+  # Disable policy-initialization and environment-stepping. Useful for testing on lower-power machines.
+  disable_policies_and_stepping: False
+
   debug_third_person_viewport:
     # If specified, enable the debug third-person camera (habitat.simulator.debug_render) with specified viewport width. If height (below) is not specified, assume square aspect ratio (height==width).
     width: ~


### PR DESCRIPTION
## Motivation and Context

This is handy if you just want to load scenes but not run policies or otherwise simulate agents. Because this codepath bypasses all policy initialization and inference code, it's also potentially a way to test a HITL app on lower-power machines.

To use this feature, enable it through the Hydra config. You could edit the config yaml, or add a command-line argument, e.g.:
`python examples/hitl/basic_viewer/basic_viewer.py habitat_hitl.disable_policies_and_stepping=True`

## How Has This Been Tested

Local testing on Macbook.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[HITL framework\]** 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
