### PR TITLE
[HITL] Gui-controlled spot and local multi-user support

### DIFF
--- a/examples/hitl/basic_viewer/basic_viewer.py
+++ b/examples/hitl/basic_viewer/basic_viewer.py
@@ -200,9 +200,9 @@ class AppStateBasicViewer(AppState):
     version_base=None, config_path="config", config_name="basic_viewer"
 )
 def main(config):
-    if config.habitat_hitl.gui_controlled_agent.agent_index is not None:
+    if len(config.habitat_hitl.gui_controlled_agents) > 0:
         raise ValueError(
-            "habitat_hitl.gui_controlled_agent.agent_index is not supported for basic_viewer"
+            "habitat_hitl.gui_controlled_agents is not supported for basic_viewer"
         )
 
     hitl_main(

--- a/examples/hitl/pick_throw_vr/config/pick_throw_vr.yaml
+++ b/examples/hitl/pick_throw_vr/config/pick_throw_vr.yaml
@@ -21,9 +21,10 @@ habitat_hitl:
     title: "Pick_throw_vr"
     width: 1300
     height: 1000
-  gui_controlled_agent:
-    agent_index: 1
-    ang_speed: 15
+  gui_controlled_agents:
+    - agent_index: 1
+      lin_speed: 10.0
+      ang_speed: 15
   networking:
     client_sync:
       # The client controls its own camera.

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -51,7 +51,11 @@ class AppStatePickThrowVr(AppState):
 
     def __init__(self, app_service: AppService):
         self._app_service = app_service
-        self._gui_agent_ctrl: Any = self._app_service.gui_agent_controller
+        self._gui_agent_ctrl: Any = (
+            self._app_service.gui_agent_controllers[0]
+            if len(self._app_service.gui_agent_controllers)
+            else None
+        )
         self._can_grasp_place_threshold = (
             self._app_service.hitl_config.can_grasp_place_threshold
         )

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -85,8 +85,6 @@ class AppStatePickThrowVr(AppState):
             self._app_service, self._gui_agent_ctrl
         )
 
-        self._gui_agent_ctrl.line_renderer = app_service.line_render
-
         self._is_remote_active_toggle: bool = False
         self._count_tsteps_stop: int = 0
         self._has_grasp_preview: bool = False

--- a/examples/hitl/rearrange/config/hitl_rearrange.yaml
+++ b/examples/hitl/rearrange/config/hitl_rearrange.yaml
@@ -29,9 +29,10 @@ habitat_hitl:
     title: "Rearrange"
     width: 1300
     height: 1000
-  gui_controlled_agent:
-    agent_index: 1
-    ang_speed: 300
+  gui_controlled_agents:
+    - agent_index: 1
+      lin_speed: 10.0
+      ang_speed: 300
   data_collection:
     save_filepath_base: "my_session"
     save_gfx_replay_keyframes: True

--- a/examples/hitl/rearrange/rearrange.py
+++ b/examples/hitl/rearrange/rearrange.py
@@ -46,7 +46,11 @@ class AppStateRearrange(AppState):
         app_service: AppService,
     ):
         self._app_service = app_service
-        self._gui_agent_ctrl: Any = self._app_service.gui_agent_controller
+        self._gui_agent_ctrl: Any = (
+            self._app_service.gui_agent_controllers[0]
+            if len(self._app_service.gui_agent_controllers)
+            else None
+        )
 
         # cache items from config; config is expensive to access at runtime
         config = self._app_service.config

--- a/examples/hitl/rearrange_v2/config/experiment/gui_controlled_humanoid_and_spot.yaml
+++ b/examples/hitl/rearrange_v2/config/experiment/gui_controlled_humanoid_and_spot.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+
+habitat_hitl:
+  gui_controlled_agents:
+    - agent_index: 1
+      lin_speed: 10.0
+      ang_speed: 300
+    - agent_index: 0
+  hide_humanoid_in_gui: False

--- a/examples/hitl/rearrange_v2/config/experiment/gui_controlled_spot_only.yaml
+++ b/examples/hitl/rearrange_v2/config/experiment/gui_controlled_spot_only.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+habitat_hitl:
+  gui_controlled_agents:
+    - agent_index: 0
+  hide_humanoid_in_gui: False

--- a/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
+++ b/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
@@ -22,6 +22,24 @@ habitat:
   dataset:
     data_path: examples/hitl/rearrange_v2/app_data/demo.json.gz
 
+  gym:
+    obs_keys:
+      # - agent_0_articulated_agent_arm_depth
+      # - agent_0_spot_head_stereo_depth_sensor
+      # - agent_0_humanoid_detector_sensor
+      - agent_1_head_depth
+      - agent_1_relative_resting_position
+      - agent_1_obj_start_sensor
+      - agent_1_obj_goal_sensor
+      - agent_1_obj_start_gps_compass
+      - agent_1_obj_goal_gps_compass
+      - agent_1_is_holding
+      - agent_1_ee_pos
+      - agent_1_localization_sensor
+      - agent_1_has_finished_oracle_nav
+      - agent_1_other_agent_gps
+
+
 habitat_baselines:
   # todo: document these choices
   eval:

--- a/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
+++ b/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
@@ -37,9 +37,10 @@ habitat_hitl:
     title: "Rearrange"
     width: 1300
     height: 1000
-  gui_controlled_agent:
-    agent_index: 1
-    ang_speed: 300
+  gui_controlled_agents:
+    - agent_index: 1
+      lin_speed: 10.0
+      ang_speed: 300
   hide_humanoid_in_gui: True
   camera:
     first_person_mode: True

