### PR TITLE
--Test fixes to support semantic sensor updates

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/art_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/art_sampler.py
@@ -107,7 +107,7 @@ class CompositeArticulatedObjectStateSampler(ArticulatedObjectStateSampler):
         On failure, return None.
         """
         ids_to_names = sutils.get_all_object_ids(sim)
-        ids_to_names[-1] = "_stage"
+        ids_to_names[habitat_sim.stage_id] = "_stage"
         logger.info(ids_to_names)
         # first collect all instances associated with requested samplers
         aom = sim.get_articulated_object_manager()

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -300,7 +300,7 @@ class ObjectSampler:
             if isinstance(receptacle, OnTopOfReceptacle):
                 snap_down = False
             if snap_down:
-                support_object_ids = [-1]
+                support_object_ids = [habitat_sim.stage_id]
                 # add support object ids for non-stage receptacles
                 if receptacle.is_parent_object_articulated:
                     ao_instance = sim.get_articulated_object_manager().get_object_by_handle(

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -155,8 +155,8 @@ def bb_ray_prescreen(
     """
     if support_obj_ids is None:
         # set default support surface to stage/ground mesh
-        # STAGE ID IS 0
-        support_obj_ids = [0]
+        # STAGE ID IS habitat_sim.stage_id
+        support_obj_ids = [habitat_sim.stage_id]
     lowest_key_point: mn.Vector3 = None
     lowest_key_point_height = None
     highest_support_impact: Optional[mn.Vector3] = None
@@ -218,7 +218,7 @@ def bb_ray_prescreen(
     margin_offset = 0
     if highest_support_impact_id is None:
         pass
-    elif highest_support_impact_id == 0:
+    elif highest_support_impact_id == habitat_sim.stage_id:
         margin_offset = sim.get_stage_initialization_template().margin
 
     surface_snap_point = (
@@ -261,7 +261,7 @@ def snap_down(
 
     if support_obj_ids is None:
         # set default support surface to stage/ground mesh
-        support_obj_ids = [0]
+        support_obj_ids = [habitat_sim.stage_id]
 
     bb_ray_prescreen_results = bb_ray_prescreen(
         sim, obj, support_obj_ids, check_all_corners=False

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -155,7 +155,8 @@ def bb_ray_prescreen(
     """
     if support_obj_ids is None:
         # set default support surface to stage/ground mesh
-        support_obj_ids = [-1]
+        # STAGE ID IS 0
+        support_obj_ids = [0]
     lowest_key_point: mn.Vector3 = None
     lowest_key_point_height = None
     highest_support_impact: Optional[mn.Vector3] = None
@@ -217,7 +218,7 @@ def bb_ray_prescreen(
     margin_offset = 0
     if highest_support_impact_id is None:
         pass
-    elif highest_support_impact_id == -1:
+    elif highest_support_impact_id == 0:
         margin_offset = sim.get_stage_initialization_template().margin
 
     surface_snap_point = (
@@ -246,7 +247,7 @@ def snap_down(
 
     :param sim: The Simulator instance.
     :param obj: The RigidObject instance.
-    :param support_obj_ids: A list of object ids designated as valid support surfaces for object placement. Contact with other objects is a criteria for placement rejection. If none provided, default support surface is the stage/ground mesh (-1).
+    :param support_obj_ids: A list of object ids designated as valid support surfaces for object placement. Contact with other objects is a criteria for placement rejection. If none provided, default support surface is the stage/ground mesh (0).
     :param dbv: Optionally provide a DebugVisualizer (dbv) to render debug images of each object's computed snap position before collision culling.
 
     Reject invalid placements by checking for penetration with other existing objects.
@@ -260,7 +261,7 @@ def snap_down(
 
     if support_obj_ids is None:
         # set default support surface to stage/ground mesh
-        support_obj_ids = [-1]
+        support_obj_ids = [0]
 
     bb_ray_prescreen_results = bb_ray_prescreen(
         sim, obj, support_obj_ids, check_all_corners=False

--- a/test/test_robot_wrapper.py
+++ b/test/test_robot_wrapper.py
@@ -319,7 +319,7 @@ def test_fetch_robot_wrapper(fixed_base):
         )
         fetch.reconfigure()
         fetch.update()
-        assert fetch.get_robot_sim_id() == 1  # 0 is the ground plane
+        assert fetch.get_robot_sim_id() == ground_plane.object_id + 1
         print(fetch.get_link_and_joint_names())
         observations += simulate(sim, 1.0, produce_debug_video)
 
@@ -484,7 +484,7 @@ def test_franka_robot_wrapper():
         franka = franka_robot.FrankaRobot(urdf_path=robot_path, sim=sim)
         franka.reconfigure()
         franka.update()
-        assert franka.get_robot_sim_id() == 1  # 0 is the ground plane
+        assert franka.get_robot_sim_id() == ground_plane.object_id + 1
         print(franka.get_link_and_joint_names())
         observations += simulate(sim, 1.0, produce_debug_video)
 
@@ -606,7 +606,7 @@ def test_spot_robot_wrapper(fixed_base):
         spot = spot_robot.SpotRobot(agent_config, sim, fixed_base=fixed_base)
         spot.reconfigure()
         spot.update()
-        assert spot.get_robot_sim_id() == 1  # 0 is the ground plane
+        assert spot.get_robot_sim_id() == ground_plane.object_id + 1
         print(spot.get_link_and_joint_names())
 
         # set the motor angles
@@ -757,7 +757,7 @@ def test_stretch_robot_wrapper(fixed_base):
         )
         stretch.reconfigure()
         stretch.update()
-        assert stretch.get_robot_sim_id() == 1  # 0 is the ground plane
+        assert stretch.get_robot_sim_id() == ground_plane.object_id + 1
 
         # set base ground position using object transformation approach
         target_base_pos = sim.pathfinder.snap_point(

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -104,7 +104,8 @@ def test_snap_down(support_margin, obj_margin, stage_support):
 
         # add the cube objects
         cube_stage_obj = None
-        support_obj_ids = [-1]
+        # stage defaults to ID 0
+        support_obj_ids = [0]
         if not stage_support:
             cube_stage_obj = rom.add_object_by_template_handle(
                 cube_stage_template_handle

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -23,7 +23,7 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     snap_down,
     within,
 )
-from habitat_sim import Simulator, built_with_bullet
+from habitat_sim import Simulator, built_with_bullet, stage_id
 from habitat_sim.metadata import MetadataMediator
 from habitat_sim.physics import MotionType
 from habitat_sim.utils.settings import default_sim_settings, make_cfg
@@ -104,8 +104,8 @@ def test_snap_down(support_margin, obj_margin, stage_support):
 
         # add the cube objects
         cube_stage_obj = None
-        # stage defaults to ID 0
-        support_obj_ids = [0]
+        # stage defaults to ID specified as constant in habitat_sim.stage_id
+        support_obj_ids = [stage_id]
         if not stage_support:
             cube_stage_obj = rom.add_object_by_template_handle(
                 cube_stage_template_handle


### PR DESCRIPTION
## Motivation and Context
This PR fixes tests that reference the hardcoded stage ID in habitat-sim. ~~This value has changed from -1 to 0, to facilitate the object id/panoptic sensor capabilities being introduced in [this PR](https://github.com/facebookresearch/habitat-sim/pull/2316)
Until the above referenced Sim PR is merged, however, this PR will fail on test_sim_utils.py~~

The stage ID value is now backed by a constant `habitat_sim.stage_id.`  This PR aims to replace all of the hard-coded numeric references to the stage with this constant.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Locally with above-referenced Habitat-Sim PR.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
