### PR TITLE
HITL: Make skinning support optional.

### DIFF
--- a/examples/hitl/pick_throw_vr/config/pick_throw_vr.yaml
+++ b/examples/hitl/pick_throw_vr/config/pick_throw_vr.yaml
@@ -28,5 +28,7 @@ habitat_hitl:
     client_sync:
       # The client controls its own camera.
       camera_transform: False
+      # This is a first-person application. We don't need to transmit skinned mesh poses.
+      skinning: False
 
 pick_throw_vr:

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -520,6 +520,10 @@ class HitlDriver(AppDriver):
                 obj = json.loads(keyframe_json)
                 assert "keyframe" in obj
                 keyframe_obj = obj["keyframe"]
+                # Remove rigs from keyframe if skinning is disabled
+                if not self._hitl_config.networking.active_features.skinning:
+                    del keyframe_obj["rigCreations"]
+                    del keyframe_obj["rigUpdates"]
                 # Insert server->client message into the keyframe
                 message = self._client_message_manager.get_message_dict()
                 if len(message) > 0:

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -522,8 +522,10 @@ class HitlDriver(AppDriver):
                 keyframe_obj = obj["keyframe"]
                 # Remove rigs from keyframe if skinning is disabled
                 if not self._hitl_config.networking.active_features.skinning:
-                    del keyframe_obj["rigCreations"]
-                    del keyframe_obj["rigUpdates"]
+                    if "rigCreations" in keyframe_obj:
+                        del keyframe_obj["rigCreations"]
+                    if "rigUpdates" in keyframe_obj:
+                        del keyframe_obj["rigUpdates"]
                 # Insert server->client message into the keyframe
                 message = self._client_message_manager.get_message_dict()
                 if len(message) > 0:

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -521,7 +521,7 @@ class HitlDriver(AppDriver):
                 assert "keyframe" in obj
                 keyframe_obj = obj["keyframe"]
                 # Remove rigs from keyframe if skinning is disabled
-                if not self._hitl_config.networking.active_features.skinning:
+                if not self._hitl_config.networking.client_sync.skinning:
                     if "rigCreations" in keyframe_obj:
                         del keyframe_obj["rigCreations"]
                     if "rigUpdates" in keyframe_obj:

