### PR TITLE
-- Change ints to float in sensor spec position and orientation

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/replay_gui_app_renderer.py
+++ b/habitat-hitl/habitat_hitl/_internal/replay_gui_app_renderer.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import magnum as mn
-import numpy as np
 
 import habitat_sim
 from habitat_hitl._internal.gui_application import GuiAppRenderer
@@ -51,8 +50,8 @@ class ReplayGuiAppRenderer(GuiAppRenderer):
                 self.window_size.y,
                 self.window_size.x,
             ]
-        camera_sensor_spec.position = np.array([0, 0, 0])
-        camera_sensor_spec.orientation = np.array([0, 0, 0])
+        camera_sensor_spec.position = [0.0, 0.0, 0.0]
+        camera_sensor_spec.orientation = [0.0, 0.0, 0.0]
         camera_sensor_spec.near = 0.2
         camera_sensor_spec.far = 50.0
 

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -886,8 +886,8 @@ class RearrangeEpisodeGenerator:
             "rgb": {
                 "sensor_type": habitat_sim.SensorType.COLOR,
                 "resolution": camera_resolution,
-                "position": [0, 0, 0],
-                "orientation": [0, 0, 0.0],
+                "position": [0.0, 0.0, 0.0],
+                "orientation": [0.0, 0.0, 0.0],
             }
         }
 

--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -133,7 +133,7 @@ class DebugVisualizer:
 
         debug_sensor_spec = habitat_sim.CameraSensorSpec()
         debug_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
-        debug_sensor_spec.position = [0, 0, 0]
+        debug_sensor_spec.position = [0.0, 0.0, 0.0]
         debug_sensor_spec.resolution = [resolution[0], resolution[1]]
         debug_sensor_spec.uuid = self.sensor_uuid
 

--- a/test/test_humanoid.py
+++ b/test/test_humanoid.py
@@ -81,7 +81,7 @@ def make_cfg(settings):
         camera_sensor_spec = habitat_sim.CameraSensorSpec()
         camera_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
         camera_sensor_spec.resolution = [settings["height"], settings["width"]]
-        camera_sensor_spec.position = [0, settings["sensor_height"], 0]
+        camera_sensor_spec.position = [0.0, settings["sensor_height"], 0.0]
         for k in kw_args:
             setattr(camera_sensor_spec, k, kw_args[k])
         return camera_sensor_spec

--- a/test/test_robot_wrapper.py
+++ b/test/test_robot_wrapper.py
@@ -88,7 +88,7 @@ def make_cfg(settings):
         camera_sensor_spec = habitat_sim.CameraSensorSpec()
         camera_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
         camera_sensor_spec.resolution = [settings["height"], settings["width"]]
-        camera_sensor_spec.position = [0, settings["sensor_height"], 0]
+        camera_sensor_spec.position = [0.0, settings["sensor_height"], 0.0]
         for k in kw_args:
             setattr(camera_sensor_spec, k, kw_args[k])
         return camera_sensor_spec
@@ -172,7 +172,7 @@ def make_cfg(settings):
         # The default principal_point_offset is the middle of the image
         fisheye_sensor_spec.principal_point_offset = None
         # default: fisheye_sensor_spec.principal_point_offset = [i/2 for i in fisheye_sensor_spec.resolution]
-        fisheye_sensor_spec.position = [0, settings["sensor_height"], 0]
+        fisheye_sensor_spec.position = [0.0, settings["sensor_height"], 0.0]
         for k in kw_args:
             setattr(fisheye_sensor_spec, k, kw_args[k])
         return fisheye_sensor_spec
@@ -205,7 +205,7 @@ def make_cfg(settings):
             settings["height"],
             settings["width"],
         ]
-        equirect_sensor_spec.position = [0, settings["sensor_height"], 0]
+        equirect_sensor_spec.position = [0.0, settings["sensor_height"], 0.0]
         for k in kw_args:
             setattr(equirect_sensor_spec, k, kw_args[k])
         return equirect_sensor_spec

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -83,7 +83,7 @@ def test_snap_down(support_margin, obj_margin, stage_support):
 
     # Test snapping a cube object onto another object
     sim_settings = default_sim_settings.copy()
-    sim_settings["sensor_height"] = 0
+    sim_settings["sensor_height"] = 0.0
     sim_settings["scene"] = "NONE"
     if stage_support:
         sim_settings["scene"] = plane_stage_template_handle


### PR DESCRIPTION
## Motivation and Context
In preparation for Eigen->Magnum migration being introduced in Habitat-Sim [in this PR](https://github.com/facebookresearch/habitat-sim/pull/2316) for sensor_spec position and orientation, this PR makes integer initialization constants for these fields into floats. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Changed files tested locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