--- a/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
+++ b/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
@@ -22,22 +22,6 @@ habitat:
   dataset:
     data_path: examples/hitl/rearrange_v2/app_data/demo.json.gz
 
-  gym:
-    obs_keys:
-      # - agent_0_articulated_agent_arm_depth
-      # - agent_0_spot_head_stereo_depth_sensor
-      # - agent_0_humanoid_detector_sensor
-      - agent_1_head_depth
-      - agent_1_relative_resting_position
-      - agent_1_obj_start_sensor
-      - agent_1_obj_goal_sensor
-      - agent_1_obj_start_gps_compass
-      - agent_1_obj_goal_gps_compass
-      - agent_1_is_holding
-      - agent_1_ee_pos
-      - agent_1_localization_sensor
-      - agent_1_has_finished_oracle_nav
-      - agent_1_other_agent_gps
 
 
 habitat_baselines:

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -26,7 +26,6 @@ from habitat_hitl.environment.controllers.gui_controller import (
     GuiHumanoidController,
     GuiRobotController,
 )
-from habitat_hitl.environment.gui_navigation_helper import GuiNavigationHelper
 from habitat_hitl.environment.gui_pick_helper import GuiPickHelper
 from habitat_hitl.environment.gui_placement_helper import GuiPlacementHelper
 from habitat_hitl.environment.hablab_utils import get_agent_art_obj_transform
@@ -43,7 +42,8 @@ class AppStateRearrangeV2(AppState):
 
     def __init__(self, app_service):
         self._app_service = app_service
-        self._gui_agent_ctrl = self._app_service.gui_agent_controller
+        self._gui_agent_controllers = self._app_service.gui_agent_controllers
+        self._num_users = len(self._gui_agent_controllers)
         self._can_grasp_place_threshold = (
             self._app_service.hitl_config.can_grasp_place_threshold
         )
@@ -53,6 +53,7 @@ class AppStateRearrangeV2(AppState):
         self._opened_ao_set: Set = set()
 
         self._cam_transform = None
+        self._camera_user_index = 0
         self._held_obj_id = None
         self._recent_reach_pos = None
         self._paused = False
@@ -63,12 +64,8 @@ class AppStateRearrangeV2(AppState):
             self._app_service.gui_input,
         )
 
-        self._nav_helper = GuiNavigationHelper(
-            self._app_service, self.get_gui_controlled_agent_index()
-        )
         self._pick_helper = GuiPickHelper(
             self._app_service,
-            self.get_gui_controlled_agent_index(),
         )
         self._placement_helper = GuiPlacementHelper(self._app_service)
         self._client_helper = None
@@ -83,6 +80,21 @@ class AppStateRearrangeV2(AppState):
     @staticmethod
     def get_sim_utilities() -> Any:
         return sim_utilities
+
+    def _remap_key(self, user_index, key):
+        key_remap = {
+            GuiInput.KeyNS.SPACE: GuiInput.KeyNS.N,
+            GuiInput.KeyNS.Z: GuiInput.KeyNS.X,
+        }
+        if user_index == 1:
+            assert key in key_remap
+            key = key_remap[key]
+        return key
+
+    def _get_user_key_down(self, user_index, key):
+        return self._app_service.gui_input.get_key_down(
+            self._remap_key(user_index, key)
+        )
 
     def _open_close_ao(self, ao_handle: str):
         if not ENABLE_ARTICULATED_OPEN_CLOSE:
@@ -105,16 +117,12 @@ class AppStateRearrangeV2(AppState):
         else:
             self._opened_ao_set.add(ao_handle)
 
-    def _find_reachable_ao(self, player: GuiHumanoidController) -> str:
+    def _find_reachable_ao(self, player_pos) -> str:
         """Returns the handle of the nearest reachable articulated object. Returns None if none is found."""
         if not ENABLE_ARTICULATED_OPEN_CLOSE:
             return None
 
         max_distance = 2.0  # TODO: Const
-        player_root_node = (
-            player.get_articulated_agent().sim_obj.get_link_scene_node(-1)
-        )
-        player_pos = player_root_node.absolute_translation
         player_pos_xz = mn.Vector3(player_pos.x, 0.0, player_pos.z)
         min_dist: float = max_distance
         output: str = None
@@ -159,7 +167,6 @@ class AppStateRearrangeV2(AppState):
 
         self._held_obj_id = None
 
-        self._nav_helper.on_environment_reset()
         self._pick_helper.on_environment_reset()
 
         self._camera_helper.update(self._get_camera_lookat_pos(), dt=0)
@@ -181,12 +188,12 @@ class AppStateRearrangeV2(AppState):
     def get_sim(self):
         return self._app_service.sim
 
-    def _get_gui_agent_translation(self):
+    def _get_gui_agent_translation(self, user_index):
         return get_agent_art_obj_transform(
-            self.get_sim(), self.get_gui_controlled_agent_index()
+            self.get_sim(), self.get_gui_controlled_agent_index(user_index)
         ).translation
 
-    def _update_grasping_and_set_act_hints(self):
+    def _update_grasping_and_set_act_hints(self, user_index):
         drop_pos = None
         grasp_object_id = None
         throw_vel = None
@@ -194,28 +201,25 @@ class AppStateRearrangeV2(AppState):
 
         self._has_grasp_preview = False
 
+        # todo: implement grasping properly for each user. _held_obj_id, _has_grasp_preview, etc. must be tracked per user.
         if self._held_obj_id is not None:
-            if self._app_service.gui_input.get_key_down(GuiInput.KeyNS.SPACE):
+            if self._get_user_key_down(user_index, GuiInput.KeyNS.SPACE):
                 if DO_HUMANOID_GRASP_OBJECTS:
                     # todo: better drop pos
