### PR TITLE
"Within" set query util

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -352,3 +352,25 @@ def get_all_objects(
     for mngr in managers:
         all_objects.extend(mngr.get_objects_by_handle_substring().values())
     return all_objects
+
+
+def get_ao_link_id_map(sim: habitat_sim.Simulator) -> Dict[int, int]:
+    """
+    Construct a dict mapping ArticulatedLink object_id to parent ArticulatedObject object_id.
+    NOTE: also maps ao's root object id to itself for ease of use.
+
+    :param sim: The Simulator instance.
+
+    :return: dict mapping ArticulatedLink object ids to parent object ids.
+    """
+
+    aom = sim.get_articulated_object_manager()
+    ao_link_map: Dict[int, int] = {}
+    for ao in aom.get_objects_by_handle_substring().values():
+        # add the ao itself for ease of use
+        ao_link_map[ao.object_id] = ao.object_id
+        # add the links
+        for link_id in ao.link_object_ids:
+            ao_link_map[link_id] = ao.object_id
+
+    return ao_link_map

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -374,3 +374,63 @@ def get_ao_link_id_map(sim: habitat_sim.Simulator) -> Dict[int, int]:
             ao_link_map[link_id] = ao.object_id
 
     return ao_link_map
+
+
+def get_obj_from_id(
+    sim: habitat_sim.Simulator,
+    obj_id: int,
+    ao_link_map: Optional[Dict[int, int]] = None,
+) -> Union[
+    habitat_sim.physics.ManagedRigidObject,
+    habitat_sim.physics.ManagedArticulatedObject,
+]:
+    """
+    Get a ManagedRigidObject or ManagedArticulatedObject from an object_id.
+
+    ArticulatedLink object_ids will return the ManagedArticulatedObject.
+    If you want link id, use ManagedArticulatedObject.link_object_ids[obj_id].
+
+    :param sim: The Simulator instance.
+    :param obj_id: object id for which ManagedObject is desired.
+    :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id.
+
+    :return: a ManagedObject or None
+    """
+
+    if ao_link_map is None:
+        # Note: better to pre-compute this and pass it around
+        ao_link_map = get_ao_link_id_map(sim)
+
+    rom = sim.get_rigid_object_manager()
+    if rom.get_library_has_id(obj_id):
+        return rom.get_object_by_id(obj_id)
+    aom = sim.get_articulated_object_manager()
+    if obj_id in ao_link_map:
+        return aom.get_object_by_id(ao_link_map[obj_id])
+
+    return None
+
+
+def get_obj_from_handle(
+    sim: habitat_sim.Simulator, obj_handle: str
+) -> Union[
+    habitat_sim.physics.ManagedRigidObject,
+    habitat_sim.physics.ManagedArticulatedObject,
+]:
+    """
+    Get a ManagedRigidObject or ManagedArticulatedObject from its instance handle.
+
+    :param sim: The Simulator instance.
+    :param obj_handle: object istance handle for which ManagedObject is desired.
+
+    :return: a ManagedObject or None
+    """
+
+    rom = sim.get_rigid_object_manager()
+    if rom.get_library_has_handle(obj_handle):
+        return rom.get_object_by_handle(obj_handle)
+    aom = sim.get_articulated_object_manager()
+    if aom.get_library_has_handle(obj_handle):
+        return aom.get_object_by_handle(obj_handle)
+
+    return None

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import magnum as mn
 
@@ -302,7 +302,12 @@ def snap_down(
 def get_all_object_ids(sim: habitat_sim.Simulator) -> Dict[int, str]:
     """
     Generate a dict mapping all active object ids to a descriptive string containing the object instance handle and, for ArticulatedLinks, the link name.
+
+    :param sim: The Simulator instance.
+
+    :return: a dict mapping object ids to a descriptive string.
     """
+
     rom = sim.get_rigid_object_manager()
     aom = sim.get_articulated_object_manager()
 
@@ -321,3 +326,29 @@ def get_all_object_ids(sim: habitat_sim.Simulator) -> Dict[int, str]:
             )
 
     return object_id_map
+
+
+def get_all_objects(
+    sim: habitat_sim.Simulator,
+) -> List[
+    Union[
+        habitat_sim.physics.ManagedRigidObject,
+        habitat_sim.physics.ManagedArticulatedObject,
+    ]
+]:
+    """
+    Get a list of all ManagedRigidObjects and ManagedArticulatedObjects in the scene.
+
+    :param sim: The Simulator instance.
+
+    :return: a list of ManagedObject wrapper instances containing all objects currently instantiated in the scene.
+    """
+
+    managers = [
+        sim.get_rigid_object_manager(),
+        sim.get_articulated_object_manager(),
+    ]
+    all_objects = []
+    for mngr in managers:
+        all_objects.extend(mngr.get_objects_by_handle_substring().values())
+    return all_objects

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -14,6 +14,8 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     get_all_object_ids,
     get_all_objects,
     get_ao_link_id_map,
+    get_obj_from_handle,
+    get_obj_from_id,
     snap_down,
 )
 from habitat_sim import Simulator, built_with_bullet
