### PR TITLE
Add RemoteGuiInput.connection_params() and hitl_defaults.yaml networking.wait_for_app_ready_signal

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
@@ -100,6 +100,7 @@ def update_consolidated_keyframe(consolidated_keyframe, inc_keyframe):
             "teleportAvatarBasePosition",
             "sceneChanged",
             "navmeshVertices",
+            "isAppReady",
         ]:
             if message_key in inc_message:
                 ensure_dict(consolidated_keyframe, "message")

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -23,6 +23,9 @@ habitat_hitl:
     # We'll listen for incoming client connections at this port.
     port: 8888
 
+    # If True, NetworkManager will wait until the application issues ClientMessageManager.signal_app_ready before sending the first gfx-replay keyframe to the client. This gives the application an opportunity to e.g. change scenes when a client connects. If False, NetworkManager will start sending keyframes immediately upon connect.
+    wait_for_app_ready_signal: False
+
     # Used with AWS elastic load balancer (ELB) health checks. If enabled, we run a separate HTTP server that returns a code based on whether the HITL server is available to accept new client connections. Note this HTTP server doesn't serve any files or other content. Note the current HITL server implementation only handles one client at a time, so the expected behavior is that it becomes "unavailable" once it has a connected client. The HTTP server can be tested locally with e.g. curl -i 0.0.0.0:8889.
     http_availability_server:
       enable: False

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -52,6 +52,12 @@ class ClientMessageManager:
         """
         self._message["sceneChanged"] = True
 
+    def signal_app_ready(self):
+        r"""
+        See hitl_defaults.yaml wait_for_app_ready_signal documentation.
+        """
+        self._message["isAppReady"] = True
+
     def update_navmesh_triangles(self, triangle_vertices):
         r"""
         Send a navmesh. triangle_vertices should be a list of vertices, 3 per triangle.

--- a/habitat-hitl/habitat_hitl/scripts/stub_client.html
+++ b/habitat-hitl/habitat_hitl/scripts/stub_client.html
@@ -21,6 +21,12 @@
     <div id="serverUrl"></div>
     <div id="status">Disconnected</div>
     <div id="messageRate">Message Rate: 0</div>
+    <!-- Add your new fields and button here -->
+    <label for="keyField">Key:</label>
+    <input type="text" id="keyField">
+    <label for="valueField">Value:</label>
+    <input type="text" id="valueField">
+    <button id="sendButton" disabled>Send</button>
 
     <script>
         var ws = null;
@@ -40,6 +46,7 @@
                 document.getElementById('disconnectButton').disabled = false;
                 document.getElementById('serverIp').disabled = true;
                 document.getElementById('serverPort').disabled = true;
+                document.getElementById('sendButton').disabled = false;
                 ws.send('client ready!');  // Send "client ready!" to the server
             };
 
@@ -49,6 +56,7 @@
                 document.getElementById('disconnectButton').disabled = true;
                 document.getElementById('serverIp').disabled = false;
                 document.getElementById('serverPort').disabled = false;
+                document.getElementById('sendButton').disabled = true;
             };
 
             ws.onmessage = function() {
@@ -62,6 +70,14 @@
             }
         }
 
+        function send() {
+            var key = document.getElementById('keyField').value;
+            var value = document.getElementById('valueField').value;
+            var dict = {};
+            dict[key] = value;
+            ws.send(JSON.stringify(dict));  // Send the dictionary as a JSON string
+        }
+
         function updateMessageRate() {
             var now = Date.now();
             var deltaTime = (now - lastUpdateTime) / 1000;  // Convert to seconds
@@ -73,6 +89,7 @@
 
         document.getElementById('connectButton').addEventListener('click', connect);
         document.getElementById('disconnectButton').addEventListener('click', disconnect);
+        document.getElementById('sendButton').addEventListener('click', send);  // Add an event listener for the send button
         setInterval(updateMessageRate, 2000);  // Update message rate every 2 seconds
     </script>
 </body>


### PR DESCRIPTION
## Motivation and Context

* Add RemoteGuiInput.connection_params(). This should be provided by the client (usually only once). stub_client.html demonstrates this.
* Add hitl_defaults.yaml networking.wait_for_app_ready_signal. 
* minor fixes to debug_visualize_client

These features can be combined to let an AppState choose a new scene/episode when a new client connects, i.e.:
```
def sim_update(...):
    ...
    # reset to new episode when client connects
    if self._app_service.remote_gui_input:
        connection_params = self._app_service.remote_gui_input.get_connection_params()
        if connection_params:
            # optionally, inspect the connection_params dictionary, e.g. connection_params["episode_id"]
            self._app_service.end_episode(do_reset=True)
            client_message_manager = self._app_service.client_message_manager
            assert client_message_manager
            # See also hitl_defaults.yaml wait_for_app_ready_signal. Because we wait to signal app ready until after resetting to the new episode, we avoid forcing the client to needlessly load the previous episode.
            client_message_manager.signal_app_ready()
```

## How Has This Been Tested

Local testing with above sample code and stub_client.html.

## Types of changes

- **\[HITL\]**

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
