### PR TITLE
Region containment query utils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
               . activate habitat
               git lfs install
               conda install -y gitpython git-lfs
-              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm --data-path habitat-sim/data/ --no-replace --no-prune
+              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm hab3_bench_assets --data-path habitat-sim/data/ --no-replace --no-prune
       - run:
           name: Run sim benchmark
           command: |

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -352,3 +352,25 @@ def get_all_objects(
     for mngr in managers:
         all_objects.extend(mngr.get_objects_by_handle_substring().values())
     return all_objects
+
+
+def get_ao_link_id_map(sim: habitat_sim.Simulator) -> Dict[int, int]:
+    """
+    Construct a dict mapping ArticulatedLink object_id to parent ArticulatedObject object_id.
+    NOTE: also maps ao's root object id to itself for ease of use.
+
+    :param sim: The Simulator instance.
+
+    :return: dict mapping ArticulatedLink object ids to parent object ids.
+    """
+
+    aom = sim.get_articulated_object_manager()
+    ao_link_map: Dict[int, int] = {}
+    for ao in aom.get_objects_by_handle_substring().values():
+        # add the ao itself for ease of use
+        ao_link_map[ao.object_id] = ao.object_id
+        # add the links
+        for link_id in ao.link_object_ids:
+            ao_link_map[link_id] = ao.object_id
+
+    return ao_link_map

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -374,3 +374,63 @@ def get_ao_link_id_map(sim: habitat_sim.Simulator) -> Dict[int, int]:
             ao_link_map[link_id] = ao.object_id
 
     return ao_link_map
+
+
+def get_obj_from_id(
+    sim: habitat_sim.Simulator,
+    obj_id: int,
+    ao_link_map: Optional[Dict[int, int]] = None,
+) -> Union[
+    habitat_sim.physics.ManagedRigidObject,
+    habitat_sim.physics.ManagedArticulatedObject,
+]:
+    """
+    Get a ManagedRigidObject or ManagedArticulatedObject from an object_id.
+
+    ArticulatedLink object_ids will return the ManagedArticulatedObject.
+    If you want link id, use ManagedArticulatedObject.link_object_ids[obj_id].
+
+    :param sim: The Simulator instance.
+    :param obj_id: object id for which ManagedObject is desired.
+    :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id.
+
+    :return: a ManagedObject or None
+    """
+
+    if ao_link_map is None:
+        # Note: better to pre-compute this and pass it around
+        ao_link_map = get_ao_link_id_map(sim)
+
+    rom = sim.get_rigid_object_manager()
+    if rom.get_library_has_id(obj_id):
+        return rom.get_object_by_id(obj_id)
+    aom = sim.get_articulated_object_manager()
+    if obj_id in ao_link_map:
+        return aom.get_object_by_id(ao_link_map[obj_id])
+
+    return None
+
+
+def get_obj_from_handle(
+    sim: habitat_sim.Simulator, obj_handle: str
+) -> Union[
+    habitat_sim.physics.ManagedRigidObject,
+    habitat_sim.physics.ManagedArticulatedObject,
+]:
+    """
+    Get a ManagedRigidObject or ManagedArticulatedObject from its instance handle.
+
+    :param sim: The Simulator instance.
+    :param obj_handle: object istance handle for which ManagedObject is desired.
+
+    :return: a ManagedObject or None
+    """
+
+    rom = sim.get_rigid_object_manager()
+    if rom.get_library_has_handle(obj_handle):
+        return rom.get_object_by_handle(obj_handle)
+    aom = sim.get_articulated_object_manager()
+    if aom.get_library_has_handle(obj_handle):
+        return aom.get_object_by_handle(obj_handle)
+
+    return None

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import magnum as mn
 
@@ -355,6 +355,65 @@ def get_all_objects(
     return all_objects
 
 
+def get_ao_root_bb(
+    ao: habitat_sim.physics.ManagedArticulatedObject,
+) -> mn.Range3D:
+    """
+    Get the local bounding box of all links of an articulated object in the root frame.
+
+    :param ao: The ArticulatedObject instance.
+    """
+
+    # NOTE: we'd like to use SceneNode AABB, but this won't work because the links are not in the subtree of the root:
+    # ao.root_scene_node.compute_cumulative_bb()
+
+    ao_local_part_bb_corners = []
+
+    link_nodes = [ao.get_link_scene_node(ix) for ix in range(-1, ao.num_links)]
+    for link_node in link_nodes:
+        local_bb_corners = get_bb_corners(link_node.cumulative_bb)
+        global_bb_corners = [
+            link_node.absolute_transformation().transform_point(bb_corner)
+            for bb_corner in local_bb_corners
+        ]
+        ao_local_bb_corners = [
+            ao.transformation.inverted().transform_point(p)
+            for p in global_bb_corners
+        ]
+        ao_local_part_bb_corners.extend(ao_local_bb_corners)
+
+    # get min and max of each dimension
+    # TODO: use numpy arrays for more elegance...
+    max_vec = mn.Vector3(ao_local_part_bb_corners[0])
+    min_vec = mn.Vector3(ao_local_part_bb_corners[0])
+    for point in ao_local_part_bb_corners:
+        for dim in range(3):
+            max_vec[dim] = max(max_vec[dim], point[dim])
+            min_vec[dim] = min(min_vec[dim], point[dim])
+    return mn.Range3D(min_vec, max_vec)
+
+
+def get_ao_root_bbs(
+    sim: habitat_sim.Simulator,
+) -> Dict[int, mn.Range3D]:
+    """
+    Computes a dictionary mapping AO handles to a global bounding box of parts.
+    Must be updated when AO state changes to correctly bound the full set of links.
+
+    :param sim: The Simulator instance.
+
+    :return: dictionary mapping ArticulatedObjects' object_id to their bounding box in local space.
+    """
+
+    ao_local_bbs: Dict[
+        habitat_sim.physics.ManagedBulletArticulatedObject, mn.Range3D
+    ] = {}
+    aom = sim.get_articulated_object_manager()
+    for ao in aom.get_objects_by_handle_substring().values():
+        ao_local_bbs[ao.object_id] = get_ao_root_bb(ao)
+    return ao_local_bbs
+
+
 def get_ao_link_id_map(sim: habitat_sim.Simulator) -> Dict[int, int]:
     """
     Construct a dict mapping ArticulatedLink object_id to parent ArticulatedObject object_id.
@@ -437,6 +496,27 @@ def get_obj_from_handle(
     return None
 
 
+def get_global_keypoints_from_bb(
+    aabb: mn.Range3D, local_to_global: mn.Matrix4
+) -> List[mn.Vector3]:
+    """
+    Get a list of bounding box keypoints in global space.
+    0th point is the bounding box center, others are bounding box corners.
+
+    :param aabb: The local bounding box.
+    :param local_to_global: The local to global transformation matrix.
+
+    :return: A set of global 3D keypoints for the bounding box.
+    """
+    local_keypoints = [aabb.center()]
+    local_keypoints.extend(get_bb_corners(aabb))
+    global_keypoints = [
+        local_to_global.transform_point(key_point)
+        for key_point in local_keypoints
+    ]
+    return global_keypoints
+
+
 def get_rigid_object_global_keypoints(
     objectA: habitat_sim.physics.ManagedRigidObject,
 ) -> List[mn.Vector3]:
@@ -450,13 +530,79 @@ def get_rigid_object_global_keypoints(
     """
 
     bb = objectA.root_scene_node.cumulative_bb
-    local_keypoints = [bb.center()]
-    local_keypoints.extend(get_bb_corners(bb))
-    global_keypoints = [
-        objectA.transformation.transform_point(key_point)
-        for key_point in local_keypoints
-    ]
-    return global_keypoints
+    return get_global_keypoints_from_bb(bb, objectA.transformation)
+
+
+def get_articulated_object_global_keypoints(
+    objectA: habitat_sim.physics.ManagedArticulatedObject,
+    ao_aabbs: Dict[int, mn.Range3D] = None,
+) -> List[mn.Vector3]:
+    """
+    Get global bb keypoints for an ArticulatedObject.
+
+    :param objectA: The ManagedArticulatedObject from which to extract keypoints.
+    :param ao_aabbs: A pre-computed map from ArticulatedObject object_ids to their local bounding boxes. If not provided, recomputed as necessary. Must contain the subjects of the query.
+
+    :return: A set of global 3D keypoints for the object.
+    """
+
+    ao_bb = None
+    if ao_aabbs is None:
+        ao_bb = get_ao_root_bb(objectA)
+    else:
+        ao_bb = ao_aabbs[objectA.object_id]
+
+    return get_global_keypoints_from_bb(ao_bb, objectA.transformation)
+
+
+def get_articulated_link_global_keypoints(
+    objectA: habitat_sim.physics.ManagedArticulatedObject, link_index: int
+) -> List[mn.Vector3]:
+    """
+    Get global bb keypoints for an ArticulatedLink.
+
+    :param objectA: The parent ManagedArticulatedObject for the link.
+    :param link_index: The local index of the link within the parent ArticulatedObject. Not the object_id of the link.
+
+    :return: A set of global 3D keypoints for the link.
+    """
+    link_node = objectA.get_link_scene_node(link_index)
+
+    return get_global_keypoints_from_bb(
+        link_node.cumulative_bb, link_node.absolute_transformation()
+    )
+
+
+def get_global_keypoints_from_object_id(
+    sim: habitat_sim.Simulator,
+    object_id: int,
+    ao_link_map: Optional[Dict[int, int]] = None,
+    ao_aabbs: Dict[int, mn.Range3D] = None,
+) -> List[mn.Vector3]:
+    """
+    Get a list of object keypoints in global space given an object id.
+    0th point is the center of bb, others are bounding box corners.
+
+    :param sim: The Simulator instance.
+    :param object_id: The integer id for the object from which to extract keypoints.
+    :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id. If not provided, recomputed as necessary.
+    :param ao_aabbs: A pre-computed map from ArticulatedObject object_ids to their local bounding boxes. If not provided, recomputed as necessary.
+
+    :return: A set of global 3D keypoints for the object.
+    """
+
+    obj = get_obj_from_id(sim, object_id, ao_link_map)
+
+    if type(obj) == habitat_sim.physics.ManagedBulletRigidObject:
+        return get_rigid_object_global_keypoints(obj)
+    elif obj.object_id != object_id:
+        # this is an ArticulatedLink
+        return get_articulated_link_global_keypoints(
+            obj, obj.link_object_ids[object_id]
+        )
+    else:
+        # ArticulatedObject
+        return get_articulated_object_global_keypoints(obj, ao_aabbs)
 
 
 def object_keypoint_cast(
@@ -605,3 +751,76 @@ def within(
         containment_ids.remove(objectA.object_id)
 
     return containment_ids
+
+
+def object_in_region(
+    sim: habitat_sim.Simulator,
+    objectA: Union[
+        habitat_sim.physics.ManagedRigidObject,
+        habitat_sim.physics.ManagedArticulatedObject,
+    ],
+    region: habitat_sim.scene.SemanticRegion,
+    containment_threshold=0.25,
+    center_only=False,
+    ao_link_map: Dict[int, int] = None,
+    ao_aabbs: Dict[int, mn.Range3D] = None,
+) -> Tuple[bool, float]:
+    """
+    Check if an object is within a region by checking region containment of keypoints.
+
+    :param sim: The Simulator instance.
+    :param objectA: The object instance.
+    :param region: The SemanticRegion to check.
+    :param containment_threshold: threshold ratio of keypoints which need to be in a region to count as containment.
+    :param center_only: If True, only use the BB center keypoint, all or nothing.
+    :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id.
+    :param ao_aabbs: A pre-computed map from ArticulatedObject object_ids to their local bounding boxes. If not provided, recomputed as necessary.
+
+
+    :return: boolean containment and the ratio of keypoints which are inside the region.
+    """
+
+    key_points = get_global_keypoints_from_object_id(
+        sim,
+        object_id=objectA.object_id,
+        ao_link_map=ao_link_map,
+        ao_aabbs=ao_aabbs,
+    )
+
+    if center_only:
+        key_points = [key_points[0]]
+
+    contained_points = [p for p in key_points if region.contains(p)]
+    ratio = len(contained_points) / float(len(key_points))
+
+    return ratio >= containment_threshold, ratio
+
+
+def get_object_regions(
+    sim: habitat_sim.Simulator,
+    objectA: Union[
+        habitat_sim.physics.ManagedRigidObject,
+        habitat_sim.physics.ManagedArticulatedObject,
+    ],
+    ao_link_map: Dict[int, int] = None,
+    ao_aabbs: Dict[int, mn.Range3D] = None,
+) -> List[Tuple[int, float]]:
+    """
+    Get a sorted list of regions containing an object using bounding box keypoints.
+
+    :param sim: The Simulator instance.
+    :param objectA: The object instance.
+    :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id.
+    :param ao_aabbs: A pre-computed map from ArticulatedObject object_ids to their local bounding boxes. If not provided, recomputed as necessary.
+
+    :return: A sorted list of region index, ratio pairs. First item in the list the primary containing region.
+    """
+
+    key_points = get_global_keypoints_from_object_id(
+        sim,
+        object_id=objectA.object_id,
+        ao_link_map=ao_link_map,
+        ao_aabbs=ao_aabbs,
+    )
+
+    return sim.semantic_scene.get_regions_for_points(key_points)

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import magnum as mn
 
@@ -302,7 +302,12 @@ def snap_down(
 def get_all_object_ids(sim: habitat_sim.Simulator) -> Dict[int, str]:
     """
     Generate a dict mapping all active object ids to a descriptive string containing the object instance handle and, for ArticulatedLinks, the link name.
+
+    :param sim: The Simulator instance.
+
+    :return: a dict mapping object ids to a descriptive string.
     """
+
     rom = sim.get_rigid_object_manager()
     aom = sim.get_articulated_object_manager()
 
@@ -321,3 +326,29 @@ def get_all_object_ids(sim: habitat_sim.Simulator) -> Dict[int, str]:
             )
 
     return object_id_map
+
+
+def get_all_objects(
+    sim: habitat_sim.Simulator,
+) -> List[
+    Union[
+        habitat_sim.physics.ManagedRigidObject,
+        habitat_sim.physics.ManagedArticulatedObject,
+    ]
+]:
+    """
+    Get a list of all ManagedRigidObjects and ManagedArticulatedObjects in the scene.
+
+    :param sim: The Simulator instance.
+
+    :return: a list of ManagedObject wrapper instances containing all objects currently instantiated in the scene.
+    """
+
+    managers = [
+        sim.get_rigid_object_manager(),
+        sim.get_articulated_object_manager(),
+    ]
+    all_objects = []
+    for mngr in managers:
+        all_objects.extend(mngr.get_objects_by_handle_substring().values())
+    return all_objects

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -593,7 +593,7 @@ def get_global_keypoints_from_object_id(
 
     obj = get_obj_from_id(sim, object_id, ao_link_map)
 
-    if type(obj) == habitat_sim.physics.ManagedBulletRigidObject:
+    if isinstance(obj, habitat_sim.physics.ManagedBulletRigidObject):
         return get_rigid_object_global_keypoints(obj)
     elif obj.object_id != object_id:
         # this is an ArticulatedLink

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -14,6 +14,8 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     get_all_object_ids,
     get_all_objects,
     get_ao_link_id_map,
+    get_obj_from_handle,
+    get_obj_from_id,
     snap_down,
 )
 from habitat_sim import Simulator, built_with_bullet
@@ -196,6 +198,13 @@ def test_object_getters():
             assert (
                 obj.object_id in all_object_ids
             ), f"Object's object_id {object_id} is not found in the global object id map."
+            # check the wrapper getter functions
+            obj_from_id_getter = get_obj_from_id(
+                sim, obj.object_id, ao_link_map
+            )
+            obj_from_handle_getter = get_obj_from_handle(sim, obj.handle)
+            assert obj_from_id_getter.object_id == obj.object_id
+            assert obj_from_handle_getter.object_id == obj.object_id
 
         # specifically validate link object_id mapping
         aom = sim.get_articulated_object_manager()
@@ -208,3 +217,8 @@ def test_object_getters():
                 assert link_object_id in ao_link_map
                 assert ao_link_map[link_object_id] == ao.object_id
                 assert link_index in link_indices
+                # links should return reference to parent object
+                obj_from_id_getter = get_obj_from_id(
+                    sim, link_object_id, ao_link_map
+                )
+                assert obj_from_id_getter.object_id == ao.object_id

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -10,6 +10,7 @@ import magnum as mn
 import pytest
 
 from habitat.sims.habitat_simulator.sim_utilities import (
+    above,
     bb_ray_prescreen,
     get_all_object_ids,
     get_all_objects,
@@ -222,3 +223,53 @@ def test_object_getters():
                     sim, link_object_id, ao_link_map
                 )
                 assert obj_from_id_getter.object_id == ao.object_id
+
+
+@pytest.mark.skipif(
+    not built_with_bullet,
+    reason="Raycasting API requires Bullet physics.",
+)
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/"),
+    reason="Requires ReplicaCAD dataset.",
+)
+def test_keypoint_cast_prepositions():
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    sim_settings["scene"] = "apt_0"
+    hab_cfg = make_cfg(sim_settings)
+    with Simulator(hab_cfg) as sim:
+        all_objects = get_all_object_ids(sim)
+
+        mixer_object = get_obj_from_handle(
+            sim, "frl_apartment_small_appliance_01_:0000"
+        )
+        mixer_above = above(sim, mixer_object)
+        mixer_above_strings = [
+            all_objects[obj_id] for obj_id in mixer_above if obj_id >= 0
+        ]
+        expected_mixer_above_strings = [
+            "kitchen_counter_:0000",
+            "kitchen_counter_:0000 -- drawer2_bottom",
+            "kitchen_counter_:0000 -- drawer2_middle",
+            "kitchen_counter_:0000 -- drawer2_top",
+        ]
+        for expected in expected_mixer_above_strings:
+            assert expected in mixer_above_strings
+        assert len(mixer_above_strings) == len(expected_mixer_above_strings)
+
+        tv_object = get_obj_from_handle(sim, "frl_apartment_tv_screen_:0000")
+        tv_above = above(sim, tv_object)
+        tv_above_strings = [
+            all_objects[obj_id] for obj_id in tv_above if obj_id >= 0
+        ]
+        expected_tv_above_strings = [
+            "frl_apartment_tvstand_:0000",
+            "frl_apartment_chair_01_:0000",
+        ]
+
+        for expected in expected_tv_above_strings:
+            assert expected in tv_above_strings
+        assert len(tv_above_strings) == len(expected_tv_above_strings)

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -11,6 +11,9 @@ import pytest
 
 from habitat.sims.habitat_simulator.sim_utilities import (
     bb_ray_prescreen,
+    get_all_object_ids,
+    get_all_objects,
+    get_ao_link_id_map,
     snap_down,
 )
 from habitat_sim import Simulator, built_with_bullet
@@ -155,3 +158,53 @@ def test_snap_down(support_margin, obj_margin, stage_support):
                 if stage_support:
                     # don't need 3 iterations for stage b/c no motion types to test
                     break
+
+
+@pytest.mark.skipif(
+    not built_with_bullet,
+    reason="Raycasting API requires Bullet physics.",
+)
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/"),
+    reason="Requires ReplicaCAD dataset.",
+)
+def test_object_getters():
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    sim_settings["scene"] = "apt_0"
+    hab_cfg = make_cfg(sim_settings)
+    with Simulator(hab_cfg) as sim:
+        # scrape various lists from utils
+        all_objects = get_all_objects(sim)
+        all_object_ids = get_all_object_ids(sim)
+        ao_link_map = get_ao_link_id_map(sim)
+
+        # validate parity between util results
+        assert len(all_objects) == (
+            sim.get_rigid_object_manager().get_num_objects()
+            + sim.get_articulated_object_manager().get_num_objects()
+        )
+        for object_id in ao_link_map:
+            assert (
+                object_id in all_object_ids
+            ), f"Link or AO object id {object_id} is not found in the global object id map."
+        for obj in all_objects:
+            assert obj is not None
+            assert obj.is_alive
+            assert (
+                obj.object_id in all_object_ids
+            ), f"Object's object_id {object_id} is not found in the global object id map."
+
+        # specifically validate link object_id mapping
+        aom = sim.get_articulated_object_manager()
+        for ao in aom.get_objects_by_handle_substring().values():
+            assert ao.object_id in all_object_ids
+            assert ao.object_id in ao_link_map
+            link_indices = ao.get_link_ids()
+            assert len(ao.link_object_ids) == len(link_indices)
+            for link_object_id, link_index in ao.link_object_ids.items():
+                assert link_object_id in ao_link_map
+                assert ao_link_map[link_object_id] == ao.object_id
+                assert link_index in link_indices

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -399,12 +399,12 @@ def test_region_containment_utils():
         in_livingroom, livingroom_ratio = object_in_region(
             sim, desk_object, living_room_region
         )
-        in_bedroomroom, bedroom_ratio = object_in_region(
+        in_bedroom, bedroom_ratio = object_in_region(
             sim, desk_object, bedroom_region
         )
 
         assert in_livingroom
-        assert in_bedroomroom
+        assert in_bedroom
         assert (
             abs(livingroom_ratio + bedroom_ratio - 1.0) < 1e-5
         )  # eps for float error
@@ -430,12 +430,12 @@ def test_region_containment_utils():
         in_livingroom, livingroom_ratio = object_in_region(
             sim, desk_object, living_room_region, center_only=True
         )
-        in_bedroomroom, bedroom_ratio = object_in_region(
+        in_bedroom, bedroom_ratio = object_in_region(
             sim, desk_object, bedroom_region, center_only=True
         )
 
         assert not in_livingroom
-        assert in_bedroomroom
+        assert in_bedroom
         assert livingroom_ratio == 0
         assert bedroom_ratio == 1.0
 
@@ -443,12 +443,12 @@ def test_region_containment_utils():
         in_livingroom, livingroom_ratio = object_in_region(
             sim, desk_object, living_room_region, containment_threshold=0.51
         )
-        in_bedroomroom, bedroom_ratio = object_in_region(
+        in_bedroom, bedroom_ratio = object_in_region(
             sim, desk_object, bedroom_region, containment_threshold=0.51
         )
 
         assert not in_livingroom
-        assert in_bedroomroom
+        assert in_bedroom
         assert livingroom_ratio + bedroom_ratio == 1.0
         assert livingroom_ratio > 0
         assert livingroom_ratio < 0.51

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -17,6 +17,7 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     get_ao_link_id_map,
     get_obj_from_handle,
     get_obj_from_id,
+    object_keypoint_cast,
     snap_down,
 )
 from habitat_sim import Simulator, built_with_bullet
@@ -273,3 +274,17 @@ def test_keypoint_cast_prepositions():
         for expected in expected_tv_above_strings:
             assert expected in tv_above_strings
         assert len(tv_above_strings) == len(expected_tv_above_strings)
+
+        # now define a custom keypoint cast from the mixer constructed to include tv in the set
+        mixer_to_tv = (
+            tv_object.translation - mixer_object.translation
+        ).normalized()
+        mixer_to_tv_object_ids = [
+            hit.object_id
+            for keypoint_raycast_result in object_keypoint_cast(
+                sim, mixer_object, direction=mixer_to_tv
+            )
+            for hit in keypoint_raycast_result.hits
+        ]
+        mixer_to_tv_object_ids = list(set(mixer_to_tv_object_ids))
+        assert tv_object.object_id in mixer_to_tv_object_ids

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -17,6 +17,8 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     get_ao_link_id_map,
     get_obj_from_handle,
     get_obj_from_id,
+    get_object_regions,
+    object_in_region,
     object_keypoint_cast,
     snap_down,
     within,
@@ -350,3 +352,104 @@ def test_keypoint_cast_prepositions():
         )
         assert len(canister_within) == 1
         assert basket_object.object_id in canister_within
+
+
+@pytest.mark.skipif(
+    not osp.exists("data/hab3_bench_assets/"),
+    reason="Requires HSSD benchmark mini dataset.",
+)
+def test_region_containment_utils():
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/hab3_bench_assets/hab3-hssd/hab3-hssd.scene_dataset_config.json"
+    sim_settings["scene"] = "103997919_171031233"
+    hab_cfg = make_cfg(sim_settings)
+
+    with Simulator(hab_cfg) as sim:
+        assert len(sim.semantic_scene.regions) > 0
+
+        desk_object = get_obj_from_handle(
+            sim, "41d16010bfc200eb4d71aea6edaf6ad4bc548105_:0000"
+        )
+        desk_object.motion_type = MotionType.DYNAMIC
+
+        living_room_region_index = 0
+        bedroom_region_index = 3
+
+        living_room_region = sim.semantic_scene.regions[
+            living_room_region_index
+        ]
+        bedroom_region = sim.semantic_scene.regions[bedroom_region_index]
+
+        # the desk starts in completely in the living room
+        in_livingroom, ratio = object_in_region(
+            sim, desk_object, living_room_region
+        )
+
+        assert in_livingroom
+        assert (
+            ratio > 0
+        )  # won't be 1.0 because some AABB corners are inside the floor or walls
+
+        # move the desk most of the way into the bedroom
+        desk_object.translation = mn.Vector3(-3.77824, 0.405816, -2.30807)
+
+        # first validate standard region containment
+        in_livingroom, livingroom_ratio = object_in_region(
+            sim, desk_object, living_room_region
+        )
+        in_bedroomroom, bedroom_ratio = object_in_region(
+            sim, desk_object, bedroom_region
+        )
+
+        assert in_livingroom
+        assert in_bedroomroom
+        assert (
+            abs(livingroom_ratio + bedroom_ratio - 1.0) < 1e-5
+        )  # eps for float error
+        assert livingroom_ratio > 0
+        assert bedroom_ratio > 0
+        assert bedroom_ratio > livingroom_ratio
+
+        # compute aggregate containment in all scene regions
+        all_regions_containment = get_object_regions(sim, desk_object)
+
+        # this list should be sorted, so bedroom is first
+        assert all_regions_containment[0][0] == bedroom_region_index
+        assert (
+            abs(all_regions_containment[0][1] - bedroom_ratio) < 1e-5
+        )  # eps for float error
+        assert all_regions_containment[1][0] == living_room_region_index
+        assert (
+            abs(all_regions_containment[1][1] - livingroom_ratio) < 1e-5
+        )  # eps for float error
+        assert len(all_regions_containment) == 2
+
+        # "center_only" excludes the livingroom
+        in_livingroom, livingroom_ratio = object_in_region(
+            sim, desk_object, living_room_region, center_only=True
+        )
+        in_bedroomroom, bedroom_ratio = object_in_region(
+            sim, desk_object, bedroom_region, center_only=True
+        )
+
+        assert not in_livingroom
+        assert in_bedroomroom
+        assert livingroom_ratio == 0
+        assert bedroom_ratio == 1.0
+
+        # "containment_threshold" greater than half excludes the livingroom
+        in_livingroom, livingroom_ratio = object_in_region(
+            sim, desk_object, living_room_region, containment_threshold=0.51
+        )
+        in_bedroomroom, bedroom_ratio = object_in_region(
+            sim, desk_object, bedroom_region, containment_threshold=0.51
+        )
+
+        assert not in_livingroom
+        assert in_bedroomroom
+        assert livingroom_ratio + bedroom_ratio == 1.0
+        assert livingroom_ratio > 0
+        assert livingroom_ratio < 0.51
+        assert bedroom_ratio > 0.51


### PR DESCRIPTION
## Motivation and Context

Based on #1770.

This PR introduces utils for querying region containment of objects via point containment checks on bounding box global keypoints.

Supporting utils enable bounding box and keypoint extraction for ArticulatedObjects and ArticulatedLinks.

## How Has This Been Tested

Added pytest using hab3_benchmark HSSD scenes.
Added region annotations to one benchmark scene and updated CI to gather those assets.

TODO: follow-up should add some unit tests for bounding box and keypoint utils tested indirectly here through the query API.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