--- a/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
@@ -73,7 +73,9 @@ def update_consolidated_keyframe(
     if "rigCreations" in inc_keyframe:
         if networking_config.active_features.skinning:
             ensure_list(consolidated_keyframe, "rigCreations")
-            consolidated_keyframe["rigCreations"] += inc_keyframe["rigCreations"]
+            consolidated_keyframe["rigCreations"] += inc_keyframe[
+                "rigCreations"
+            ]
         else:
             # Remove rigCreations if skinned mesh pose transmission is disabled.
             del inc_keyframe["rigCreations"]

--- a/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
@@ -7,9 +7,7 @@
 from typing import Any
 
 
-def update_consolidated_keyframe(
-    consolidated_keyframe, inc_keyframe, networking_config
-):
+def update_consolidated_keyframe(consolidated_keyframe, inc_keyframe):
     """
     A "consolidated" keyframe is several incremental keyframes merged together.
     See nearly duplicate logic in habitat-sim Recorder::addLoadsCreationsDeletions.
@@ -49,20 +47,16 @@ def update_consolidated_keyframe(
 
     # add or update rigUpdates
     if "rigUpdates" in inc_keyframe:
-        if networking_config.active_features.skinning:
-            for rig_update in inc_keyframe["rigUpdates"]:
-                key = rig_update["id"]
-                pose = rig_update["pose"]
-                found = False
-                for con_rig_update in consolidated_keyframe["rigUpdates"]:
-                    if con_rig_update["id"] == key:
-                        con_rig_update["pose"] = pose
-                        found = True
-                if not found:
-                    consolidated_keyframe["rigUpdates"].append(rig_update)
-        else:
-            # Remove rigUpdates if skinned mesh pose transmission is disabled.
-            del inc_keyframe["rigUpdates"]
+        for rig_update in inc_keyframe["rigUpdates"]:
+            key = rig_update["id"]
+            pose = rig_update["pose"]
+            found = False
+            for con_rig_update in consolidated_keyframe["rigUpdates"]:
+                if con_rig_update["id"] == key:
+                    con_rig_update["pose"] = pose
+                    found = True
+            if not found:
+                consolidated_keyframe["rigUpdates"].append(rig_update)
 
     # append creations
     if "creations" in inc_keyframe:
@@ -71,14 +65,8 @@ def update_consolidated_keyframe(
 
     # append rigCreations if skinning transmission is enabled
     if "rigCreations" in inc_keyframe:
-        if networking_config.active_features.skinning:
-            ensure_list(consolidated_keyframe, "rigCreations")
-            consolidated_keyframe["rigCreations"] += inc_keyframe[
-                "rigCreations"
-            ]
-        else:
-            # Remove rigCreations if skinned mesh pose transmission is disabled.
-            del inc_keyframe["rigCreations"]
+        ensure_list(consolidated_keyframe, "rigCreations")
+        consolidated_keyframe["rigCreations"] += inc_keyframe["rigCreations"]
 
     # for a deletion, just remove all references to this instanceKey
     if "deletions" in inc_keyframe:

--- a/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
@@ -45,25 +45,28 @@ def update_consolidated_keyframe(consolidated_keyframe, inc_keyframe):
             if not found:
                 consolidated_keyframe["stateUpdates"].append(state_update)
 
-    # if "rigUpdates" in inc_keyframe:
-    #     for rig_update in inc_keyframe["rigUpdates"]:
-    #         id = rig_update["id"]
-    #         pose = rig_update["pose"]
-    #         found = False
-    #         for con_rig_update in consolidated_keyframe["rigUpdates"]:
-    #             if con_rig_update["id"] == id:
-    #                 con_rig_update["pose"] = pose
-    #                 found = True
-    #         if not found:
-    #             consolidated_keyframe["rigUpdates"].append(rig_update)
+    # todo: make optional
+    if "rigUpdates" in inc_keyframe:
+        for rig_update in inc_keyframe["rigUpdates"]:
+            id = rig_update["id"]
+            pose = rig_update["pose"]
+            found = False
+            for con_rig_update in consolidated_keyframe["rigUpdates"]:
+                if con_rig_update["id"] == id:
+                    con_rig_update["pose"] = pose
+                    found = True
+            if not found:
+                consolidated_keyframe["rigUpdates"].append(rig_update)
 
     # append creations
     if "creations" in inc_keyframe:
         ensure_list(consolidated_keyframe, "creations")
         consolidated_keyframe["creations"] += inc_keyframe["creations"]
 
-    # if "rigCreations" in inc_keyframe:
-    #     consolidated_keyframe["rigCreations"] += inc_keyframe["rigCreations"]
+    # todo: make optional
+    if "rigCreations" in inc_keyframe:
+        ensure_list(consolidated_keyframe, "rigCreations")
+        consolidated_keyframe["rigCreations"] += inc_keyframe["rigCreations"]
 
     # for a deletion, just remove all references to this instanceKey
     if "deletions" in inc_keyframe:
@@ -85,7 +88,7 @@ def update_consolidated_keyframe(consolidated_keyframe, inc_keyframe):
                 ensure_list(consolidated_keyframe, "deletions")
                 consolidated_keyframe["deletions"].append(key)
 
-        # remote stateUpdates for the deleted keys
+        # remove stateUpdates for the deleted keys
         if "stateUpdates" in consolidated_keyframe:
             consolidated_keyframe["stateUpdates"] = [
                 entry

--- a/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
@@ -108,7 +108,9 @@ class NetworkManager:
     def update_consolidated_keyframes(self, keyframes):
         for inc_keyframe in keyframes:
             update_consolidated_keyframe(
-                self._consolidated_keyframe, inc_keyframe
+                self._consolidated_keyframe,
+                inc_keyframe,
+                self._networking_config,
             )
 
     async def receive_client_states(self, websocket):
@@ -148,7 +150,9 @@ class NetworkManager:
                 if len(inc_keyframes) > 1:
                     for i in range(1, len(inc_keyframes)):
                         update_consolidated_keyframe(
-                            tmp_con_keyframe, inc_keyframes[i]
+                            tmp_con_keyframe,
+                            inc_keyframes[i],
+                            self._networking_config,
                         )
                     inc_keyframes = [tmp_con_keyframe]
 

--- a/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
@@ -108,9 +108,7 @@ class NetworkManager:
     def update_consolidated_keyframes(self, keyframes):
         for inc_keyframe in keyframes:
             update_consolidated_keyframe(
-                self._consolidated_keyframe,
-                inc_keyframe,
-                self._networking_config,
+                self._consolidated_keyframe, inc_keyframe
             )
 
     async def receive_client_states(self, websocket):
@@ -150,9 +148,7 @@ class NetworkManager:
                 if len(inc_keyframes) > 1:
                     for i in range(1, len(inc_keyframes)):
                         update_consolidated_keyframe(
-                            tmp_con_keyframe,
-                            inc_keyframes[i],
-                            self._networking_config,
+                            tmp_con_keyframe, inc_keyframes[i]
                         )
                     inc_keyframes = [tmp_con_keyframe]
 

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -40,7 +40,7 @@ habitat_hitl:
     client_sync:
       # If enabled, the main camera transform will be sent to the client. Disable if the client should control its own camera (e.g. VR).
       camera_transform: True
-      # Enable transmission of skinned mesh poses.
+      # Enable transmission of skinned mesh poses. If 'camera.first_person_mode' is enabled, you should generally disable this as well as enable `hide_humanoid_in_gui` because the humanoid will occlude the camera.
       skinning: True
 
   # Target rate to step the environment (steps per second); actual SPS may be lower depending on your hardware

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -40,6 +40,8 @@ habitat_hitl:
     client_sync:
       # If enabled, the main camera transform will be sent to the client. Disable if the client should control its own camera (e.g. VR).
       camera_transform: True
+      # Enable transmission of skinned mesh poses.
+      skinning: True
 
   # Target rate to step the environment (steps per second); actual SPS may be lower depending on your hardware
   target_sps: 30


### PR DESCRIPTION
## Motivation and Context

This changeset makes skinning transmission optional.
* If `self._hitl_config.networking.active_features.skinning` is disabled, rig keyframe data is removed before transmission.
* Otherwise, rig keyframe data is consolidated along with other data.

See: https://github.com/0mdc/siro_hitl_unity_client/pull/4

## How Has This Been Tested

Tested locally along with the Unity app.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
