### PR TITLE
HITL: server-side helpers to measure client latency

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/keyframe_utils.py
@@ -95,18 +95,12 @@ def update_consolidated_keyframe(consolidated_keyframe, inc_keyframe):
 
     if "message" in inc_keyframe:
         inc_message = inc_keyframe["message"]
-        # add/update these messages
-        for message_key in [
-            "teleportAvatarBasePosition",
-            "sceneChanged",
-            "navmeshVertices",
-            "isAppReady",
-        ]:
-            if message_key in inc_message:
-                ensure_dict(consolidated_keyframe, "message")
-                consolidated_keyframe["message"][message_key] = inc_message[
-                    message_key
-                ]
+        # add/update all messages
+        for message_key in inc_message:
+            ensure_dict(consolidated_keyframe, "message")
+            consolidated_keyframe["message"][message_key] = inc_message[
+                message_key
+            ]
 
     # todo: lights, userTransforms
 

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -58,6 +58,9 @@ class ClientMessageManager:
         """
         self._message["isAppReady"] = True
 
+    def set_server_keyframe_id(self, keyframe_id):
+        self._message["serverKeyframeId"] = keyframe_id
+
     def update_navmesh_triangles(self, triangle_vertices):
         r"""
         Send a navmesh. triangle_vertices should be a list of vertices, 3 per triangle.

--- a/habitat-hitl/habitat_hitl/core/remote_gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/remote_gui_input.py
@@ -12,6 +12,7 @@ from habitat_hitl._internal.networking.average_rate_tracker import (
 from habitat_hitl.core.gui_input import GuiInput
 
 
+# todo: rename to RemoteClientState
 class RemoteGuiInput:
     def __init__(self, interprocess_record, debug_line_render):
         self._recent_client_states = []
@@ -43,6 +44,23 @@ class RemoteGuiInput:
 
     def get_connection_params(self):
         return self._connection_params
+
+    def pop_recent_server_keyframe_id(self):
+        """
+        Removes and returns ("pops") the recentServerKeyframeId included in the latest client state.
+
+        The removal behavior here is to help user code by only returning a keyframe ID when a new (unseen) one is available.
+        """
+        if len(self._recent_client_states) == 0:
+            return None
+
+        latest_client_state = self._recent_client_states[0]
+        if "recentServerKeyframeId" not in latest_client_state:
+            return None
+
+        retval = int(latest_client_state["recentServerKeyframeId"])
+        del latest_client_state["recentServerKeyframeId"]
+        return retval
 
     def get_head_pose(self, history_index=0):
         if history_index >= len(self._recent_client_states):

--- a/habitat-hitl/habitat_hitl/scripts/stub_client.html
+++ b/habitat-hitl/habitat_hitl/scripts/stub_client.html
@@ -39,6 +39,8 @@
             var url = 'ws://' + ip + ':' + port;
             document.getElementById('serverUrl').textContent = 'Server URL: ' + url;
             ws = new WebSocket(url);
+            var sendIntervalId = null;  // Variable to hold the ID of the interval
+            var recentServerKeyframeId = null;
 
             ws.onopen = function() {
                 document.getElementById('status').textContent = 'Connected';
@@ -48,6 +50,18 @@
                 document.getElementById('serverPort').disabled = true;
                 document.getElementById('sendButton').disabled = false;
                 ws.send('client ready!');  // Send "client ready!" to the server
+
+                // Start sending messages at 10 Hz
+                sendIntervalId = setInterval(function() {
+                        var dict = {};  // Create an empty JavaScript object
+
+                        // Our stub client only sends recentServerKeyframeId. It doesn't send local GUI input or other client state.
+                        if (recentServerKeyframeId != null) {
+                            dict["recentServerKeyframeId"] = recentServerKeyframeId;
+                        }
+                        var message = JSON.stringify(dict);  // Convert the object to a JSON string
+                        ws.send(message);  // Send the JSON string
+                    }, 100);  // Repeat every 100 milliseconds
             };
 
             ws.onclose = function() {
@@ -57,10 +71,34 @@
                 document.getElementById('serverIp').disabled = false;
                 document.getElementById('serverPort').disabled = false;
                 document.getElementById('sendButton').disabled = true;
+
+                if (sendIntervalId) {
+                    clearInterval(sendIntervalId);
+                    sendIntervalId = null;
+                }
+                recentServerKeyframeId = null;
+
             };
 
             ws.onmessage = function() {
                 messageCount++;
+
+                var message = event.data;
+                var dict = JSON.parse(message);
+
+                // parse the latest serverKeyframeId from received keyframes
+                if ("keyframes" in dict) {
+                    keyframes = dict["keyframes"]
+                    if (keyframes.length) {
+                        keyframe = keyframes[keyframes.length - 1];
+                        if ("message" in keyframe) {
+                            message = keyframe["message"]
+                            if ("serverKeyframeId" in message) {
+                                recentServerKeyframeId = message["serverKeyframeId"];
+                            }
+                        }
+                    }
+                }
             };
         }
 


### PR DESCRIPTION
## Motivation and Context

Add ClientMessageManager.set_server_keyframe_id and RemoteGuiInput.pop_recent_server_keyframe_id to help the server measure client latency.

This feature will require follow-up work in the Unity client. `stub_client.html` provides a reference implementation.

In the example code below, roughly speaking, this is the latency between something happening in a sim_step on the server and the client's reaction (as GuiInput) being available in a later sim_step.

Usage: consider a server AppState that maintains a frame counter. It uses `ClientMessageManager.set_server_keyframe_id` on every frame. The client receives and renders a frame with serverKeyframeID=k. It should include `recentServerKeyframeId=k` in the next clientState it sends to the server. (See stub_client.html for an example.). In the server AppState, it can check `RemoteGuiInput.pop_recent_server_keyframe_id()` and compare it to its current frame counter.

Example usage in an AppState:
```
def __init__(...):
    self._frame_counter = 0

def sim_update(...):
    ...
    if self._app_service.remote_gui_input:
        recent_server_keyframe_id = self._app_service.remote_gui_input.pop_recent_server_keyframe_id()
        if recent_server_keyframe_id:
            print(f"client frame latency: {self._frame_counter - recent_server_keyframe_id}")

    if self._app_service.client_message_manager:
        self._app_service.client_message_manager.set_server_keyframe_id(self._frame_counter)
    self._frame_counter += 1
```

## How Has This Been Tested

Local testing with rearrange and pick_throw_vr AppStates. With stub HTML client. Regression testing with Unity in-editor client (although it doesn't yet implement the required client-side functionality for this feature).

## Types of changes

[HITL]

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
