### PR TITLE
Use receptacle unique name for dictionary key

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -673,7 +673,7 @@ class RearrangeSim(HabitatSim):
                     ],
                     axis=0,
                 )
-                receps[recep.name] = mn.Range3D(
+                receps[recep.unique_name] = mn.Range3D(
                     np.min(bounds, axis=0), np.max(bounds, axis=0)
                 )
             self._receptacles_cache[scene_id] = receps


### PR DESCRIPTION
## Motivation and Context

Multiple Receptacles in a scene may have the same name, instead unique_name should be used to refer to specific Receptacle instances.

Specifically, whenever an object with a Receptacle annotation is instantiated multiple times in a scene, all Receptacles for that object will have the same name.

TODO: there may be ramifications to this change which needs to be addressed.

## How Has This Been Tested

TODO: 

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
