### PR TITLE
Fixed config habitat_hitl.episodes_filter='4' and episodes_filter episode order

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -12,7 +12,7 @@ import abc
 import json
 from datetime import datetime
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Dict, List, Set
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import numpy as np
 
@@ -84,7 +84,7 @@ class HitlDriver(AppDriver):
             )
         self._hitl_config = omegaconf_to_object(config.habitat_hitl)
         self._dataset_config = config.habitat.dataset
-        self._play_episodes_filter_str = self._hitl_config.episodes_filter
+        self._play_episodes_filter_str = str(self._hitl_config.episodes_filter)
         self._num_recorded_episodes = 0
         if (
             not self._hitl_config.experimental.headless
@@ -236,33 +236,42 @@ class HitlDriver(AppDriver):
         dataset = make_dataset(
             id_dataset=dataset_config.type, config=dataset_config
         )
-
         if self._play_episodes_filter_str is not None:
             max_num_digits: int = len(str(len(dataset.episodes)))
 
             def get_play_episodes_ids(play_episodes_filter_str):
-                play_episodes_ids: Set[str] = set()
+                play_episodes_ids: List[str] = []
                 for ep_filter_str in play_episodes_filter_str.split(" "):
                     if ":" in ep_filter_str:
                         range_params = map(int, ep_filter_str.split(":"))
-                        play_episodes_ids.update(
+                        play_episodes_ids.extend(
                             episode_id.zfill(max_num_digits)
                             for episode_id in map(str, range(*range_params))
                         )
                     else:
                         episode_id = ep_filter_str
-                        play_episodes_ids.add(episode_id.zfill(max_num_digits))
+                        play_episodes_ids.append(
+                            episode_id.zfill(max_num_digits)
+                        )
 
                 return play_episodes_ids
 
-            play_episodes_ids_set: Set[str] = get_play_episodes_ids(
+            play_episodes_ids_list = get_play_episodes_ids(
                 self._play_episodes_filter_str
             )
+
             dataset.episodes = [
                 ep
                 for ep in dataset.episodes
-                if ep.episode_id.zfill(max_num_digits) in play_episodes_ids_set
+                if ep.episode_id.zfill(max_num_digits)
+                in play_episodes_ids_list
             ]
+
+            dataset.episodes.sort(
+                key=lambda x: play_episodes_ids_list.index(
+                    x.episode_id.zfill(max_num_digits)
+                )
+            )
 
         return dataset
 


### PR DESCRIPTION
Fixed error when using config habitat_hitl.episodes_filter='4' and Fixed episodes_filter episode order not respected

**Types of changes**
config habitat_hitl.episodes_filter='4' Casting int->str

episodes_filter episode not in order To keep the sequence, the update uses a list instead of a set to preserve order, appends/extends to list instead of adding to set, and returns the final list

**Local Testing**
To test this change:

Checked out branch fix/episodes_filter
Modified config.yaml to set habitat_hitl.episodes_filter='4'
Ran training job and confirmed no errors when parsing filter
Modified config.yaml to complex filter string: "1000:2000:100 3000 4000 0:10:3"
Inspected order of episode ids before and after change and confirmed order matches filter string
Ran full pipeline with updated filter logic and confirmed no issues