### PR TITLE
[bugfix] -  minor generator fixes

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -886,8 +886,8 @@ class RearrangeEpisodeGenerator:
             "rgb": {
                 "sensor_type": habitat_sim.SensorType.COLOR,
                 "resolution": camera_resolution,
-                "position": [0.0, 0.0, 0.0],
-                "orientation": [0.0, 0.0, 0.0],
+                "position": [0, 0, 0],
+                "orientation": [0, 0, 0.0],
             }
         }
 
@@ -1057,7 +1057,8 @@ class RearrangeEpisodeGenerator:
             if obj_name in unstable_placements:
                 rec_num_obj_vs_unstable[rec]["num_unstable_objects"] += 1
         for rec, obj_in_rec in rec_num_obj_vs_unstable.items():
-            detailed_receptacle_stability_report += f"\n      receptacle '{rec.unique_name}': ({obj_in_rec['num_unstable_objects']}/{obj_in_rec['num_objects']}) (unstable/total) objects."
+            rec_unique_name = rec.unique_name if rec is not None else "floor"
+            detailed_receptacle_stability_report += f"\n      receptacle '{rec_unique_name}': ({obj_in_rec['num_unstable_objects']}/{obj_in_rec['num_objects']}) (unstable/total) objects."
 
         success = len(unstable_placements) == 0
 

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -887,7 +887,7 @@ class RearrangeEpisodeGenerator:
                 "sensor_type": habitat_sim.SensorType.COLOR,
                 "resolution": camera_resolution,
                 "position": [0, 0, 0],
-                "orientation": [0, 0, 0.0],
+                "orientation": [0, 0, 0],
             }
         }
 

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -256,6 +256,12 @@ class ObjectSampler:
                 sim.pathfinder, sim, allow_outdoor=False
             )
 
+        rec_up_global = (
+            receptacle.get_global_transform(sim)
+            .transform_vector(receptacle.up)
+            .normalized()
+        )
+
         while num_placement_tries < self.max_placement_attempts:
             num_placement_tries += 1
 
@@ -264,7 +270,7 @@ class ObjectSampler:
                 receptacle.sample_uniform_global(
                     sim, self.sample_region_ratio[receptacle.name]
                 )
-                + self._translation_up_offset * receptacle.up
+                + self._translation_up_offset * rec_up_global
             )
 
             # instance the new potential object from the handle

--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -89,7 +89,7 @@ class DebugVisualizer:
     dbv.get_observation().show()
     dbv.translate(mn.Vector3(1,0,0), show=True)
     dbv.peek_articulated_object(my_ao, show=True)
-    dbv.peek_rigid_object(my_ro, show_all_axis=True, show=True)
+    dbv.peek_rigid_object(my_ro, peek_all_axis=True, show=True)
     """
 
     def __init__(
@@ -133,7 +133,7 @@ class DebugVisualizer:
 
         debug_sensor_spec = habitat_sim.CameraSensorSpec()
         debug_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
-        debug_sensor_spec.position = [0.0, 0.0, 0.0]
+        debug_sensor_spec.position = [0, 0, 0]
         debug_sensor_spec.resolution = [resolution[0], resolution[1]]
         debug_sensor_spec.uuid = self.sensor_uuid
 
@@ -502,6 +502,10 @@ class DebugVisualizer:
 
         :return: a tuple containing saved filepath and the list of DebugObservations generated.
         """
+
+        # scene is best viewed from above by default
+        if cam_local_pos is None:
+            cam_local_pos = mn.Vector3(0, 1, 0)
 
         return self._peek_bb(
             bb_name=self.sim.curr_scene_name,


### PR DESCRIPTION
## Motivation and Context

This PR contains three minor, independent fixes from #1770:
1. `DebugVisualizer.peek_scene` now defaults to a topdown view
2. `ObjectSampler.sample_placement` now correctly uses the global "up" vector of the receptacle for initial snap_down position.
3. improved stability report during `settle_sim` allowing objects added to a "None" receptacle object for "floor" placements.

## How Has This Been Tested

in other branch logic from habitat-llm and #1770

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
