### PR TITLE
Add remote_gui config.

### DIFF
--- a/examples/hitl/pick_throw_vr/README.md
+++ b/examples/hitl/pick_throw_vr/README.md
@@ -76,12 +76,12 @@ The system is composed of the following components:
 
 The standard keyboard-mouse launch command-line arguments can be used with those differences:
 
-* The `habitat_hitl.remote_gui_mode=True` config override launches the Pick_throw_vr app as a server, allowing a remote client (e.g. VR headset) to connect and control the human avatar.
+* The `habitat_hitl.remote_gui.enabled=True` config override launches the Pick_throw_vr app as a server, allowing a remote client (e.g. VR headset) to connect and control the human avatar.
 
 ```bash
 HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
 python examples/hitl/pick_throw_vr/pick_throw_vr.py \
-habitat_hitl.remote_gui_mode=True
+habitat_hitl.remote_gui.enabled=True
 ```
 
 We also have an experimental headless server:

--- a/examples/hitl/pick_throw_vr/README.md
+++ b/examples/hitl/pick_throw_vr/README.md
@@ -76,12 +76,12 @@ The system is composed of the following components:
 
 The standard keyboard-mouse launch command-line arguments can be used with those differences:
 
-* The `habitat_hitl.remote_gui.enabled=True` config override launches the Pick_throw_vr app as a server, allowing a remote client (e.g. VR headset) to connect and control the human avatar.
+* The `habitat_hitl.networking.enabled=True` config override launches the Pick_throw_vr app as a server, allowing a remote client (e.g. VR headset) to connect and control the human avatar.
 
 ```bash
 HABITAT_SIM_LOG=warning MAGNUM_LOG=warning \
 python examples/hitl/pick_throw_vr/pick_throw_vr.py \
-habitat_hitl.remote_gui.enabled=True
+habitat_hitl.networking.enabled=True
 ```
 
 We also have an experimental headless server:

--- a/examples/hitl/pick_throw_vr/config/experiment/headless_server.yaml
+++ b/examples/hitl/pick_throw_vr/config/experiment/headless_server.yaml
@@ -10,4 +10,5 @@ habitat_hitl:
       #   num_frames_to_save: 50
       #   filepath_base: "./debug_video"
       # exit_after: 40
-  remote_gui_mode: True
+  remote_gui:
+    enabled: True

--- a/examples/hitl/pick_throw_vr/config/experiment/headless_server.yaml
+++ b/examples/hitl/pick_throw_vr/config/experiment/headless_server.yaml
@@ -10,5 +10,5 @@ habitat_hitl:
       #   num_frames_to_save: 50
       #   filepath_base: "./debug_video"
       # exit_after: 40
-  remote_gui:
+  networking:
     enabled: True

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -572,7 +572,7 @@ class AppStatePickThrowVr(AppState):
             controls_str += "1-5: select scene\n"
             controls_str += "R + drag: rotate camera\n"
             controls_str += "Scroll: zoom\n"
-            if self._app_service.hitl_config.remote_gui.enabled:
+            if self._app_service.hitl_config.networking.enabled:
                 controls_str += "T: toggle keyboard.VR\n"
             controls_str += "P: pause\n"
             if not self._is_remote_active_toggle:
@@ -585,7 +585,7 @@ class AppStatePickThrowVr(AppState):
     def _get_status_text(self):
         status_str = ""
 
