### PR TITLE
HITL - Fix debug viewport size calculation.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -68,6 +68,9 @@ def hitl_headed_main(hitl_config, app_config, create_app_state_lambda):
         ReplayGuiAppRenderer,
     )
 
+    assert hitl_config.window.width > 0
+    assert hitl_config.window.height > 0
+
     glfw_config = Application.Configuration()
     glfw_config.title = hitl_config.window.title
     glfw_config.size = (hitl_config.window.width, hitl_config.window.height)
@@ -76,8 +79,8 @@ def hitl_headed_main(hitl_config, app_config, create_app_state_lambda):
     framebuffer_size = gui_app_wrapper.get_framebuffer_size()
 
     viewport_multiplier = (
-        framebuffer_size.x // hitl_config.window.width,
-        framebuffer_size.y // hitl_config.window.height,
+        framebuffer_size.x / hitl_config.window.width,
+        framebuffer_size.y / hitl_config.window.height,
     )
 
     (


### PR DESCRIPTION
## Motivation and Context

Use floating point division instead of integer division to resolve viewport multiplier. Fractional DPI (<1.0) would result in a 0 viewport multiplier when rounding down after division.

This fixes the following error when creating a debug view in the HITL tool:
`assert viewport_multiplier[0] > 0 and viewport_multiplier[1] > 0` _(hitl_main.py)_

## How Has This Been Tested

Tested locally on: Fedora + KDE + RPM Fusion NVIDIA drivers

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
