### PR TITLE
HITL - Fix 'None' episode filter.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -84,7 +84,11 @@ class HitlDriver(AppDriver):
             )
         self._hitl_config = omegaconf_to_object(config.habitat_hitl)
         self._dataset_config = config.habitat.dataset
-        self._play_episodes_filter_str = str(self._hitl_config.episodes_filter)
+        self._play_episodes_filter_str = (
+            str(self._hitl_config.episodes_filter)
+            if self._hitl_config.episodes_filter
+            else None
+        )
         self._num_recorded_episodes = 0
         if (
             not self._hitl_config.experimental.headless


### PR DESCRIPTION
## Motivation and Context

This fixes a bug where the absence of an episode filter is interpreted as a "None" string instead of `None`, causing the HITL tool to fail.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