@@ -196,6 +198,13 @@ def test_object_getters():
             assert (
                 obj.object_id in all_object_ids
             ), f"Object's object_id {object_id} is not found in the global object id map."
+            # check the wrapper getter functions
+            obj_from_id_getter = get_obj_from_id(
+                sim, obj.object_id, ao_link_map
+            )
+            obj_from_handle_getter = get_obj_from_handle(sim, obj.handle)
+            assert obj_from_id_getter.object_id == obj.object_id
+            assert obj_from_handle_getter.object_id == obj.object_id
 
         # specifically validate link object_id mapping
         aom = sim.get_articulated_object_manager()
@@ -208,3 +217,8 @@ def test_object_getters():
                 assert link_object_id in ao_link_map
                 assert ao_link_map[link_object_id] == ao.object_id
                 assert link_index in link_indices
+                # links should return reference to parent object
+                obj_from_id_getter = get_obj_from_id(
+                    sim, link_object_id, ao_link_map
+                )
+                assert obj_from_id_getter.object_id == ao.object_id

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -10,6 +10,7 @@ import magnum as mn
 import pytest
 
 from habitat.sims.habitat_simulator.sim_utilities import (
+    above,
     bb_ray_prescreen,
     get_all_object_ids,
     get_all_objects,
@@ -222,3 +223,53 @@ def test_object_getters():
                     sim, link_object_id, ao_link_map
                 )
                 assert obj_from_id_getter.object_id == ao.object_id
+
+
+@pytest.mark.skipif(
+    not built_with_bullet,
+    reason="Raycasting API requires Bullet physics.",
+)
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/"),
+    reason="Requires ReplicaCAD dataset.",
+)
+def test_keypoint_cast_prepositions():
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    sim_settings["scene"] = "apt_0"
+    hab_cfg = make_cfg(sim_settings)
+    with Simulator(hab_cfg) as sim:
+        all_objects = get_all_object_ids(sim)
+
+        mixer_object = get_obj_from_handle(
+            sim, "frl_apartment_small_appliance_01_:0000"
+        )
+        mixer_above = above(sim, mixer_object)
+        mixer_above_strings = [
+            all_objects[obj_id] for obj_id in mixer_above if obj_id >= 0
+        ]
+        expected_mixer_above_strings = [
+            "kitchen_counter_:0000",
+            "kitchen_counter_:0000 -- drawer2_bottom",
+            "kitchen_counter_:0000 -- drawer2_middle",
+            "kitchen_counter_:0000 -- drawer2_top",
+        ]
+        for expected in expected_mixer_above_strings:
+            assert expected in mixer_above_strings
+        assert len(mixer_above_strings) == len(expected_mixer_above_strings)
+
+        tv_object = get_obj_from_handle(sim, "frl_apartment_tv_screen_:0000")
+        tv_above = above(sim, tv_object)
+        tv_above_strings = [
+            all_objects[obj_id] for obj_id in tv_above if obj_id >= 0
+        ]
+        expected_tv_above_strings = [
+            "frl_apartment_tvstand_:0000",
+            "frl_apartment_chair_01_:0000",
+        ]
+
+        for expected in expected_tv_above_strings:
+            assert expected in tv_above_strings
+        assert len(tv_above_strings) == len(expected_tv_above_strings)

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -11,6 +11,9 @@ import pytest
 
 from habitat.sims.habitat_simulator.sim_utilities import (
     bb_ray_prescreen,
+    get_all_object_ids,
+    get_all_objects,
+    get_ao_link_id_map,
     snap_down,
 )
 from habitat_sim import Simulator, built_with_bullet
