### PR TITLE
HITL: Limit amount of float decimals in JSON transmissions.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -205,6 +205,12 @@ class HitlDriver(AppDriver):
         assert create_app_state_lambda is not None
         self._app_state = create_app_state_lambda(self._app_service)
 
+        # Limit the number of float decimals in JSON transmissions
+        if hasattr(
+            self.get_sim().gfx_replay_manager, "set_max_decimal_places"
+        ):
+            self.get_sim().gfx_replay_manager.set_max_decimal_places(3)
+
         self._reset_environment()
 
     def close(self):

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -209,7 +209,7 @@ class HitlDriver(AppDriver):
         if hasattr(
             self.get_sim().gfx_replay_manager, "set_max_decimal_places"
         ):
-            self.get_sim().gfx_replay_manager.set_max_decimal_places(3)
+            self.get_sim().gfx_replay_manager.set_max_decimal_places(4)
 
         self._reset_environment()
 


### PR DESCRIPTION
## Motivation and Context

This uses the `gfx_replay_manager` API introduced [here](https://github.com/facebookresearch/habitat-sim/pull/2319) to limit the amount of floating point decimals used in HITL JSON serialization.

## How Has This Been Tested

Tested locally. Verified that this doesn't introduce z-fighting.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