-                    drop_pos = (
-                        self._get_gui_agent_translation()
-                    )  # self._gui_agent_ctrl.get_base_translation()
+                    drop_pos = self._get_gui_agent_translation(
+                        user_index
+                    )  # self._gui_agent_controllers.get_base_translation()
                 else:
                     # GuiPlacementHelper has already placed this object, so nothing to do here
                     pass
                 self._held_obj_id = None
         else:
-            query_pos = (
-                self._get_gui_agent_translation()
-            )  # self._gui_agent_ctrl.get_base_translation()
+            query_pos = self._get_gui_agent_translation(user_index)
             obj_id = self._pick_helper.get_pick_object_near_query_position(
                 query_pos
             )
             if obj_id:
-                if self._app_service.gui_input.get_key_down(
-                    GuiInput.KeyNS.SPACE
-                ):
+                if self._get_user_key_down(user_index, GuiInput.KeyNS.SPACE):
                     if DO_HUMANOID_GRASP_OBJECTS:
                         grasp_object_id = obj_id
                     self._held_obj_id = obj_id
@@ -238,10 +242,11 @@ class AppStateRearrangeV2(AppState):
         #     walk_dir = candidate_walk_dir
         #     distance_multiplier = candidate_distance_multiplier
 
+        gui_agent_controller = self._gui_agent_controllers[user_index]
         assert isinstance(
-            self._gui_agent_ctrl, (GuiHumanoidController, GuiRobotController)
+            gui_agent_controller, (GuiHumanoidController, GuiRobotController)
         )
