### PR TITLE
--Address regression and missing stage_id checks

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_generator.py
@@ -886,8 +886,8 @@ class RearrangeEpisodeGenerator:
             "rgb": {
                 "sensor_type": habitat_sim.SensorType.COLOR,
                 "resolution": camera_resolution,
-                "position": [0, 0, 0],
-                "orientation": [0, 0, 0],
+                "position": [0.0, 0.0, 0.0],
+                "orientation": [0.0, 0.0, 0.0],
             }
         }
 

--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -133,7 +133,7 @@ class DebugVisualizer:
 
         debug_sensor_spec = habitat_sim.CameraSensorSpec()
         debug_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
-        debug_sensor_spec.position = [0, 0, 0]
+        debug_sensor_spec.position = [0.0, 0.0, 0.0]
         debug_sensor_spec.resolution = [resolution[0], resolution[1]]
         debug_sensor_spec.uuid = self.sensor_uuid
 

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -253,7 +253,7 @@ def test_keypoint_cast_prepositions():
         )
         mixer_above = above(sim, mixer_object)
         mixer_above_strings = [
-            all_objects[obj_id] for obj_id in mixer_above if obj_id >= 0
+            all_objects[obj_id] for obj_id in mixer_above if obj_id > stage_id
         ]
         expected_mixer_above_strings = [
             "kitchen_counter_:0000",
@@ -268,7 +268,7 @@ def test_keypoint_cast_prepositions():
         tv_object = get_obj_from_handle(sim, "frl_apartment_tv_screen_:0000")
         tv_above = above(sim, tv_object)
         tv_above_strings = [
-            all_objects[obj_id] for obj_id in tv_above if obj_id >= 0
+            all_objects[obj_id] for obj_id in tv_above if obj_id > stage_id
         ]
         expected_tv_above_strings = [
             "frl_apartment_tvstand_:0000",


### PR DESCRIPTION
## Motivation and Context
This PR addresses a regression [introduced in this PR](https://github.com/facebookresearch/habitat-lab/pull/1814) where sensorspec position and orientation values were changed to be integers, but are required to be floats for future refactor to magnum vector backend [in this sim pr](https://github.com/facebookresearch/habitat-sim/pull/2316).

This PR also addresses a missed stage ID comparison refactor from a magic number to the habitat_sim.stage_id value.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Changes tested locally.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
