### PR TITLE
HITL: Add typing annotations to AppService

### DIFF
--- a/examples/hitl/basic_viewer/basic_viewer.py
+++ b/examples/hitl/basic_viewer/basic_viewer.py
@@ -7,6 +7,7 @@
 import hydra
 import magnum as mn
 
+from habitat_hitl.app_states.app_service import AppService
 from habitat_hitl.app_states.app_state_abc import AppState
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.hitl_main import hitl_main
@@ -18,7 +19,7 @@ from habitat_hitl.environment.camera_helper import CameraHelper
 class AppStateBasicViewer(AppState):
     def __init__(
         self,
-        app_service,
+        app_service: AppService,
     ):
         self._app_service = app_service
         self._gui_input = self._app_service.gui_input

--- a/examples/hitl/minimal/minimal.py
+++ b/examples/hitl/minimal/minimal.py
@@ -7,6 +7,7 @@
 import hydra
 import magnum
 
+from habitat_hitl.app_states.app_service import AppService
 from habitat_hitl.app_states.app_state_abc import AppState
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.hitl_main import hitl_main
@@ -19,7 +20,7 @@ class AppStateMinimal(AppState):
     a fixed overhead camera.
     """
 
-    def __init__(self, app_service):
+    def __init__(self, app_service: AppService):
         self._app_service = app_service
 
     def sim_update(self, dt, post_sim_update_dict):

--- a/examples/hitl/rearrange/rearrange.py
+++ b/examples/hitl/rearrange/rearrange.py
@@ -4,10 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Any, List, Optional
+
 import hydra
 import magnum as mn
 import numpy as np
 
+from habitat_hitl.app_states.app_service import AppService
 from habitat_hitl.app_states.app_state_abc import AppState
 from habitat_hitl.app_states.app_state_tutorial import AppStateTutorial
 from habitat_hitl.core.gui_input import GuiInput
@@ -40,10 +43,10 @@ class AppStateRearrange(AppState):
 
     def __init__(
         self,
-        app_service,
+        app_service: AppService,
     ):
         self._app_service = app_service
-        self._gui_agent_ctrl = self._app_service.gui_agent_controller
+        self._gui_agent_ctrl: Any = self._app_service.gui_agent_controller
 
         # cache items from config; config is expensive to access at runtime
         config = self._app_service.config
@@ -55,15 +58,19 @@ class AppStateRearrange(AppState):
             self._app_service.hitl_config.can_grasp_place_threshold
         )
 
-        self._cam_transform = None
+        self._cam_transform: Optional[mn.Matrix4] = None
 
-        self._held_target_obj_idx = None
-        self._num_remaining_objects = None  # resting, not at goal location yet
-        self._num_busy_objects = None  # currently held by non-gui agents
+        self._held_target_obj_idx: Optional[int] = None
+
+        # resting, not at goal location yet
+        self._num_remaining_objects: Optional[int] = None
+
+        # currently held by non-gui agents
+        self._num_busy_objects: Optional[int] = None
 
         # will be set in on_environment_reset
-        self._target_obj_ids = None
-        self._goal_positions = None
+        self._target_obj_ids: Optional[List[str]] = None
+        self._goal_positions: Optional[List[mn.Vector3]] = None
 
         self._camera_helper = CameraHelper(
             self._app_service.hitl_config, self._app_service.gui_input

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -175,26 +175,30 @@ class HitlDriver(AppDriver):
         if self.network_server_enabled:
             self._client_message_manager = ClientMessageManager()
 
-        self._app_service = AppService(
-            config,
-            self._hitl_config,
-            gui_input,
-            self._remote_gui_input,
-            line_render,
-            text_drawer,
-            lambda: self._viz_anim_fraction,
-            self.habitat_env,
-            self.get_sim(),
-            lambda: self._compute_action_and_step_env(),
-            self._step_recorder,
-            lambda: self._get_recent_metrics(),
-            local_end_episode,
-            lambda: self._set_cursor_style,
-            self._episode_helper,
-            self._client_message_manager,
+        gui_agent_controller: Any = (
             self.ctrl_helper.get_gui_agent_controller()
             if self.ctrl_helper
-            else None,
+            else None
+        )
+
+        self._app_service = AppService(
+            config=config,
+            hitl_config=self._hitl_config,
+            gui_input=gui_input,
+            remote_gui_input=self._remote_gui_input,
+            line_render=line_render,
+            text_drawer=text_drawer,
+            get_anim_fraction=lambda: self._viz_anim_fraction,
+            env=self.habitat_env,
+            sim=self.get_sim(),
+            compute_action_and_step_env=lambda: self._compute_action_and_step_env(),
+            step_recorder=self._step_recorder,
+            get_metrics=lambda: self._get_recent_metrics(),
+            end_episode=local_end_episode,
+            set_cursor_style=self._set_cursor_style,
+            episode_helper=self._episode_helper,
+            client_message_manager=self._client_message_manager,
+            gui_agent_controller=gui_agent_controller,
         )
 
         self._app_state: AppState = None

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -10,8 +10,6 @@ from typing import Callable, Optional
 
 from habitat import Env
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
-
-# Helpers to provide to AppState classes, provided by the underlying SandboxDriver
 from habitat_hitl.core.client_message_manager import ClientMessageManager
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.remote_gui_input import RemoteGuiInput
@@ -22,6 +20,7 @@ from habitat_hitl.environment.episode_helper import EpisodeHelper
 from habitat_sim.gfx import DebugLineRender
 
 
+# Helpers to provide to AppState classes, provided by the underlying SandboxDriver
 class AppService:
     def __init__(
         self,

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -4,28 +4,44 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from habitat import Env
+from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
 
 # Helpers to provide to AppState classes, provided by the underlying SandboxDriver
+from habitat_hitl.core.client_message_manager import ClientMessageManager
+from habitat_hitl.core.gui_input import GuiInput
+from habitat_hitl.core.remote_gui_input import RemoteGuiInput
+from habitat_hitl.core.serialize_utils import BaseRecorder
+from habitat_hitl.core.text_drawer import AbstractTextDrawer
+from habitat_hitl.environment.controllers.controller_abc import GuiController
+from habitat_hitl.environment.episode_helper import EpisodeHelper
+from habitat_sim.gfx import DebugLineRender
+
+
 class AppService:
     def __init__(
         self,
         config,
         hitl_config,
-        gui_input,
-        remote_gui_input,
-        line_render,
-        text_drawer,
-        get_anim_fraction,
-        env,
-        sim,
-        compute_action_and_step_env,
-        step_recorder,
-        get_metrics,
-        end_episode,
-        set_cursor_style,
-        episode_helper,
-        client_message_manager,
-        gui_agent_controller,
+        gui_input: GuiInput,
+        remote_gui_input: RemoteGuiInput,
+        line_render: DebugLineRender,
+        text_drawer: AbstractTextDrawer,
+        get_anim_fraction: Callable[[], float],
+        env: Env,
+        sim: RearrangeSim,
+        compute_action_and_step_env: Callable[[], None],
+        step_recorder: BaseRecorder,
+        get_metrics: Callable[[], Dict | Any],
+        end_episode: Callable[[bool], None],
+        set_cursor_style: Callable[[Any], None],
+        episode_helper: EpisodeHelper,
+        client_message_manager: ClientMessageManager,
+        gui_agent_controller: Optional[GuiController],
     ):
         self._config = config
         self._hitl_config = hitl_config
@@ -54,61 +70,61 @@ class AppService:
         return self._hitl_config
 
     @property
-    def gui_input(self):
+    def gui_input(self) -> GuiInput:
         return self._gui_input
 
     @property
-    def remote_gui_input(self):
+    def remote_gui_input(self) -> RemoteGuiInput:
         return self._remote_gui_input
 
     @property
-    def line_render(self):
+    def line_render(self) -> DebugLineRender:
         return self._line_render
 
     @property
-    def text_drawer(self):
+    def text_drawer(self) -> AbstractTextDrawer:
         return self._text_drawer
 
     @property
-    def get_anim_fraction(self):
+    def get_anim_fraction(self) -> Callable[[], float]:
         return self._get_anim_fraction
 
     @property
-    def env(self):
+    def env(self) -> Env:
         return self._env
 
     @property
-    def sim(self):
+    def sim(self) -> RearrangeSim:
         return self._sim
 
     @property
-    def compute_action_and_step_env(self):
+    def compute_action_and_step_env(self) -> Callable[[], None]:
         return self._compute_action_and_step_env
 
     @property
-    def step_recorder(self):
+    def step_recorder(self) -> BaseRecorder:
         return self._step_recorder
 
     @property
-    def get_metrics(self):
+    def get_metrics(self) -> Callable[[], Dict | Any]:
         return self._get_metrics
 
     @property
-    def end_episode(self):
+    def end_episode(self) -> Callable[[bool], None]:
         return self._end_episode
 
     @property
-    def set_cursor_style(self):
+    def set_cursor_style(self) -> Callable[[Any], None]:
         return self._set_cursor_style
 
     @property
-    def episode_helper(self):
+    def episode_helper(self) -> EpisodeHelper:
         return self._episode_helper
 
     @property
-    def client_message_manager(self):
+    def client_message_manager(self) -> ClientMessageManager:
         return self._client_message_manager
 
     @property
-    def gui_agent_controller(self):
+    def gui_agent_controller(self) -> Optional[GuiController]:
         return self._gui_agent_controller

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -24,6 +24,7 @@ from habitat_sim.gfx import DebugLineRender
 class AppService:
     def __init__(
         self,
+        *,
         config,
         hitl_config,
         gui_input: GuiInput,

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional
+from typing import Callable, Optional
 
 from habitat import Env
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
@@ -31,14 +31,14 @@ class AppService:
         remote_gui_input: RemoteGuiInput,
         line_render: DebugLineRender,
         text_drawer: AbstractTextDrawer,
-        get_anim_fraction: Callable[[], float],
+        get_anim_fraction: Callable,
         env: Env,
         sim: RearrangeSim,
-        compute_action_and_step_env: Callable[[], None],
+        compute_action_and_step_env: Callable,
         step_recorder: BaseRecorder,
-        get_metrics: Callable[[], Dict | Any],
-        end_episode: Callable[[bool], None],
-        set_cursor_style: Callable[[Any], None],
+        get_metrics: Callable,
+        end_episode: Callable,
+        set_cursor_style: Callable,
         episode_helper: EpisodeHelper,
         client_message_manager: ClientMessageManager,
         gui_agent_controller: Optional[GuiController],
@@ -86,7 +86,7 @@ class AppService:
         return self._text_drawer
 
     @property
-    def get_anim_fraction(self) -> Callable[[], float]:
+    def get_anim_fraction(self) -> Callable:
         return self._get_anim_fraction
 
     @property
@@ -98,7 +98,7 @@ class AppService:
         return self._sim
 
     @property
-    def compute_action_and_step_env(self) -> Callable[[], None]:
+    def compute_action_and_step_env(self) -> Callable:
         return self._compute_action_and_step_env
 
     @property
@@ -106,15 +106,15 @@ class AppService:
         return self._step_recorder
 
     @property
-    def get_metrics(self) -> Callable[[], Dict | Any]:
+    def get_metrics(self) -> Callable:
         return self._get_metrics
 
     @property
-    def end_episode(self) -> Callable[[bool], None]:
+    def end_episode(self) -> Callable:
         return self._end_episode
 
     @property
-    def set_cursor_style(self) -> Callable[[Any], None]:
+    def set_cursor_style(self) -> Callable:
         return self._set_cursor_style
 
     @property


### PR DESCRIPTION
## Motivation and Context

The `AppService` object acts a dependency injection container for HITL components. Its dependencies are opaque and difficult to track.
This changeset adds type annotations to this object.

## How Has This Been Tested

Pre-commit and local run.

## Types of changes

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
