### PR TITLE
"Ontop" utility

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -761,7 +761,7 @@ def ontop(
         habitat_sim.physics.ManagedArticulatedObject,
         int,
     ],
-    do_collision_detection: bool = True,
+    do_collision_detection: bool,
     vertical_normal_error_threshold: float = 0.75,
 ) -> List[int]:
     """

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -519,29 +519,29 @@ def get_global_keypoints_from_bb(
 
 
 def get_rigid_object_global_keypoints(
-    objectA: habitat_sim.physics.ManagedRigidObject,
+    object_a: habitat_sim.physics.ManagedRigidObject,
 ) -> List[mn.Vector3]:
     """
     Get a list of rigid object keypoints in global space.
     0th point is the bounding box center, others are bounding box corners.
 
-    :param objectA: The ManagedRigidObject from which to extract keypoints.
+    :param object_a: The ManagedRigidObject from which to extract keypoints.
 
     :return: A set of global 3D keypoints for the object.
     """
 
-    bb = objectA.root_scene_node.cumulative_bb
-    return get_global_keypoints_from_bb(bb, objectA.transformation)
+    bb = object_a.root_scene_node.cumulative_bb
+    return get_global_keypoints_from_bb(bb, object_a.transformation)
 
 
 def get_articulated_object_global_keypoints(
-    objectA: habitat_sim.physics.ManagedArticulatedObject,
+    object_a: habitat_sim.physics.ManagedArticulatedObject,
     ao_aabbs: Dict[int, mn.Range3D] = None,
 ) -> List[mn.Vector3]:
     """
     Get global bb keypoints for an ArticulatedObject.
 
-    :param objectA: The ManagedArticulatedObject from which to extract keypoints.
+    :param object_a: The ManagedArticulatedObject from which to extract keypoints.
     :param ao_aabbs: A pre-computed map from ArticulatedObject object_ids to their local bounding boxes. If not provided, recomputed as necessary. Must contain the subjects of the query.
 
     :return: A set of global 3D keypoints for the object.
