### PR TITLE
[WIP] ArticulatedLink marker_set utils for handle annotation

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -947,6 +947,24 @@ def write_ao_marker_sets(
     )
 
 
+def write_ao_marker_set_to_template(
+    sim: habitat_sim.Simulator,
+    objectA: habitat_sim.physics.ManagedArticulatedObject,
+) -> None:
+    """
+    Writes the ao's current marker set to its creation attributes template.
+    """
+
+    ca = objectA.creation_attributes
+    template_user_config = ca.get_user_config()
+    object_user_config = objectA.user_attributes
+    if "marker_sets" in object_user_config.get_subconfig_keys():
+        template_user_config.save_subconfig(
+            "marker_sets", object_user_config.get_subconfig("marker_sets")
+        )
+    sim.metadata_mediator.ao_template_manager.save_template_to_file(ca, True)
+
+
 def parse_scene_marker_sets(
     sim: habitat_sim.Simulator,
 ) -> Dict[str, Dict[int, Dict[str, List[mn.Vector3]]]]:


### PR DESCRIPTION
## Motivation and Context

We want to annotate handles for opening and closing ArticulatedLinks such as doors and drawers. Instead of relying on mesh parts and semantics, which could be challenging to add to existing assets, we instead use named sets of 3D marker points in the local space of each link. 

This PR adds a set of utilities for parsing/writing marker sets from/to ManagedArticulatedObject instance user metadata config structs.

Example expected JSON format of marker set with an ao_config.json:
```
"user_defined": {
  "marker_sets": {
    "dresser0003_drawer05": {
      "handle_0": {
        "1": [-0.172053,-0.0160375,0.0046036],
        "0": [-0.2300691,-0.0164337,0.0020326]
      },
      "handle_1": {
        "1": [0.2261741,-0.0204898,0.0083177],
        "0": [0.1662454,-0.0141804,0.0046603]
      }
      ...
```

TODO: 
- writing configs back to file requires additional habitat-sim bindings WIP
- include debug drawing method for marker sets
- consider moving to new module instead of sim_utils

## How Has This Been Tested

TODO: pytest once we lock down the API

This functionality is tested locally with a viewer tool to author marker annotations.

Example annotation of object `47c28745703eaa9b3bfe792ad97a4de3467d3bc3` from prototype scene `102817140`.
![image](https://github.com/facebookresearch/habitat-lab/assets/1445143/74cb94e5-84cb-4250-9fd8-452706eebe0a)


## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
