### PR TITLE
Add use-multiprocessing and verbose flags to Unity dataset processing.

### DIFF
--- a/scripts/unity_dataset_processing/decimate.py
+++ b/scripts/unity_dataset_processing/decimate.py
@@ -116,16 +116,15 @@ def decimate(
     for i in range(importer.mesh_count):
         mesh = importer.mesh(i)
 
-        # Transform the mesh to its max scale in the scene. For quantized meshes
-        # this expands the position attribute to a floating-point Vector3.
-        scaled_mesh = meshtools.transform3d(
-            mesh, Matrix4.scaling(max_mesh_scaling.get(i, Vector3(1.0)))
-        )
-
         # Calculate total triangle area of the *transformed* mesh. You might want
         # to fiddle with this heuristics, another option is calculating the mesh
         # AABB but that won't do the right thing for planar meshes.
         if simplify:
+            # Transform the mesh to its max scale in the scene. For quantized meshes
+            # this expands the position attribute to a floating-point Vector3.
+            scaled_mesh = meshtools.transform3d(
+                mesh, Matrix4.scaling(max_mesh_scaling.get(i, Vector3(1.0)))
+            )
             if not scaled_mesh.is_indexed:
                 converter.end_file()
                 importer.close()


### PR DESCRIPTION
## Motivation and Context

This adds `use-multiprocessing` and `verbose` command line arguments to the Habitat->Unity dataset processing pipeline. The multiprocessing was mostly implemented but not used.

**Processing speed on my machine (32 cores, 64 threads):**
`unity_dataset_processing.py [...] --scenes 105515448_173104512`
| Single process | Multi-process |
|---|---|
| 48.23s | 6.81s |

## How Has This Been Tested

Tested that the output is valid in the Unity client.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
