### PR TITLE
(1) Fixed error when using config habitat_hitl.episodes_filter='4' (2) Fixed episodes_filter episode order not respected (3) added check for data folder in current working directory

### DIFF
--- a/examples/hitl/basic_viewer/README.md
+++ b/examples/hitl/basic_viewer/README.md
@@ -7,6 +7,9 @@ Inspect Habitat environments, episodes, and agent policy evaluation in real time
 ## Installing and using HITL apps
 See [habitat-hitl/README.md](../../../habitat-hitl/README.md)
 
+## To run
+cd path/to/habitat-lab # Or wherever data/ is symlinked
+
 ## Example launch command
 
 ```bash

--- a/examples/hitl/minimal/README.md
+++ b/examples/hitl/minimal/README.md
@@ -1,3 +1,7 @@
 # Minimal HITL application
 
 A minimal HITL app that loads and steps a Habitat environment, with a fixed overhead camera. See [`habitat_hitl/README.md`](../../../habitat-hitl/README.md#minimal-hitl-application)
+
+# To run
+
+cd path/to/habitat-lab # Or wherever data/ is symlinked

--- a/habitat-hitl/README.md
+++ b/habitat-hitl/README.md
@@ -36,7 +36,7 @@ Example HITL apps are configured to run at 30 steps per second (SPS). If your sy
         * Be sure to include Bullet physics, e.g. `python setup.py install --bullet`.
 4. Install the `habitat-hitl` package.
     * From the `habitat-lab` root directory, run `pip install -e habitat-hitl`.
-5. Download required assets for our example HITL applications:
+5. Download required assets for our example HITL applications (Note that the dataset downloader should be run from habitat-lab/.):
     ```bash
     python -m habitat_sim.utils.datasets_download \
     --uids hab3-episodes habitat_humanoids hab_spot_arm ycb hssd-hab \

--- a/habitat-hitl/README.md
+++ b/habitat-hitl/README.md
@@ -43,13 +43,12 @@ Example HITL apps are configured to run at 30 steps per second (SPS). If your sy
     --data-path data/
     ```
 
-## Run Requirements
+## Data directory and running location
 
-HITL apps expect a `data/` directory in the running location. This can be satisfied by:
+HITL apps (and Habitat libraries in general) expect a `data/` directory in the running location (aka current working directory). Notice the `--data-path` argument in our installation steps above. Here are two options to consider:
 
-1. Running HITL directly from habitat-lab/ where the data directory exists
-2. Symlinking `data/` from habitat-lab into another location
-3. Placing compatible Habitat dataset into a `data/` folder in the running directory
+1. Download data to `habitat-lab/data` as shown in our installation steps above. This is the default location for many Habitat tutorials and utilities. Run your HITL app from this location, e.g. `habitat-lab/$ python /path/to/my_hitl_app/my_hitl_app.py`.
+2. Download (or symlink) data to your HITL app's root directory, e.g. `/path/to/my_hitl_app/data`. Run your HITL app from this location, e.g. `/path/to/my_hitl_app/$ python my_hitl_app.py`."
 
 ## Example HITL applications
 

--- a/habitat-hitl/README.md
+++ b/habitat-hitl/README.md
@@ -43,6 +43,14 @@ Example HITL apps are configured to run at 30 steps per second (SPS). If your sy
     --data-path data/
     ```
 
+## Run Requirements
+
+HITL apps expect a `data/` directory in the running location. This can be satisfied by:
+
+1. Running HITL directly from habitat-lab/ where the data directory exists
+2. Symlinking `data/` from habitat-lab into another location
+3. Placing compatible Habitat dataset into a `data/` folder in the running directory
+
 ## Example HITL applications
 
 Check out our example HITL apps [here](../examples/hitl/).

--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+
 import magnum as mn
 
 from habitat_hitl._internal.config_helper import update_config
@@ -42,6 +44,14 @@ def _parse_debug_third_person(hitl_config, viewport_multiplier=(1, 1)):
 
 
 def hitl_main(app_config, create_app_state_lambda=None):
+    # Add check for data/
+    if not os.path.exists("data/"):
+        raise FileNotFoundError(
+            "Could not find /data in current directory. "
+            "HITL apps expect 'data/' directory to exist. "
+            "Either run from habitat-lab directory or symlink data/ folder to your HITL app working directory"
+        )
+
     hitl_config = omegaconf_to_object(app_config.habitat_hitl)
 
     if hitl_config.experimental.headless.do_headless:


### PR DESCRIPTION
## Motivation and Context

Fix error when using habitat_hitl.episodes_filter config value. Fixed episodes_filter episode order not respected Add check for required `data/` directory at runtime. Update docs with data directory requirements. 

Related to issues:
https://app.asana.com/0/0/1206342374687783/f
https://app.asana.com/0/0/1206329593074711/f
https://app.asana.com/0/0/1206363026162478/f

## How Has This Been Tested

- Locally tested habitat_hitl.episodes_filter config with string values containing integers (ex: '4') and verified no errors for minimal, basic_viewer, and pick_throw_vr apps.
- Tested order of episodes when setting episodes_filter with edge cases.
- Added data directory check in code and tested with missing `data/` folder
- Updated READMEs with example launch command directories  

## Types of changes

- **[Bug Fix]** habitat_hitl.episodes_filter int casting issue
- **[Bug Fix]** habitat_hitl.episodes_filter episode order not respected
- **[Docs change]** Added data directory requirements to HITL documentation
- **[Bug Fix]** Runtime check for `data/` folder with error message

## Checklist

- [x] My code follows the code style of this project.  
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
