### PR TITLE
HITL - Check remote client input.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/remote_gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/remote_gui_input.py
@@ -43,9 +43,13 @@ class RemoteGuiInput:
         if history_index >= len(self._recent_client_states):
             return None, None
 
-        avatar_root_json = self._recent_client_states[history_index]["avatar"][
-            "root"
-        ]
+        client_state = self._recent_client_states[history_index]
+
+        if "avatar" not in client_state:
+            return None, None
+
+        avatar_root_json = client_state["avatar"]["root"]
+
         pos_json = avatar_root_json["position"]
         pos = mn.Vector3(pos_json[0], pos_json[1], pos_json[2])
         rot_json = avatar_root_json["rotation"]
@@ -60,6 +64,10 @@ class RemoteGuiInput:
             return None, None
 
         client_state = self._recent_client_states[history_index]
+
+        if "avatar" not in client_state:
+            return None, None
+
         assert "hands" in client_state["avatar"]
         hands_json = client_state["avatar"]["hands"]
         assert hand_idx >= 0 and hand_idx < len(hands_json)


### PR DESCRIPTION
## Motivation and Context

This checks for null client inputs. This can now happen with the mouse/keyboard clients as XR pose structs are never created.

Required for: https://github.com/eundersander/siro_hitl_unity_client/pull/24

## How Has This Been Tested

Tested locally with the mouse/keyboard remote app.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
