### PR TITLE
Remove RTLD_GLOBAL flag from apps.

### DIFF
--- a/examples/hitl/basic_viewer/basic_viewer.py
+++ b/examples/hitl/basic_viewer/basic_viewer.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ctypes
-import sys
-
-# must call this before importing habitat or magnum! avoids runtime errors on some platforms
-sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
-
 import hydra
 import magnum as mn
 

--- a/examples/hitl/minimal/minimal.py
+++ b/examples/hitl/minimal/minimal.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ctypes
-import sys
-
-# must call this before importing habitat or magnum! avoids runtime errors on some platforms
-sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
-
 import hydra
 import magnum
 

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ctypes
-import sys
-
-# must call this before importing habitat or magnum! avoids runtime errors on some platforms
-sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
-
 from typing import Final
 
 import hydra

--- a/examples/hitl/rearrange/rearrange.py
+++ b/examples/hitl/rearrange/rearrange.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ctypes
-import sys
-
-# must call this before importing habitat or magnum! avoids runtime errors on some platforms
-sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
-
 import hydra
 import magnum as mn
 import numpy as np

--- a/habitat-hitl/README.md
+++ b/habitat-hitl/README.md
@@ -86,11 +86,6 @@ defaults:
 ```
 # minimal.py
 
-import ctypes, sys
-
-# must call this before importing habitat or magnum! avoids runtime errors on some platforms
-sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
-
 import hydra
 import magnum
 


### PR DESCRIPTION
## Motivation and Context

This removes the `RTLD_GLOBAL` flag from python apps, which is no longer required since [this magnum update](https://github.com/facebookresearch/habitat-sim/pull/2309).

This flag was required before loading native magnum/habitat modules to de-duplicate globals across shared modules. [This is now done automatically when importing corrade.](https://github.com/mosra/magnum-bindings/commit/b4d437bb3ff7bf925064532a39b02c7e6ee1356f#diff-e6d652e2d587ecbff4369a8f11be89982863d5f613feb96777d9aa95136d1675).

[This PR](https://github.com/facebookresearch/habitat-sim/pull/2312) does the same changes in `habitat-sim`.

## How Has This Been Tested

Tested locally on Linux.

## Types of changes

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