@@ -155,3 +158,53 @@ def test_snap_down(support_margin, obj_margin, stage_support):
                 if stage_support:
                     # don't need 3 iterations for stage b/c no motion types to test
                     break
+
+
+@pytest.mark.skipif(
+    not built_with_bullet,
+    reason="Raycasting API requires Bullet physics.",
+)
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/"),
+    reason="Requires ReplicaCAD dataset.",
+)
+def test_object_getters():
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    sim_settings["scene"] = "apt_0"
+    hab_cfg = make_cfg(sim_settings)
+    with Simulator(hab_cfg) as sim:
+        # scrape various lists from utils
+        all_objects = get_all_objects(sim)
+        all_object_ids = get_all_object_ids(sim)
+        ao_link_map = get_ao_link_id_map(sim)
+
+        # validate parity between util results
+        assert len(all_objects) == (
+            sim.get_rigid_object_manager().get_num_objects()
+            + sim.get_articulated_object_manager().get_num_objects()
+        )
+        for object_id in ao_link_map:
+            assert (
+                object_id in all_object_ids
+            ), f"Link or AO object id {object_id} is not found in the global object id map."
+        for obj in all_objects:
+            assert obj is not None
+            assert obj.is_alive
+            assert (
+                obj.object_id in all_object_ids
+            ), f"Object's object_id {object_id} is not found in the global object id map."
+
+        # specifically validate link object_id mapping
+        aom = sim.get_articulated_object_manager()
+        for ao in aom.get_objects_by_handle_substring().values():
+            assert ao.object_id in all_object_ids
+            assert ao.object_id in ao_link_map
+            link_indices = ao.get_link_ids()
+            assert len(ao.link_object_ids) == len(link_indices)
+            for link_object_id, link_index in ao.link_object_ids.items():
+                assert link_object_id in ao_link_map
+                assert ao_link_map[link_object_id] == ao.object_id
+                assert link_index in link_indices

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -17,6 +17,7 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     get_ao_link_id_map,
     get_obj_from_handle,
     get_obj_from_id,
+    object_keypoint_cast,
     snap_down,
 )
 from habitat_sim import Simulator, built_with_bullet
@@ -273,3 +274,17 @@ def test_keypoint_cast_prepositions():
         for expected in expected_tv_above_strings:
             assert expected in tv_above_strings
         assert len(tv_above_strings) == len(expected_tv_above_strings)
+
+        # now define a custom keypoint cast from the mixer constructed to include tv in the set
+        mixer_to_tv = (
+            tv_object.translation - mixer_object.translation
+        ).normalized()
+        mixer_to_tv_object_ids = [
+            hit.object_id
+            for keypoint_raycast_result in object_keypoint_cast(
+                sim, mixer_object, direction=mixer_to_tv
+            )
+            for hit in keypoint_raycast_result.hits
+        ]
+        mixer_to_tv_object_ids = list(set(mixer_to_tv_object_ids))
+        assert tv_object.object_id in mixer_to_tv_object_ids


### PR DESCRIPTION
## Motivation and Context

Based on #1770.

Adds "within" preposition query based on raycasting from object keypoints.

NOTE: returns a set of object_id rather than previous prototype's ManagedObject tuples.

## How Has This Been Tested

Added a pytest

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