-        if self._app_service.hitl_config.remote_gui.enabled:
+        if self._app_service.hitl_config.networking.enabled:
             status_str += (
                 "human control: VR\n"
                 if self._is_remote_active()
@@ -657,7 +657,7 @@ class AppStatePickThrowVr(AppState):
         # - must not be holding anything
         # - toggle on T keypress OR switch to remote if any remote button is pressed
         if (
-            self._app_service.hitl_config.remote_gui.enabled
+            self._app_service.hitl_config.networking.enabled
             and self._held_target_obj_idx is None
             and (
                 self._app_service.gui_input.get_key_down(GuiInput.KeyNS.T)

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -572,7 +572,7 @@ class AppStatePickThrowVr(AppState):
             controls_str += "1-5: select scene\n"
             controls_str += "R + drag: rotate camera\n"
             controls_str += "Scroll: zoom\n"
-            if self._app_service.hitl_config.remote_gui_mode:
+            if self._app_service.hitl_config.remote_gui.enabled:
                 controls_str += "T: toggle keyboard.VR\n"
             controls_str += "P: pause\n"
             if not self._is_remote_active_toggle:
@@ -585,7 +585,7 @@ class AppStatePickThrowVr(AppState):
     def _get_status_text(self):
         status_str = ""
 
-        if self._app_service.hitl_config.remote_gui_mode:
+        if self._app_service.hitl_config.remote_gui.enabled:
             status_str += (
                 "human control: VR\n"
                 if self._is_remote_active()
@@ -657,7 +657,7 @@ class AppStatePickThrowVr(AppState):
         # - must not be holding anything
         # - toggle on T keypress OR switch to remote if any remote button is pressed
         if (
-            self._app_service.hitl_config.remote_gui_mode
+            self._app_service.hitl_config.remote_gui.enabled
             and self._held_target_obj_idx is None
             and (
                 self._app_service.gui_input.get_key_down(GuiInput.KeyNS.T)

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -208,7 +208,7 @@ class HitlDriver(AppDriver):
 
     @property
     def network_server_enabled(self) -> bool:
-        return self._hitl_config.remote_gui_mode
+        return self._hitl_config.remote_gui.enabled
 
     def _check_init_server(self, line_render):
         self._remote_gui_input = None

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -208,7 +208,7 @@ class HitlDriver(AppDriver):
 
     @property
     def network_server_enabled(self) -> bool:
-        return self._hitl_config.remote_gui.enabled
+        return self._hitl_config.networking.enabled
 
     def _check_init_server(self, line_render):
         self._remote_gui_input = None

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -26,7 +26,7 @@ habitat_hitl:
     # Choose between classic and batch renderer. This is an experimental feature aimed at those of us building the batch renderer.
     use_batch_renderer: False
     headless:
-      # Run without a GUI window. For unit-testing or use with remote_gui_mode as a headless server.
+      # Run without a GUI window. For unit-testing or use with remote_gui.enabled as a headless server.
       do_headless: False
       # Shortly after app startup, write debug images from the first K steps to video files. See debug_third_person_viewport and debug_images.
       debug_video_writer:
@@ -59,12 +59,12 @@ habitat_hitl:
   # See GuiHumanoidController.
   walk_pose_path: "data/humanoids/humanoid_data/walking_motion_processed_smplx.pkl"
 
-  # When enabled, a HITL app behaves as a server that takes input from a remote client.
-  # See pick_throw_vr example app.
-  remote_gui_mode: False
+  remote_gui:
+    # When enabled, a HITL app behaves as a server that takes input from a remote client.
+    # See pick_throw_vr example app.
+    enabled: False
 
   camera:
-
     # See CameraHelper. Set first_person_mode=True, or False to use third-person mode. With first-person mode, use  `max_look_up_angle` and `min_look_down_angle` arguments to limit humanoid's look up/down angle. For example, `--max-look-up-angle 0 --min-look-down-angle -45` to let the humanoid look down -45 degrees. You should also generally use `hide_humanoid_in_gui=True` with `first_person_mode`, because it doesn't make sense to visualize the humanoid with this camera. For first-person mode, you should also set gui_controlled_agent.ang_speed=300 to avoid delayed movement after turning.
     first_person_mode: False
     max_look_up_angle: 15.0

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -26,7 +26,7 @@ habitat_hitl:
     # Choose between classic and batch renderer. This is an experimental feature aimed at those of us building the batch renderer.
     use_batch_renderer: False
     headless:
-      # Run without a GUI window. For unit-testing or use with remote_gui.enabled as a headless server.
+      # Run without a GUI window. For unit-testing or use with networking.enabled as a headless server.
       do_headless: False
       # Shortly after app startup, write debug images from the first K steps to video files. See debug_third_person_viewport and debug_images.
       debug_video_writer:
@@ -59,7 +59,7 @@ habitat_hitl:
   # See GuiHumanoidController.
   walk_pose_path: "data/humanoids/humanoid_data/walking_motion_processed_smplx.pkl"
 
-  remote_gui:
+  networking:
     # When enabled, a HITL app behaves as a server that takes input from a remote client.
     # See pick_throw_vr example app.
     enabled: False


### PR DESCRIPTION
## Motivation and Context

This small refactor adds a `networking` config, which is intended to contain the parameters that will control networking properties and remote features.

`remote_gui_mode` has been moved into this config as `networking.enabled`.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