-        self._gui_agent_ctrl.set_act_hints(
+        gui_agent_controller.set_act_hints(
             walk_dir,
             distance_multiplier,
             grasp_object_id,
@@ -253,15 +258,15 @@ class AppStateRearrangeV2(AppState):
 
         return drop_pos
 
-    def get_gui_controlled_agent_index(self):
-        return self._gui_agent_ctrl._agent_idx
+    def get_gui_controlled_agent_index(self, user_index):
+        return self._gui_agent_controllers[user_index]._agent_idx
 
     def _get_controls_text(self):
         def get_grasp_release_controls_text():
             if self._held_obj_id is not None:
-                return "Spacebar: put down\n"
+                return "Space/N: put down\n"
             elif self._has_grasp_preview:
-                return "Spacebar: pick up\n"
+                return "Space/N: pick up\n"
             else:
                 return ""
 
@@ -275,10 +280,12 @@ class AppStateRearrangeV2(AppState):
             controls_str += "P: pause\n"
             controls_str += "I, K: look up, down\n"
             controls_str += "A, D: turn\n"
-            controls_str += "W, S: walk\n"
+            controls_str += "W/F, S/V: walk\n"
             if ENABLE_ARTICULATED_OPEN_CLOSE:
-                controls_str += "Z: open/close receptacle\n"
+                controls_str += "Z/X: open/close receptacle\n"
             controls_str += get_grasp_release_controls_text()
+            if self._num_users > 1 and self._held_obj_id is None:
+                controls_str += "T: toggle camera user\n"
 
         return controls_str
 
@@ -313,7 +320,8 @@ class AppStateRearrangeV2(AppState):
 
     def _get_camera_lookat_pos(self):
         agent_root = get_agent_art_obj_transform(
-            self.get_sim(), self.get_gui_controlled_agent_index()
+            self.get_sim(),
+            self.get_gui_controlled_agent_index(self._camera_user_index),
         )
         lookat_y_offset = mn.Vector3(0, 1, 0)
         lookat = agent_root.translation + lookat_y_offset
@@ -398,23 +406,35 @@ class AppStateRearrangeV2(AppState):
 
         self._check_change_episode()
 
-        reachable_ao_handle = self._find_reachable_ao(
-            self._app_service.gui_agent_controller
-        )
-        if reachable_ao_handle is not None:
-            self._highlight_ao(reachable_ao_handle)
-            if self._app_service.gui_input.get_key_down(GuiInput.KeyNS.Z):
-                self._open_close_ao(reachable_ao_handle)
+        for user_index in range(self._num_users):
+            reachable_ao_handle = self._find_reachable_ao(
+                self._get_gui_agent_translation(user_index)
+            )
+            if reachable_ao_handle is not None:
+                self._highlight_ao(reachable_ao_handle)
+                if self._get_user_key_down(user_index, GuiInput.KeyNS.Z):
+                    self._open_close_ao(reachable_ao_handle)
 
         if not self._paused:
-            self._update_grasping_and_set_act_hints()
+            for user_index in range(self._num_users):
+                self._update_grasping_and_set_act_hints(user_index)
             self._app_service.compute_action_and_step_env()
         else:
             # temp hack: manually add a keyframe while paused
             self.get_sim().gfx_replay_manager.save_keyframe()
 
+        # todo: visualize objects properly for each user (this requires a separate debug_line_render per user!), or find a reasonable debug line visualization that can be shared between both users every frame.
         if self._held_obj_id is None:
             self._pick_helper.viz_objects()
+
+        if (
+            self._num_users > 1
+            and self._held_obj_id is None
+            and self._app_service.gui_input.get_key_down(GuiInput.KeyNS.T)
+        ):
+            self._camera_user_index = (
+                self._camera_user_index + 1
+            ) % self._num_users
 
         self._camera_helper.update(self._get_camera_lookat_pos(), dt)
 

--- a/habitat-hitl/habitat_hitl/_internal/config_helper.py
+++ b/habitat-hitl/habitat_hitl/_internal/config_helper.py
@@ -42,17 +42,19 @@ def update_config(
             hitl_config.debug_images.append(agent_sensor_name)
             gym_obs_keys.append(agent_sensor_name)
 
-        gui_controlled_agent_index = (
-            config.habitat_hitl.gui_controlled_agent.agent_index
-        )
-        if gui_controlled_agent_index is not None:
+        for (
+            gui_controlled_agent_config
+        ) in config.habitat_hitl.gui_controlled_agents:
+            gui_controlled_agent_index = (
+                gui_controlled_agent_config.agent_index
+            )
             # make sure gui_controlled_agent_index is valid
             if not (
                 gui_controlled_agent_index >= 0
                 and gui_controlled_agent_index < len(sim_config.agents)
             ):
                 print(
-                    f"habitat_hitl.gui_controlled_agent.agent_index ({gui_controlled_agent_index}) "
+                    f"habitat_hitl.gui_controlled_agents[i].agent_index ({gui_controlled_agent_index}) "
                     f"must be >= 0 and < number of agents ({len(sim_config.agents)})"
                 )
                 exit()
@@ -63,11 +65,10 @@ def update_config(
                 gui_agent_key
             ].articulated_agent_type
             if agent_type != "KinematicHumanoid" and agent_type != "SpotRobot":
-                print(
+                raise ValueError(
                     f"Selected agent for GUI control is of type {sim_config.agents[gui_agent_key].articulated_agent_type}, "
                     "but only KinematicHumanoid and SpotRobot are supported at the moment."
                 )
-                exit()
 
             # avoid camera sensors for GUI-controlled agents
             gui_controlled_agent_config = get_agent_config(
@@ -99,7 +100,11 @@ def update_config(
                     task_config.measurements.pop(measurement_name)
 
             # todo: decide whether to fix up config here versus validate config
-            sim_sensor_names = ["head_depth", "head_rgb"]
+            sim_sensor_names = [
+                "head_depth",
+                "head_rgb",
+                "articulated_agent_arm_depth",
+            ]
             for sensor_name in sim_sensor_names + lab_sensor_names:
                 sensor_name = (
                     sensor_name

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -180,6 +180,8 @@ class HitlDriver(AppDriver):
             if self.ctrl_helper
             else None
         )
+        if gui_agent_controller:
+            gui_agent_controller.line_render = line_render
 
         self._app_service = AppService(
             config=config,

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -112,10 +112,18 @@ class HitlDriver(AppDriver):
             self.gym_habitat_env.unwrapped.habitat_env
         )
 
-        if self._hitl_config.gui_controlled_agent.agent_index is not None:
+        # If all agents are gui-controlled, we should have no camera sensors and thus no renderer.
+        if len(config.habitat_hitl.gui_controlled_agents) == len(
+            config.habitat.simulator.agents
+        ):
+            assert self.get_sim().renderer is None
+
+        for (
+            gui_controlled_agent_config
+        ) in self._hitl_config.gui_controlled_agents:
             sim_config = config.habitat.simulator
             gui_agent_key = sim_config.agents_order[
-                self._hitl_config.gui_controlled_agent.agent_index
+                gui_controlled_agent_config.agent_index
             ]
             oracle_nav_sensor_key = f"{gui_agent_key}_has_finished_oracle_nav"
             if (

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -175,13 +175,13 @@ class HitlDriver(AppDriver):
         if self.network_server_enabled:
             self._client_message_manager = ClientMessageManager()
 
-        gui_agent_controller: Any = (
-            self.ctrl_helper.get_gui_agent_controller()
+        gui_agent_controllers: Any = (
+            self.ctrl_helper.get_gui_agent_controllers()
             if self.ctrl_helper
-            else None
+            else []
         )
-        if gui_agent_controller:
-            gui_agent_controller.line_render = line_render
+        for controller in gui_agent_controllers:
+            controller.line_render = line_render
 
         self._app_service = AppService(
             config=config,
@@ -200,7 +200,7 @@ class HitlDriver(AppDriver):
             set_cursor_style=self._set_cursor_style,
             episode_helper=self._episode_helper,
             client_message_manager=self._client_message_manager,
-            gui_agent_controller=gui_agent_controller,
+            gui_agent_controllers=gui_agent_controllers,
         )
 
         self._app_state: AppState = None

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable, List
 
 from habitat import Env
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
@@ -41,7 +41,7 @@ class AppService:
         set_cursor_style: Callable,
         episode_helper: EpisodeHelper,
         client_message_manager: ClientMessageManager,
-        gui_agent_controller: Optional[GuiController],
+        gui_agent_controllers: List[GuiController],
     ):
         self._config = config
         self._hitl_config = hitl_config
@@ -59,7 +59,7 @@ class AppService:
         self._set_cursor_style = set_cursor_style
         self._episode_helper = episode_helper
         self._client_message_manager = client_message_manager
-        self._gui_agent_controller = gui_agent_controller
+        self._gui_agent_controllers = gui_agent_controllers
 
     @property
     def config(self):
@@ -126,5 +126,5 @@ class AppService:
         return self._client_message_manager
 
     @property
-    def gui_agent_controller(self) -> Optional[GuiController]:
-        return self._gui_agent_controller
+    def gui_agent_controllers(self) -> List[GuiController]:
+        return self._gui_agent_controllers

--- a/habitat-hitl/habitat_hitl/app_states/app_state_tutorial.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_state_tutorial.py
@@ -16,7 +16,11 @@ class AppStateTutorial(AppState):
         app_service,
     ):
         self._app_service = app_service
-        self._gui_agent_ctrl = self._app_service.gui_agent_controller
+        self._gui_agent_ctrl = (
+            self._app_service.gui_agent_controllers[0]
+            if len(self._app_service.gui_agent_controllers)
+            else None
+        )
         self._cam_transform = None
 
     def get_sim(self):

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -98,9 +98,9 @@ habitat_hitl:
   gui_controlled_agent:
     # GUI-controlled agent index (must be None or >= 0 and < number of agents). Defaults to None, indicating that all the agents are policy-controlled.
     agent_index: ~
-    # linear speed
+    # linear speed. Applies only to KinematicHumanoid. For SpotRobot, see habitat.task.actions.agent_0_base_velocity.ang_speed.
     lin_speed: 10.0
-    # angular speed
+    # angular speed. Applies only to KinematicHumanoid. For SpotRobot, see habitat.task.actions.agent_0_base_velocity.lin_speed.
     ang_speed: 10.0
 
   data_collection:

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -95,13 +95,14 @@ habitat_hitl:
     max_look_up_angle: 15.0
     min_look_down_angle: -60.0
 
-  gui_controlled_agent:
-    # GUI-controlled agent index (must be None or >= 0 and < number of agents). Defaults to None, indicating that all the agents are policy-controlled.
-    agent_index: ~
+  # list of gui-controlled agents. Each list item should be a dict following the commented-out reference format below. Beware some apps only support one (or zero!) gui-controlled agent. For each Habitat env agent *without* a corresponding entry here, it will be policy-controlled.
+  gui_controlled_agents: []
+    # agent index corresponding to a Habitat env agent
+    # - agent_index: 0
     # linear speed. Applies only to KinematicHumanoid. For SpotRobot, see habitat.task.actions.agent_0_base_velocity.ang_speed.
-    lin_speed: 10.0
+    #   lin_speed: 10.0
     # angular speed. Applies only to KinematicHumanoid. For SpotRobot, see habitat.task.actions.agent_0_base_velocity.lin_speed.
-    ang_speed: 10.0
+    #   ang_speed: 10.0
 
   data_collection:
     # Filepath base used for saving various session data files, e.g. `my_output/my_session`. Specify a full path including basename, but not an extension.

--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -8,6 +8,7 @@ import os
 
 import magnum as mn
 
+from habitat.config.default import patch_config
 from habitat_hitl._internal.config_helper import update_config
 from habitat_hitl._internal.hitl_driver import HitlDriver
 from habitat_hitl._internal.networking.average_rate_tracker import (
@@ -51,6 +52,8 @@ def hitl_main(app_config, create_app_state_lambda=None):
             "HITL apps expect 'data/' directory to exist. "
             "Either run from habitat-lab directory or symlink data/ folder to your HITL app working directory"
         )
+
+    app_config = patch_config(app_config)
 
     hitl_config = omegaconf_to_object(app_config.habitat_hitl)
 

--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -132,15 +132,6 @@ def hitl_headed_main(hitl_config, app_config, create_app_state_lambda):
         create_app_state_lambda,
     )
 
-    # sanity check if there are no agents with camera sensors
-    # todo: fix this logic to handle multiple gui-controlled agents
-    if (
-        len(app_config.habitat.simulator.agents) == 1
-        and app_config.habitat_hitl.gui_controlled_agent.agent_index
-        is not None
-    ):
-        assert driver.get_sim().renderer is None
-
     gui_app_wrapper.set_driver_and_renderer(driver, app_renderer)
 
     gui_app_wrapper.exec()
@@ -246,13 +237,6 @@ def hitl_headless_main(hitl_config, config, create_app_state_lambda=None):
         HeadlessTextDrawer(),
         create_app_state_lambda,
     )
-
-    # sanity check if there are no agents with camera sensors
-    if (
-        len(config.habitat.simulator.agents) == 1
-        and config.habitat_hitl.gui_controlled_agent.agent_index is not None
-    ):
-        assert driver.get_sim().renderer is None
 
     _headless_app_loop(hitl_config, driver)
 

--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -133,6 +133,7 @@ def hitl_headed_main(hitl_config, app_config, create_app_state_lambda):
     )
 
     # sanity check if there are no agents with camera sensors
+    # todo: fix this logic to handle multiple gui-controlled agents
     if (
         len(app_config.habitat.simulator.agents) == 1
         and app_config.habitat_hitl.gui_controlled_agent.agent_index

--- a/habitat-hitl/habitat_hitl/environment/avatar_switcher.py
+++ b/habitat-hitl/habitat_hitl/environment/avatar_switcher.py
@@ -157,9 +157,14 @@ class AvatarSwitcher:
         humanoid_controller = HumanoidRearrangeController(
             walk_pose_path=model[1]
         )
+        # todo: support for multiple gui-controlled agents here
+        assert len(self._app_service.hitl_config.gui_controlled_agents) == 1
+        gui_controlled_agent_config = (
+            self._app_service.hitl_config.gui_controlled_agents[0]
+        )
         humanoid_controller.set_framerate_for_linspeed(
-            self._app_service.hitl_config.gui_controlled_agent.lin_speed,
-            self._app_service.hitl_config.gui_controlled_agent.ang_speed,
+            gui_controlled_agent_config.lin_speed,
+            gui_controlled_agent_config.ang_speed,
             sim.ctrl_freq,
         )
 

--- a/habitat-hitl/habitat_hitl/environment/controllers/controller_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/controllers/controller_helper.py
@@ -129,9 +129,7 @@ class ControllerHelper:
                         assert len(action_space.shape) == 1
                         num_actions = action_space.shape[0]
 
-                        articulated_agent = self._env._sim.agents_mgr[
-                            agent_index
-                        ].articulated_agent
+                        articulated_agent = self._env._sim.agents_mgr[agent_index].articulated_agent  # type: ignore[attr-defined]
 
                         # sloppy: derive turn scale. This is the change in yaw (in radians) corresponding to a base ang vel action of 1.0. See also Habitat-lab BaseVelAction.
                         turn_scale = (

--- a/habitat-hitl/habitat_hitl/environment/controllers/controller_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/controllers/controller_helper.py
@@ -4,13 +4,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List
 
 import numpy as np
 
+import habitat.gym.gym_wrapper as gym_wrapper
+from habitat_baselines.rl.hrl.utils import find_action_range
 from habitat_hitl.environment.controllers.baselines_controller import (
     MultiAgentBaselinesController,
     SingleAgentBaselinesController,
+    clean_dict,
 )
 from habitat_hitl.environment.controllers.controller_abc import Controller
 from habitat_hitl.environment.controllers.gui_controller import (
@@ -38,14 +41,17 @@ class ControllerHelper:
     ):
         self._gym_habitat_env: GymHabitatEnv = gym_habitat_env
         self._env: habitat.Env = gym_habitat_env.unwrapped.habitat_env
-        self._gui_controlled_agent_index = (
-            config.habitat_hitl.gui_controlled_agent.agent_index
-        )
+        # todo: update habitat_hitl config to support list of gui-controlled agent indices
+        self._gui_controlled_agent_indices = [
+            1,
+            0,
+        ]  # temp # config.habitat_hitl.gui_controlled_agent.agent_index
 
         self.n_agents: int = len(self._env._sim.agents_mgr)  # type: ignore[attr-defined]
-        self.n_user_controlled_agents: int = (
-            0 if self._gui_controlled_agent_index is None else 1
+        self.n_user_controlled_agents: int = len(
+            self._gui_controlled_agent_indices
         )
+        assert self.n_user_controlled_agents <= self.n_agents
         self.n_policy_controlled_agents: int = (
             self.n_agents - self.n_user_controlled_agents
         )
@@ -77,52 +83,97 @@ class ControllerHelper:
                     )
                 )
         else:
-            # one agent is gui controlled and the rest (if any) are policy controlled
-            agent_name: str = self._env.sim.habitat_config.agents_order[
-                self._gui_controlled_agent_index
-            ]
-            articulated_agent_type: str = self._env.sim.habitat_config.agents[
-                agent_name
-            ].articulated_agent_type
-
-            gui_agent_controller: Controller
-            if articulated_agent_type == "KinematicHumanoid":
-                gui_agent_controller = GuiHumanoidController(
-                    agent_idx=self._gui_controlled_agent_index,
-                    is_multi_agent=is_multi_agent,
-                    gui_input=gui_input,
-                    env=self._env,
-                    walk_pose_path=hitl_config.walk_pose_path,
-                    lin_speed=hitl_config.gui_controlled_agent.lin_speed,
-                    ang_speed=hitl_config.gui_controlled_agent.ang_speed,
-                    recorder=recorder.get_nested_recorder("gui_humanoid"),
-                )
-            else:
-                gui_agent_controller = GuiRobotController(
-                    agent_idx=self._gui_controlled_agent_index,
-                    is_multi_agent=is_multi_agent,
-                    gui_input=gui_input,
-                )
-            self.controllers.append(gui_agent_controller)
-
-            if is_multi_agent:
-                self.controllers.append(
-                    SingleAgentBaselinesController(
-                        0 if self._gui_controlled_agent_index == 1 else 1,
-                        is_multi_agent,
-                        config,
-                        self._gym_habitat_env,
+            # some agents are gui controlled and the rest (if any) are policy controlled
+            for agent_index in range(
+                len(self._env.sim.habitat_config.agents_order)
+            ):
+                if agent_index in self._gui_controlled_agent_indices:
+                    agent_name: str = (
+                        self._env.sim.habitat_config.agents_order[agent_index]
                     )
-                )
+                    articulated_agent_type: str = (
+                        self._env.sim.habitat_config.agents[
+                            agent_name
+                        ].articulated_agent_type
+                    )
 
-    def get_gui_agent_controller(self) -> Optional[Controller]:
-        if self._gui_controlled_agent_index is None:
-            return None
+                    gui_agent_controller: Controller
+                    if articulated_agent_type == "KinematicHumanoid":
+                        gui_agent_controller = GuiHumanoidController(
+                            agent_idx=agent_index,
+                            is_multi_agent=is_multi_agent,
+                            gui_input=gui_input,
+                            env=self._env,
+                            walk_pose_path=hitl_config.walk_pose_path,
+                            lin_speed=hitl_config.gui_controlled_agent.lin_speed,
+                            ang_speed=hitl_config.gui_controlled_agent.ang_speed,
+                            recorder=recorder.get_nested_recorder(
+                                "gui_humanoid"
+                            ),
+                        )
+                    elif articulated_agent_type == "SpotRobot":
+                        agent_k = f"agent_{agent_index}"
+                        original_action_space = clean_dict(
+                            self._gym_habitat_env.original_action_space,
+                            agent_k,
+                        )
+                        action_space = gym_wrapper.create_action_space(
+                            original_action_space
+                        )
 
-        return self.controllers[0]
+                        (
+                            base_vel_action_idx,
+                            base_vel_action_end_idx,
+                        ) = find_action_range(
+                            original_action_space, "_base_velocity"
+                        )
 
-    def get_gui_controlled_agent_index(self) -> Optional[int]:
-        return self._gui_controlled_agent_index
+                        assert len(action_space.shape) == 1
+                        num_actions = action_space.shape[0]
+
+                        articulated_agent = self._env._sim.agents_mgr[
+                            agent_index
+                        ].articulated_agent
+
+                        # sloppy: derive turn scale. This is the change in yaw (in radians) corresponding to a base ang vel action of 1.0. See also Habitat-lab BaseVelAction.
+                        turn_scale = (
+                            config.habitat.simulator.ctrl_freq
+                            / config.habitat.task.actions.agent_0_base_velocity.ang_speed
+                        )
+
+                        gui_agent_controller = GuiRobotController(
+                            agent_idx=agent_index,
+                            is_multi_agent=is_multi_agent,
+                            gui_input=gui_input,
+                            articulated_agent=articulated_agent,
+                            num_actions=num_actions,
+                            base_vel_action_idx=base_vel_action_idx,
+                            num_base_vel_actions=base_vel_action_end_idx
+                            - base_vel_action_idx,
+                            turn_scale=turn_scale,
+                        )
+                    else:
+                        raise ValueError(
+                            f"articulated agent type {articulated_agent_type} not supported"
+                        )
+
+                    self.controllers.append(gui_agent_controller)
+
+                else:
+                    self.controllers.append(
+                        SingleAgentBaselinesController(
+                            agent_index,
+                            is_multi_agent,
+                            config,
+                            self._gym_habitat_env,
+                        )
+                    )
+
+    def get_gui_agent_controllers(self) -> List[Controller]:
+        gui_agent_controllers = []
+        for agent_index in self._gui_controlled_agent_indices:
+            gui_agent_controllers.append(self.controllers[agent_index])
+        return gui_agent_controllers
 
     def update(self, obs):
         actions = []

--- a/habitat-hitl/habitat_hitl/environment/controllers/gui_controller.py
+++ b/habitat-hitl/habitat_hitl/environment/controllers/gui_controller.py
@@ -73,7 +73,9 @@ class GuiRobotController(GuiController):
         self._cam_yaw = cam_yaw
         self._hint_target_dir = target_dir
 
-    def angle_from_sim_obj_foward_dir_to_target_yaw(self, sim_obj, target_yaw):
+    def angle_from_sim_obj_forward_dir_to_target_yaw(
+        self, sim_obj, target_yaw
+    ):
         dir_a = sim_obj.rotation.transform_vector_normalized(
             mn.Vector3(1, 0, 0)
         )
@@ -132,7 +134,7 @@ class GuiRobotController(GuiController):
         gui_input = self._gui_input
 
         # Add 180 degrees due to our camera convention. See camera_helper.py _get_eye_and_lookat. Our camera yaw is used to offset the camera eye pos away from the lookat pos, so the resulting look direction yaw (from eye to lookat) is actually 180 degrees away from this yaw.
-        turn_angle = self.angle_from_sim_obj_foward_dir_to_target_yaw(
+        turn_angle = self.angle_from_sim_obj_forward_dir_to_target_yaw(
             self._articulated_agent.sim_obj,
             self._cam_yaw + float(mn.Rad(mn.Deg(180))),
         )

--- a/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
@@ -26,7 +26,7 @@ class GuiPickHelper:
         self._rom = self._get_sim().get_rigid_object_manager()
         self._obj_ids = self._get_sim()._scene_obj_ids
         self._dist_to_highlight_obj = DIST_HIGHLIGHT
-        self._pick_candidate_indexes = []
+        self._pick_candidate_indices = []
 
     def _get_sim(self):
         return self._app_service.sim
@@ -49,7 +49,7 @@ class GuiPickHelper:
         sim = self._get_sim()
         self._rom = sim.get_rigid_object_manager()
         self._obj_ids = sim._scene_obj_ids
-        self._pick_candidate_indexes = []
+        self._pick_candidate_indices = []
 
     def _closest_point_and_dist_to_query_position(self, points, query_pos):
         distances = np.linalg.norm(points - query_pos, axis=1)
@@ -72,7 +72,7 @@ class GuiPickHelper:
             obj_positions, query_pos
         )
         if distance < self._app_service.hitl_config.can_grasp_place_threshold:
-            self._pick_candidate_indexes.append(obj_index)
+            self._pick_candidate_indices.append(obj_index)
             return self._obj_ids[obj_index]
         else:
             return None
@@ -100,8 +100,8 @@ class GuiPickHelper:
     def viz_objects(self):
         obj_positions = self._get_object_positions()
 
-        if len(self._pick_candidate_indexes) > 0:
-            for candidate_index in self._pick_candidate_indexes:
+        if len(self._pick_candidate_indices) > 0:
+            for candidate_index in self._pick_candidate_indices:
                 obj_id = self._obj_ids[candidate_index]
                 pos = self._rom.get_object_by_id(
                     obj_id
@@ -112,7 +112,7 @@ class GuiPickHelper:
                     RADIUS_GRASP_PREVIEW,
                     do_pulse=False,
                 )
-            self._pick_candidate_indexes = []
+            self._pick_candidate_indices = []
         else:
             for i in range(len(obj_positions)):
                 obj_id = self._obj_ids[i]

--- a/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
@@ -21,12 +21,12 @@ RING_PULSE_SIZE: Final[float] = 0.03
 class GuiPickHelper:
     """Helper for picking up objects from the GUI."""
 
-    def __init__(self, gui_service, agent_idx):
+    def __init__(self, gui_service):
         self._app_service = gui_service
-        self._agent_idx = agent_idx
         self._rom = self._get_sim().get_rigid_object_manager()
         self._obj_ids = self._get_sim()._scene_obj_ids
         self._dist_to_highlight_obj = DIST_HIGHLIGHT
+        self._pick_candidate_indexes = []
 
     def _get_sim(self):
         return self._app_service.sim
@@ -49,6 +49,7 @@ class GuiPickHelper:
         sim = self._get_sim()
         self._rom = sim.get_rigid_object_manager()
         self._obj_ids = sim._scene_obj_ids
+        self._pick_candidate_indexes = []
 
     def _closest_point_and_dist_to_query_position(self, points, query_pos):
         distances = np.linalg.norm(points - query_pos, axis=1)
@@ -71,10 +72,9 @@ class GuiPickHelper:
             obj_positions, query_pos
         )
         if distance < self._app_service.hitl_config.can_grasp_place_threshold:
-            self._pick_candidate_index = obj_index
+            self._pick_candidate_indexes.append(obj_index)
             return self._obj_ids[obj_index]
         else:
-            self._pick_candidate_index = None
             return None
 
     def _draw_circle(self, pos, color, radius, billboard):
@@ -100,15 +100,19 @@ class GuiPickHelper:
     def viz_objects(self):
         obj_positions = self._get_object_positions()
 
-        if self._pick_candidate_index is not None:
-            obj_id = self._obj_ids[self._pick_candidate_index]
-            pos = self._rom.get_object_by_id(obj_id).transformation.translation
-            self._add_highlight_ring(
-                pos,
-                COLOR_GRASP_PREVIEW,
-                RADIUS_GRASP_PREVIEW,
-                do_pulse=False,
-            )
+        if len(self._pick_candidate_indexes) > 0:
+            for candidate_index in self._pick_candidate_indexes:
+                obj_id = self._obj_ids[candidate_index]
+                pos = self._rom.get_object_by_id(
+                    obj_id
+                ).transformation.translation
+                self._add_highlight_ring(
+                    pos,
+                    COLOR_GRASP_PREVIEW,
+                    RADIUS_GRASP_PREVIEW,
+                    do_pulse=False,
+                )
+            self._pick_candidate_indexes = []
         else:
             for i in range(len(obj_positions)):
                 obj_id = self._obj_ids[i]


### PR DESCRIPTION
## Motivation and Context

* Add support for gui-controlled spot, e.g. `python examples/hitl/rearrange_v2/rearrange_v2.py +experiment=gui_controlled_humanoid_and_spot`. Spot's keyboard controls include `F/V` for forward/back instead of `W/S`; similar alternates for grasping (`N`) and opening (`X`). The camera controls are shared across all users (e.g. `A/D` to turn).
* Add support for multiple local users. See references to `habitat_hitl.gui_controlled_agents` and `user_index`.

Rearrange_v2 multi-user application logic is very crude so far:
* A lot of the hacks below stem from the fact that I have two local users but only one local display. This stuff will change when we have two remote users.
* PickHelper doesn't do proper object-highlighting for two users. Later, we'll need a separate DebugLineRenderer per remote user (and probably a corresponding separate PickHelper per remote user).
* Help text isn't customized per user. Later, we'll need separate help text per remote user.
* Beware agent movement is tied to camera yaw. Later, we'll need a separate camera per remote user.
* Spot forward/back movement is hard-coded to `F` and `V` keys in `GuiRobotController`. Similar for `GuiHumanoidController`. (This hard-coding behavior is not new to this PR.) Later, GuiControllers shouldn't have direct access to `gui_input`; they should just use things like `_hint_walk_dir`.
* `AppStateRearrangeV2._get_user_key_down` is currently how I encapsulate user-specific keys for grasping and opening. For the case of a local second user, I internally remap keys to other keys in a hard-coded way. In the long run, local multi-user is probably only for testing purposes, so this hackiness is fine. Later, `_get_user_key_down` could encapsulate a second internal `gui_input` from a remote user. Alternately, instead of the `_get_user_key_down` interface, we may want to offer multiple `gui_input` instances, one per user. (In the case of local multi-user, the second one could be built from the "real" one using similar key-remapping hackiness.)

For GUI-controlled Spot, a few points:
1. I opt to use the Habitat-lab action space already configured for the Spot via the Habitat-lab config, in particular, the BaseVelocity skill. Lots of other skills are present in its action space and not used. We can imagine a different paradigm where we directly manipulate the articulated agent via Habitat-sim API.
2. In terms of turning/steering the Spot, I stick to the same convention we use for the Humanoid: "turning" is actually just turning the camera, and then we pass cam_yaw into the controller. The controller then makes a best effort to steer the agent to match the cam yaw. For Spot, doing this accurately unfortunately requires tight coupling between the GuiRobotController class and the underlying BaseVelocity action. In particular, see how `turn_scale` is computed in `controller_helper.py`. Instead of the controller steering to match camera yaw, we can imagine a different paradigm: turn inputs are forwarded to the controller, the controller is free to steer the agent however it likes, and then the camera yaw would follow the agent yaw.

## How Has This Been Tested

Local testing on Macbook:
```
python examples/hitl/rearrange_v2/rearrange_v2.py 
python examples/hitl/rearrange_v2/rearrange_v2.py +experiment=gui_controlled_spot_only
python examples/hitl/rearrange_v2/rearrange_v2.py +experiment=gui_controlled_humanoid_and_spot
python examples/hitl/rearrange/rearrange.py
python examples/hitl/basic_viewer/basic_viewer.py
python examples/hitl/pick_throw_vr/pick_throw_vr.py
python examples/hitl/minimal/minimal.py
```

## Types of changes

- [HITL]

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
