### PR TITLE
correction2 of type-cast when self._hitl_config.episodes_filter==None

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -84,7 +84,7 @@ class HitlDriver(AppDriver):
             )
         self._hitl_config = omegaconf_to_object(config.habitat_hitl)
         self._dataset_config = config.habitat.dataset
-        self._play_episodes_filter_str = str(self._hitl_config.episodes_filter)
+        self._play_episodes_filter_str = self._hitl_config.episodes_filter
         self._num_recorded_episodes = 0
         if (
             not self._hitl_config.experimental.headless


### PR DESCRIPTION
## Motivation and Context

Correction of redundant type cast when self._hitl_config.episodes_filter==None

## How Has This Been Tested

tested locally

## Types of changes


- **\[Bug Fix\]** Omitted redundant type cast

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] I have updated the documentation if required.
- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ x] I have completed my CLA (see **CONTRIBUTING**)
- [ x] I have added tests to cover my changes if required.