@@ -549,25 +549,25 @@ def get_articulated_object_global_keypoints(
 
     ao_bb = None
     if ao_aabbs is None:
-        ao_bb = get_ao_root_bb(objectA)
+        ao_bb = get_ao_root_bb(object_a)
     else:
-        ao_bb = ao_aabbs[objectA.object_id]
+        ao_bb = ao_aabbs[object_a.object_id]
 
-    return get_global_keypoints_from_bb(ao_bb, objectA.transformation)
+    return get_global_keypoints_from_bb(ao_bb, object_a.transformation)
 
 
 def get_articulated_link_global_keypoints(
-    objectA: habitat_sim.physics.ManagedArticulatedObject, link_index: int
+    object_a: habitat_sim.physics.ManagedArticulatedObject, link_index: int
 ) -> List[mn.Vector3]:
     """
     Get global bb keypoints for an ArticulatedLink.
 
-    :param objectA: The parent ManagedArticulatedObject for the link.
+    :param object_a: The parent ManagedArticulatedObject for the link.
     :param link_index: The local index of the link within the parent ArticulatedObject. Not the object_id of the link.
 
     :return: A set of global 3D keypoints for the link.
     """
-    link_node = objectA.get_link_scene_node(link_index)
+    link_node = object_a.get_link_scene_node(link_index)
 
     return get_global_keypoints_from_bb(
         link_node.cumulative_bb, link_node.absolute_transformation()
@@ -608,14 +608,14 @@ def get_global_keypoints_from_object_id(
 
 def object_keypoint_cast(
     sim: habitat_sim.Simulator,
-    objectA: habitat_sim.physics.ManagedRigidObject,
+    object_a: habitat_sim.physics.ManagedRigidObject,
     direction: mn.Vector3 = None,
 ) -> List[habitat_sim.physics.RaycastResults]:
     """
     Computes object global keypoints, casts rays from each in the specified direction and returns the resulting RaycastResults.
 
     :param sim: The Simulator instance.
-    :param objectA: The ManagedRigidObject from which to extract keypoints and raycast.
+    :param object_a: The ManagedRigidObject from which to extract keypoints and raycast.
     :param direction: Optionally provide a unit length global direction vector for the raycast. If None, default to -Y.
 
     :return: A list of RaycastResults, one from each object keypoint.
@@ -625,7 +625,7 @@ def object_keypoint_cast(
         # default to downward raycast
         direction = mn.Vector3(0, -1, 0)
 
-    global_keypoints = get_rigid_object_global_keypoints(objectA)
+    global_keypoints = get_rigid_object_global_keypoints(object_a)
     return [
         sim.cast_ray(habitat_sim.geo.Ray(keypoint, direction))
         for keypoint in global_keypoints
@@ -639,17 +639,17 @@ def object_keypoint_cast(
 
 def above(
     sim: habitat_sim.Simulator,
-    objectA: Union[
+    object_a: Union[
         habitat_sim.physics.ManagedRigidObject,
         habitat_sim.physics.ManagedArticulatedObject,
     ],
 ) -> List[int]:
     """
-    Get a list of all objects that a particular objectA is 'above'.
+    Get a list of all objects that a particular object_a is 'above'.
     Concretely, 'above' is defined as: a downward raycast of any object keypoint hits the object below.
 
     :param sim: The Simulator instance.
-    :param objectA: The ManagedRigidObject for which to query the 'above' set.
+    :param object_a: The ManagedRigidObject for which to query the 'above' set.
 
     :return: a list of object ids.
     """
@@ -657,21 +657,21 @@ def above(
     # get object ids of all objects below this one
     above_object_ids = [
         hit.object_id
-        for keypoint_raycast_result in object_keypoint_cast(sim, objectA)
+        for keypoint_raycast_result in object_keypoint_cast(sim, object_a)
         for hit in keypoint_raycast_result.hits
     ]
     above_object_ids = list(set(above_object_ids))
 
     # remove self from the list if present
-    if objectA.object_id in above_object_ids:
-        above_object_ids.remove(objectA.object_id)
+    if object_a.object_id in above_object_ids:
+        above_object_ids.remove(object_a.object_id)
 
     return above_object_ids
 
 
 def within(
     sim: habitat_sim.Simulator,
-    objectA: Union[
+    object_a: Union[
         habitat_sim.physics.ManagedRigidObject,
         habitat_sim.physics.ManagedArticulatedObject,
     ],
@@ -680,20 +680,20 @@ def within(
     center_ensures_containment: bool = True,
 ) -> List[int]:
     """
-    Get a list of all objects that a particular objectA is 'within'.
+    Get a list of all objects that a particular object_a is 'within'.
     Concretely, 'within' is defined as: a threshold number of opposing keypoint raycasts hit the same object.
     This function computes raycasts along all global axes from all keypoints and checks opposing rays for collision with the same object.
 
     :param sim: The Simulator instance.
-    :param objectA: The ManagedRigidObject for which to query the 'within' set.
+    :param object_a: The ManagedRigidObject for which to query the 'within' set.
     :param max_distance: The maximum ray distance to check in each opposing direction (this is half the "wingspan" of the check). Makes the raycast more efficienct and realistically containing objects will have a limited size.
-    :param keypoint_vote_threshold: The minimum number of keypoints which must indicate containment to qualify objectA as "within" another object.
-    :param center_ensures_containment: If True, positive test of objectA's center keypoint alone qualifies objectA as "within" another object.
+    :param keypoint_vote_threshold: The minimum number of keypoints which must indicate containment to qualify object_a as "within" another object.
+    :param center_ensures_containment: If True, positive test of object_a's center keypoint alone qualifies object_a as "within" another object.
 
     :return: a list of object_id integers.
     """
 
-    global_keypoints = get_rigid_object_global_keypoints(objectA)
+    global_keypoints = get_rigid_object_global_keypoints(object_a)
 
     # build axes vectors
     pos_axes = [mn.Vector3.x_axis(), mn.Vector3.y_axis(), mn.Vector3.z_axis()]
@@ -748,15 +748,15 @@ def within(
     containment_ids = list(set(containment_ids))
 
     # remove self from the list if present
-    if objectA.object_id in containment_ids:
-        containment_ids.remove(objectA.object_id)
+    if object_a.object_id in containment_ids:
+        containment_ids.remove(object_a.object_id)
 
     return containment_ids
 
 
 def ontop(
     sim: habitat_sim.Simulator,
-    objectA: Union[
+    object_a: Union[
         habitat_sim.physics.ManagedRigidObject,
         habitat_sim.physics.ManagedArticulatedObject,
         int,
@@ -765,27 +765,29 @@ def ontop(
     vertical_normal_error_threshold: float = 0.75,
 ) -> List[int]:
     """
-    Get a list of all object ids or objects that are "ontop" of a particular objectA.
-    Concretely, 'ontop' is defined as: contact points between objectA and objectB have vertical normals "upward" relative to objectA.
-    This function uses collision points to determine which objects are resting on or contacting the surface of objectA.
+    Get a list of all object ids or objects that are "ontop" of a particular object_a.
+    Concretely, 'ontop' is defined as: contact points between object_a and objectB have vertical normals "upward" relative to object_a.
+    This function uses collision points to determine which objects are resting on or contacting the surface of object_a.
 
     :param sim: The Simulator instance.
-    :param objectA: The ManagedRigidObject or object id for which to query the 'ontop' set.
+    :param object_a: The ManagedRigidObject or object id for which to query the 'ontop' set.
     :param do_collision_detection: If True, a fresh discrete collision detection is run before the contact point query. Pass False to skip if a recent sim step or pre-process has run a collision detection pass on the current state.
     :param vertical_normal_error_threshold: The allowed error in normal alignment for a contact point to be considered "vertical" for this check. Functionally, if dot(contact normal, Y) <= threshold, the contact is ignored.
 
-    :return: a list of integer object_ids for the set of objects "ontop" of objectA.
+    :return: a list of integer object_ids for the set of objects "ontop" of object_a.
     """
 
     link_id = None
-    if isinstance(objectA, int):
-        subject_object = get_obj_from_id(sim, objectA)
+    if isinstance(object_a, int):
+        subject_object = get_obj_from_id(sim, object_a)
         if subject_object is None:
-            raise AssertionError(f"The passed object_id {objectA} is invalid.")
-        if subject_object.object_id != objectA:
-            # objectA is a link
-            link_id = subject_object.link_object_ids[objectA]
-        objectA = subject_object
+            raise AssertionError(
+                f"The passed object_id {object_a} is invalid."
+            )
+        if subject_object.object_id != object_a:
+            # object_a is a link
+            link_id = subject_object.link_object_ids[object_a]
+        object_a = subject_object
 
     if do_collision_detection:
         sim.perform_discrete_collision_detection()
@@ -796,11 +798,11 @@ def ontop(
     for cp in sim.get_physics_contact_points():
         contacting_obj_id = None
         obj_is_b = False
-        if cp.object_id_a == objectA.object_id and (
+        if cp.object_id_a == object_a.object_id and (
             link_id is None or link_id == cp.link_id_a
         ):
             contacting_obj_id = cp.object_id_b
-        elif cp.object_id_b == objectA.object_id and (
+        elif cp.object_id_b == object_a.object_id and (
             link_id is None or link_id == cp.link_id_b
         ):
             contacting_obj_id = cp.object_id_a
@@ -824,7 +826,7 @@ def ontop(
 
 def object_in_region(
     sim: habitat_sim.Simulator,
-    objectA: Union[
+    object_a: Union[
         habitat_sim.physics.ManagedRigidObject,
         habitat_sim.physics.ManagedArticulatedObject,
     ],
@@ -838,7 +840,7 @@ def object_in_region(
     Check if an object is within a region by checking region containment of keypoints.
 
     :param sim: The Simulator instance.
-    :param objectA: The object instance.
+    :param object_a: The object instance.
     :param region: The SemanticRegion to check.
     :param containment_threshold: threshold ratio of keypoints which need to be in a region to count as containment.
     :param center_only: If True, only use the BB center keypoint, all or nothing.
@@ -851,7 +853,7 @@ def object_in_region(
 
     key_points = get_global_keypoints_from_object_id(
         sim,
-        object_id=objectA.object_id,
+        object_id=object_a.object_id,
         ao_link_map=ao_link_map,
         ao_aabbs=ao_aabbs,
     )
@@ -867,7 +869,7 @@ def object_in_region(
 
 def get_object_regions(
     sim: habitat_sim.Simulator,
-    objectA: Union[
+    object_a: Union[
         habitat_sim.physics.ManagedRigidObject,
         habitat_sim.physics.ManagedArticulatedObject,
     ],
@@ -878,7 +880,7 @@ def get_object_regions(
     Get a sorted list of regions containing an object using bounding box keypoints.
 
     :param sim: The Simulator instance.
-    :param objectA: The object instance.
+    :param object_a: The object instance.
     :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id.
     :param ao_aabbs: A pre-computed map from ArticulatedObject object_ids to their local bounding boxes. If not provided, recomputed as necessary.
 
@@ -887,7 +889,7 @@ def get_object_regions(
 
     key_points = get_global_keypoints_from_object_id(
         sim,
-        object_id=objectA.object_id,
+        object_id=object_a.object_id,
         ao_link_map=ao_link_map,
         ao_aabbs=ao_aabbs,
     )

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -808,13 +808,13 @@ def ontop(
             contacting_obj_id = cp.object_id_a
             obj_is_b = True
         if contacting_obj_id is not None:
-            contact_dir_me = (
+            contact_normal = (
                 cp.contact_normal_on_b_in_ws
                 if obj_is_b
                 else -cp.contact_normal_on_b_in_ws
             )
             if (
-                mn.math.dot(contact_dir_me, yup)
+                mn.math.dot(contact_normal, yup)
                 > vertical_normal_error_threshold
             ):
                 ontop_object_ids.append(contacting_obj_id)

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -9,6 +9,7 @@ import os.path as osp
 import magnum as mn
 import pytest
 
+from habitat.sims.habitat_simulator.debug_visualizer import DebugVisualizer
 from habitat.sims.habitat_simulator.sim_utilities import (
     above,
     bb_ray_prescreen,
@@ -454,3 +455,16 @@ def test_region_containment_utils():
         assert livingroom_ratio > 0
         assert livingroom_ratio < 0.51
         assert bedroom_ratio > 0.51
+
+
+def test_ontop_util():
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene"
+    ] = "data/test_assets/scenes/simple_room.stage_config.json"
+    hab_cfg = make_cfg(sim_settings)
+
+    with Simulator(hab_cfg) as sim:
+        # rom = sim.get_rigid_object_manager()
+        dbv = DebugVisualizer(sim)
+        dbv.peek_scene(show=True)

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -9,7 +9,6 @@ import os.path as osp
 import magnum as mn
 import pytest
 
-from habitat.sims.habitat_simulator.debug_visualizer import DebugVisualizer
 from habitat.sims.habitat_simulator.sim_utilities import (
     above,
     bb_ray_prescreen,
@@ -21,6 +20,7 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     get_object_regions,
     object_in_region,
     object_keypoint_cast,
+    ontop,
     snap_down,
     within,
 )
@@ -457,14 +457,89 @@ def test_region_containment_utils():
         assert bedroom_ratio > 0.51
 
 
+@pytest.mark.skipif(
+    not built_with_bullet,
+    reason="Collision detection API requires Bullet physics.",
+)
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/"),
+    reason="Requires ReplicaCAD dataset.",
+)
 def test_ontop_util():
     sim_settings = default_sim_settings.copy()
     sim_settings[
-        "scene"
-    ] = "data/test_assets/scenes/simple_room.stage_config.json"
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    sim_settings["scene"] = "apt_0"
     hab_cfg = make_cfg(sim_settings)
-
     with Simulator(hab_cfg) as sim:
-        # rom = sim.get_rigid_object_manager()
-        dbv = DebugVisualizer(sim)
-        dbv.peek_scene(show=True)
+        # a rigid object to test
+        table_object = get_obj_from_handle(sim, "frl_apartment_table_02_:0000")
+
+        # an articulated object to test
+        counter_object = get_obj_from_handle(sim, "kitchen_counter_:0000")
+
+        # the link to test
+        drawer_link_id = 7
+
+        drawer_link_object_ids = [
+            obj_id
+            for obj_id in counter_object.link_object_ids.keys()
+            if counter_object.link_object_ids[obj_id] == drawer_link_id
+        ]
+        assert len(drawer_link_object_ids) == 1
+        drawer_link_object_id = drawer_link_object_ids[0]
+
+        # open the drawer
+        drawer_link_dof = counter_object.get_link_joint_pos_offset(
+            drawer_link_id
+        )
+        joint_positions = counter_object.joint_positions
+        joint_positions[drawer_link_dof] = 0.5
+        counter_object.joint_positions = joint_positions
+
+        # drop an object into the open drawer
+        container_object = get_obj_from_handle(
+            sim, "frl_apartment_kitchen_utensil_08_:0000"
+        )
+        container_object.translation = mn.Vector3(-1.7, 0.6, 0.2)
+
+        # in the initial state:
+        # objects are on the table
+        assert ontop(sim, table_object) == [102, 103, 51, 52, 53, 55]
+        assert ontop(sim, table_object) == ontop(sim, table_object.object_id)
+        # objects about the counter are floating slightly and don't register
+        assert len(ontop(sim, counter_object)) == 0
+        assert len(ontop(sim, drawer_link_object_id)) == 0
+
+        # after some simulation, object settle onto the counter and drawer
+        sim.step_physics(0.75)
+
+        # objects are on the table
+        assert ontop(sim, table_object) == [102, 103, 51, 52, 53, 55]
+        assert ontop(sim, table_object) == ontop(sim, table_object.object_id)
+        on_counter = ontop(sim, counter_object)
+        assert on_counter == [
+            65,
+            1,
+            67,
+            68,
+            69,
+            70,
+            71,
+            72,
+            66,
+            81,
+            82,
+            83,
+            84,
+            85,
+            86,
+            87,
+            63,
+        ]
+        assert container_object.object_id in on_counter
+        assert ontop(sim, drawer_link_object_id) == [
+            container_object.object_id
+        ]
+        assert ontop(sim, counter_object.object_id) == on_counter

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -506,19 +506,24 @@ def test_ontop_util():
 
         # in the initial state:
         # objects are on the table
-        assert ontop(sim, table_object) == [102, 103, 51, 52, 53, 55]
-        assert ontop(sim, table_object) == ontop(sim, table_object.object_id)
+        assert ontop(sim, table_object, True) == [102, 103, 51, 52, 53, 55]
+        assert ontop(sim, table_object, False) == ontop(
+            sim, table_object.object_id, False
+        )
         # objects about the counter are floating slightly and don't register
-        assert len(ontop(sim, counter_object)) == 0
-        assert len(ontop(sim, drawer_link_object_id)) == 0
+        assert len(ontop(sim, counter_object, False)) == 0
+        assert len(ontop(sim, drawer_link_object_id, False)) == 0
 
         # after some simulation, object settle onto the counter and drawer
         sim.step_physics(0.75)
 
         # objects are on the table
-        assert ontop(sim, table_object) == [102, 103, 51, 52, 53, 55]
-        assert ontop(sim, table_object) == ontop(sim, table_object.object_id)
-        on_counter = ontop(sim, counter_object)
+        # NOTE: we only do collision detection on the first query after a state change
+        assert ontop(sim, table_object, True) == [102, 103, 51, 52, 53, 55]
+        assert ontop(sim, table_object, False) == ontop(
+            sim, table_object.object_id, False
+        )
+        on_counter = ontop(sim, counter_object, False)
         assert on_counter == [
             65,
             1,
@@ -539,7 +544,7 @@ def test_ontop_util():
             63,
         ]
         assert container_object.object_id in on_counter
-        assert ontop(sim, drawer_link_object_id) == [
+        assert ontop(sim, drawer_link_object_id, False) == [
             container_object.object_id
         ]
-        assert ontop(sim, counter_object.object_id) == on_counter
+        assert ontop(sim, counter_object.object_id, False) == on_counter


### PR DESCRIPTION
## Motivation and Context

This PR adds a utility for querying which objects are "ontop" of a subject object. Initial prototype in #1770. 

Here, "ontop" means the objects have contacting collision points with a close to vertical contact normal. The epsilon threshold for the dot product is a controllable variable, defaulting to 0.75.

The function inputs can be `ManagedObject`s or `object_id` integers. If the `object_id` provided refers to an `ArticulatedLink`, _only that link_ is checked. Conversely, if a ManagedArticulatedObject is provided, _all links_ are checked.

## How Has This Been Tested

A pytest is added using all input variant in a ReplicaCAD scene.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
