### PR TITLE
Add humanoids to Unity dataset processing script.

### DIFF
--- a/scripts/unity_dataset_processing/decimate.py
+++ b/scripts/unity_dataset_processing/decimate.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-from typing import Dict
+from typing import Dict, Tuple
 
 from magnum import (
     Matrix4,
@@ -69,13 +69,13 @@ converter.configuration[
 
 
 def decimate(
-    inputFile,
-    outputFile,
-    quiet=None,
-    verbose=None,
-    sloppy=False,
-    simplify=True,
-):
+    input_file: str,
+    output_file: str,
+    quiet: bool = None,
+    verbose: bool = None,
+    sloppy: bool = False,
+    simplify: bool = True,
+) -> Tuple[int, int, int]:
     if quiet:
         importer.flags |= trade.ImporterFlags.QUIET
         converter.flags |= trade.SceneConverterFlags.QUIET
@@ -87,8 +87,8 @@ def decimate(
         resizer.flags |= trade.ImageConverterFlags.VERBOSE
         meshoptimizer.flags |= trade.SceneConverterFlags.VERBOSE
 
-    importer.open_file(inputFile)
-    converter.begin_file(outputFile)
+    importer.open_file(input_file)
+    converter.begin_file(output_file)
 
     # For each mesh calculate the transformation scaling in the scene to make the
     # decimation reflect how large a particular mesh actually is there. The same

--- a/scripts/unity_dataset_processing/unity_dataset_processing.py
+++ b/scripts/unity_dataset_processing/unity_dataset_processing.py
@@ -372,6 +372,17 @@ def main():
         job.job_type = JobType.PROCESS
         jobs.append(job)
 
+    # Add humanoids.
+    for filename in Path("data/humanoids/humanoid_data").rglob("*.glb"):
+        rel_path = str(filename)[len("data/") :]
+        job = Job()
+        job.source_path = os.path.join("data", rel_path)
+        job.dest_path = os.path.join(OUTPUT_DIR, rel_path)
+        # GltfSceneConverter doesn't support skinning.
+        # Use humanoid models as-is.
+        job.job_type = JobType.COPY
+        jobs.append(job)
+
     simplify_models(jobs)
 
 


### PR DESCRIPTION
## Motivation and Context

This adds humanoids to the Unity dataset processing script.
`GltfSceneConverter` doesn't support skinning. Therefore, they are directly copied to the output. A "copy" job type was added to support this, as well as future cases (e.g. assets that are not models).

## How Has This Been Tested

Tested output in Unity.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
