### PR TITLE
HITL - Add GUI rendering wrapper.

### DIFF
--- a/examples/hitl/basic_viewer/basic_viewer.py
+++ b/examples/hitl/basic_viewer/basic_viewer.py
@@ -69,7 +69,7 @@ class AppStateBasicViewer(AppState):
 
         # draw lookat point
         radius = 0.15
-        self._app_service.line_render.draw_circle(
+        self._app_service.gui_drawer.draw_circle(
             self._get_camera_lookat_pos(),
             radius,
             mn.Color3(255 / 255, 0 / 255, 0 / 255),

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -484,7 +484,7 @@ class AppStatePickThrowVr(AppState):
 
     def _draw_circle(self, pos, color, radius):
         num_segments = 24
-        self._app_service.line_render.draw_circle(
+        self._app_service.gui_drawer.draw_circle(
             pos,
             radius,
             color,

--- a/examples/hitl/rearrange/rearrange.py
+++ b/examples/hitl/rearrange/rearrange.py
@@ -120,7 +120,7 @@ class AppStateRearrange(AppState):
         if self._held_target_obj_idx is not None:
             color = mn.Color3(0, 255 / 255, 0)  # green
             goal_position = self._goal_positions[self._held_target_obj_idx]
-            self._app_service.line_render.draw_circle(
+            self._app_service.gui_drawer.draw_circle(
                 goal_position, end_radius, color, 24
             )
 
@@ -134,7 +134,7 @@ class AppStateRearrange(AppState):
             # draw can place area
             can_place_position = mn.Vector3(goal_position)
             can_place_position[1] = self._get_agent_feet_height()
-            self._app_service.line_render.draw_circle(
+            self._app_service.gui_drawer.draw_circle(
                 can_place_position,
                 self._can_grasp_place_threshold,
                 mn.Color3(255 / 255, 255 / 255, 0),
@@ -252,7 +252,7 @@ class AppStateRearrange(AppState):
                 box_offset = mn.Vector3(
                     box_half_size, box_half_size, box_half_size
                 )
-                self._app_service.line_render.draw_box(
+                self._app_service.gui_drawer.draw_box(
                     this_target_pos - box_offset,
                     this_target_pos + box_offset,
                     color,
@@ -268,7 +268,7 @@ class AppStateRearrange(AppState):
                 # draw can grasp area
                 can_grasp_position = mn.Vector3(this_target_pos)
                 can_grasp_position[1] = self._get_agent_feet_height()
-                self._app_service.line_render.draw_circle(
+                self._app_service.gui_drawer.draw_circle(
                     can_grasp_position,
                     self._can_grasp_place_threshold,
                     mn.Color3(255 / 255, 255 / 255, 0),

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -166,7 +166,7 @@ class HitlDriver(AppDriver):
         self._debug_images = self._hitl_config.debug_images
 
         self._viz_anim_fraction: float = 0.0
-        self._pending_cursor_style = None
+        self._pending_cursor_style: Optional[Any] = None
 
         self._episode_helper = EpisodeHelper(self.habitat_env)
 

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -12,7 +12,7 @@ import abc
 import json
 from datetime import datetime
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import magnum as mn
 import numpy as np
@@ -31,6 +31,7 @@ from habitat_hitl._internal.networking.networking_process import (
 from habitat_hitl.app_states.app_service import AppService
 from habitat_hitl.app_states.app_state_abc import AppState
 from habitat_hitl.core.client_message_manager import ClientMessageManager
+from habitat_hitl.core.gui_drawer import GuiDrawer
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.hydra_utils import omegaconf_to_object
 from habitat_hitl.core.remote_client_state import RemoteClientState
@@ -42,10 +43,12 @@ from habitat_hitl.core.serialize_utils import (
     save_as_json_gzip,
     save_as_pickle_gzip,
 )
+from habitat_hitl.core.text_drawer import AbstractTextDrawer
 from habitat_hitl.environment.controllers.controller_helper import (
     ControllerHelper,
 )
 from habitat_hitl.environment.episode_helper import EpisodeHelper
+from habitat_sim.gfx import DebugLineRender
 
 if TYPE_CHECKING:
     from habitat.core.environments import GymHabitatEnv
@@ -73,11 +76,12 @@ class AppDriver:
 class HitlDriver(AppDriver):
     def __init__(
         self,
+        *,
         config,
-        gui_input,
-        line_render,
-        text_drawer,
-        create_app_state_lambda,
+        gui_input: GuiInput,
+        debug_line_drawer: Optional[DebugLineRender],
+        text_drawer: AbstractTextDrawer,
+        create_app_state_lambda: Callable,
     ):
         if "habitat_hitl" not in config:
             raise RuntimeError(
@@ -88,8 +92,6 @@ class HitlDriver(AppDriver):
         self._play_episodes_filter_str = self._hitl_config.episodes_filter
         self._num_recorded_episodes = 0
         self._gui_input = gui_input
-
-        line_render.set_line_width(self._hitl_config.debug_line_width)
 
         with habitat.config.read_write(config):  # type: ignore
             # needed so we can provide keyframes to GuiApplication
@@ -168,29 +170,28 @@ class HitlDriver(AppDriver):
 
         self._episode_helper = EpisodeHelper(self.habitat_env)
 
-        self._check_init_server(line_render, gui_input)
-
-        def local_end_episode(do_reset=False):
-            self._end_episode(do_reset)
-
         self._client_message_manager = None
         if self.network_server_enabled:
             self._client_message_manager = ClientMessageManager()
 
+        gui_drawer = GuiDrawer(debug_line_drawer, self._client_message_manager)
+        gui_drawer.set_line_width(self._hitl_config.debug_line_width)
+
+        self._check_init_server(gui_drawer, gui_input)
+
+        def local_end_episode(do_reset=False):
+            self._end_episode(do_reset)
+
         gui_agent_controllers: Any = (
             self.ctrl_helper.get_gui_agent_controllers()
-            if self.ctrl_helper
-            else []
         )
-        for controller in gui_agent_controllers:
-            controller.line_render = line_render
 
         self._app_service = AppService(
             config=config,
             hitl_config=self._hitl_config,
             gui_input=gui_input,
             remote_client_state=self._remote_client_state,
-            line_render=line_render,
+            gui_drawer=gui_drawer,
             text_drawer=text_drawer,
             get_anim_fraction=lambda: self._viz_anim_fraction,
             env=self.habitat_env,
@@ -224,7 +225,7 @@ class HitlDriver(AppDriver):
     def network_server_enabled(self) -> bool:
         return self._hitl_config.networking.enable
 
-    def _check_init_server(self, line_render, gui_input: GuiInput):
+    def _check_init_server(self, gui_drawer: GuiDrawer, gui_input: GuiInput):
         self._remote_client_state = None
         self._interprocess_record = None
         if self.network_server_enabled:
@@ -238,7 +239,7 @@ class HitlDriver(AppDriver):
             )
             launch_networking_process(self._interprocess_record)
             self._remote_client_state = RemoteClientState(
-                self._interprocess_record, line_render, gui_input
+                self._interprocess_record, gui_drawer, gui_input
             )
 
     def _check_terminate_server(self):

--- a/habitat-hitl/habitat_hitl/_internal/networking/interprocess_record.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/interprocess_record.py
@@ -69,10 +69,10 @@ class InterprocessRecord:
 
         return items
 
-    def get_queued_client_states(self) -> List:
+    def get_queued_client_states(self) -> List[Any]:
         """Dequeue all client states."""
         return self._dequeue_all(self._client_state_queue)
 
-    def get_queued_connection_records(self) -> List:
+    def get_queued_connection_records(self) -> List[Any]:
         """Dequeue all connection records."""
         return self._dequeue_all(self._connection_record_queue)

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -11,6 +11,7 @@ from typing import Callable, List
 from habitat import Env
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
 from habitat_hitl.core.client_message_manager import ClientMessageManager
+from habitat_hitl.core.gui_drawer import GuiDrawer
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.remote_client_state import RemoteClientState
 from habitat_hitl.core.serialize_utils import BaseRecorder
@@ -29,7 +30,7 @@ class AppService:
         hitl_config,
         gui_input: GuiInput,
         remote_client_state: RemoteClientState,
-        line_render: DebugLineRender,
+        gui_drawer: GuiDrawer,
         text_drawer: AbstractTextDrawer,
         get_anim_fraction: Callable,
         env: Env,
@@ -47,7 +48,7 @@ class AppService:
         self._hitl_config = hitl_config
         self._gui_input = gui_input
         self._remote_client_state = remote_client_state
-        self._line_render = line_render
+        self._gui_drawer = gui_drawer
         self._text_drawer = text_drawer
         self._get_anim_fraction = get_anim_fraction
         self._env = env
@@ -78,8 +79,8 @@ class AppService:
         return self._remote_client_state
 
     @property
-    def line_render(self) -> DebugLineRender:
-        return self._line_render
+    def gui_drawer(self) -> GuiDrawer:
+        return self._gui_drawer
 
     @property
     def text_drawer(self) -> AbstractTextDrawer:

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -18,7 +18,6 @@ from habitat_hitl.core.serialize_utils import BaseRecorder
 from habitat_hitl.core.text_drawer import AbstractTextDrawer
 from habitat_hitl.environment.controllers.controller_abc import GuiController
 from habitat_hitl.environment.episode_helper import EpisodeHelper
-from habitat_sim.gfx import DebugLineRender
 
 
 # Helpers to provide to AppState classes, provided by the underlying SandboxDriver

--- a/habitat-hitl/habitat_hitl/core/gui_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/gui_drawer.py
@@ -105,19 +105,23 @@ class GuiDrawer:
         color: mn.Color4,
         num_segments: int = DEFAULT_SEGMENT_COUNT,
         normal: mn.Vector3 = DEFAULT_NORMAL,
+        billboard: bool = False,
     ) -> None:
         """
         Draw a circle in world-space or local-space (see pushTransform).
         The circle is an approximation; see numSegments.
         """
+        # If server rendering is enabled:
         if self._sim_debug_line_render:
             self._sim_debug_line_render.draw_circle(
                 translation, radius, color, num_segments, normal
             )
 
+        # If remote rendering is enabled:
         if self._client_message_manager:
-            # Networking not implemented
-            pass
+            self._client_message_manager.add_highlight(
+                translation, radius, billboard=billboard, color=color
+            )
 
     def draw_transformed_line(
         self,

--- a/habitat-hitl/habitat_hitl/core/gui_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/gui_drawer.py
@@ -8,7 +8,7 @@ from typing import Final, List, Optional
 
 import magnum as mn
 
-from habitat_hitl.core import ClientMessageManager
+from habitat_hitl.core.client_message_manager import ClientMessageManager
 from habitat_sim.gfx import DebugLineRender
 
 
@@ -17,7 +17,6 @@ class GuiDrawer:
     Renders UI elements.
     """
 
-    ID_BROADCAST: Final[int] = -1
     DEFAULT_SEGMENT_COUNT: Final[int] = 24
     DEFAULT_NORMAL: mn.Vector3 = mn.Vector3(0.0, 1.0, 0.0)
 
@@ -29,15 +28,21 @@ class GuiDrawer:
         """
         Construct the UI drawer.
         If sim_debug_line_render is defined, uses the habitat-sim DebugLineRender to render on the server viewport.
-        If client_message_manager is defined, sends render messages to the clients.
+        If client_message_manager is defined, sends render messages to the client.
         """
         self._sim_debug_line_render = sim_debug_line_render
         self._client_message_manager = client_message_manager
 
+    def get_sim_debug_line_render(self) -> Optional[DebugLineRender]:
+        """
+        Set the internal 'sim_debug_line_render' object, used for rendering lines onto the server.
+        Returns None if server rendering is disabled.
+        """
+        return self._sim_debug_line_render
+
     def set_line_width(
         self,
         line_width: float,
-        destination_id: int = ID_BROADCAST,
     ) -> None:
         """
         Set global line width for all lines rendered by GuiDrawer.
@@ -52,7 +57,6 @@ class GuiDrawer:
     def push_transform(
         self,
         transform: mn.Matrix4,
-        destination_id: int = ID_BROADCAST,
     ) -> None:
         """
         Push (multiply) a transform onto the transform stack, affecting all line-drawing until popped.
@@ -67,7 +71,6 @@ class GuiDrawer:
 
     def pop_transform(
         self,
-        destination_id: int = ID_BROADCAST,
     ) -> None:
         """
         See push_transform.
@@ -84,7 +87,6 @@ class GuiDrawer:
         min_extent: mn.Vector3,
         max_extent: mn.Vector3,
         color: mn.Color4,
-        destination_id: int = ID_BROADCAST,
     ) -> None:
         """
         Draw a box in world-space or local-space (see pushTransform).
@@ -103,7 +105,6 @@ class GuiDrawer:
         color: mn.Color4,
         num_segments: int = DEFAULT_SEGMENT_COUNT,
         normal: mn.Vector3 = DEFAULT_NORMAL,
-        destination_id: int = ID_BROADCAST,
     ) -> None:
         """
         Draw a circle in world-space or local-space (see pushTransform).
@@ -124,7 +125,6 @@ class GuiDrawer:
         to_pos: mn.Vector3,
         from_color: mn.Color4,
         to_color: mn.Color4 = None,
-        destination_id: int = ID_BROADCAST,
     ) -> None:
         """
         Draw a line segment in world-space or local-space (see pushTransform) with interpolated color.
@@ -151,7 +151,6 @@ class GuiDrawer:
         color: mn.Color4,
         num_segments: int = DEFAULT_SEGMENT_COUNT,
         normal: mn.Vector3 = DEFAULT_NORMAL,
-        destination_id: int = ID_BROADCAST,
     ) -> None:
         """
         Draw a sequence of line segments with circles at the two endpoints.

--- a/habitat-hitl/habitat_hitl/core/gui_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/gui_drawer.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Final, List, Optional
+
+import magnum as mn
+
+from habitat_hitl.core import ClientMessageManager
+from habitat_sim.gfx import DebugLineRender
+
+
+class GuiDrawer:
+    """
+    Renders UI elements.
+    """
+
+    ID_BROADCAST: Final[int] = -1
+    DEFAULT_SEGMENT_COUNT: Final[int] = 24
+    DEFAULT_NORMAL: mn.Vector3 = mn.Vector3(0.0, 1.0, 0.0)
+
+    def __init__(
+        self,
+        sim_debug_line_render: Optional[DebugLineRender],
+        client_message_manager: Optional[ClientMessageManager],
+    ) -> None:
+        """
+        Construct the UI drawer.
+        If sim_debug_line_render is defined, uses the habitat-sim DebugLineRender to render on the server viewport.
+        If client_message_manager is defined, sends render messages to the clients.
+        """
+        self._sim_debug_line_render = sim_debug_line_render
+        self._client_message_manager = client_message_manager
+
+    def set_line_width(
+        self,
+        line_width: float,
+        destination_id: int = ID_BROADCAST,
+    ) -> None:
+        """
+        Set global line width for all lines rendered by GuiDrawer.
+        """
+        if self._sim_debug_line_render:
+            self._sim_debug_line_render.set_line_width(line_width)
+
+        if self._client_message_manager:
+            # Networking not implemented
+            pass
+
+    def push_transform(
+        self,
+        transform: mn.Matrix4,
+        destination_id: int = ID_BROADCAST,
+    ) -> None:
+        """
+        Push (multiply) a transform onto the transform stack, affecting all line-drawing until popped.
+        Must be paired with popTransform().
+        """
+        if self._sim_debug_line_render:
+            self._sim_debug_line_render.push_transform(transform)
+
+        if self._client_message_manager:
+            # Networking not implemented
+            pass
+
+    def pop_transform(
+        self,
+        destination_id: int = ID_BROADCAST,
+    ) -> None:
+        """
+        See push_transform.
+        """
+        if self._sim_debug_line_render:
+            self._sim_debug_line_render.pop_transform()
+
+        if self._client_message_manager:
+            # Networking not implemented
+            pass
+
+    def draw_box(
+        self,
+        min_extent: mn.Vector3,
+        max_extent: mn.Vector3,
+        color: mn.Color4,
+        destination_id: int = ID_BROADCAST,
+    ) -> None:
+        """
+        Draw a box in world-space or local-space (see pushTransform).
+        """
+        if self._sim_debug_line_render:
+            self._sim_debug_line_render.draw_box(min, max, color)
+
+        if self._client_message_manager:
+            # Networking not implemented
+            pass
+
+    def draw_circle(
+        self,
+        translation: mn.Vector3,
+        radius: float,
+        color: mn.Color4,
+        num_segments: int = DEFAULT_SEGMENT_COUNT,
+        normal: mn.Vector3 = DEFAULT_NORMAL,
+        destination_id: int = ID_BROADCAST,
+    ) -> None:
+        """
+        Draw a circle in world-space or local-space (see pushTransform).
+        The circle is an approximation; see numSegments.
+        """
+        if self._sim_debug_line_render:
+            self._sim_debug_line_render.draw_circle(
+                translation, radius, color, num_segments, normal
+            )
+
+        if self._client_message_manager:
+            # Networking not implemented
+            pass
+
+    def draw_transformed_line(
+        self,
+        from_pos: mn.Vector3,
+        to_pos: mn.Vector3,
+        from_color: mn.Color4,
+        to_color: mn.Color4 = None,
+        destination_id: int = ID_BROADCAST,
+    ) -> None:
+        """
+        Draw a line segment in world-space or local-space (see pushTransform) with interpolated color.
+        Specify two colors to interpolate the line color.
+        """
+        if self._sim_debug_line_render:
+            if to_color is None:
+                self._sim_debug_line_render.draw_transformed_line(
+                    from_pos, to_pos, from_color
+                )
+            else:
+                self._sim_debug_line_render.draw_transformed_line(
+                    from_pos, to_pos, from_color, to_color
+                )
+
+        if self._client_message_manager:
+            # Networking not implemented
+            pass
+
+    def draw_path_with_endpoint_circles(
+        self,
+        points: List[mn.Vector3],
+        radius: float,
+        color: mn.Color4,
+        num_segments: int = DEFAULT_SEGMENT_COUNT,
+        normal: mn.Vector3 = DEFAULT_NORMAL,
+        destination_id: int = ID_BROADCAST,
+    ) -> None:
+        """
+        Draw a sequence of line segments with circles at the two endpoints.
+        In world-space or local-space (see pushTransform).
+        """
+        if self._sim_debug_line_render:
+            self._sim_debug_line_render.draw_path_with_endpoint_circles(
+                points, radius, color, num_segments, normal
+            )
+
+        if self._client_message_manager:
+            # Networking not implemented
+            pass

--- a/habitat-hitl/habitat_hitl/core/gui_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/gui_drawer.py
@@ -47,9 +47,11 @@ class GuiDrawer:
         """
         Set global line width for all lines rendered by GuiDrawer.
         """
+        # If server rendering is enabled:
         if self._sim_debug_line_render:
             self._sim_debug_line_render.set_line_width(line_width)
 
+        # If remote rendering is enabled:
         if self._client_message_manager:
             # Networking not implemented
             pass
@@ -62,9 +64,11 @@ class GuiDrawer:
         Push (multiply) a transform onto the transform stack, affecting all line-drawing until popped.
         Must be paired with popTransform().
         """
+        # If server rendering is enabled:
         if self._sim_debug_line_render:
             self._sim_debug_line_render.push_transform(transform)
 
+        # If remote rendering is enabled:
         if self._client_message_manager:
             # Networking not implemented
             pass
@@ -75,9 +79,11 @@ class GuiDrawer:
         """
         See push_transform.
         """
+        # If server rendering is enabled:
         if self._sim_debug_line_render:
             self._sim_debug_line_render.pop_transform()
 
+        # If remote rendering is enabled:
         if self._client_message_manager:
             # Networking not implemented
             pass
@@ -91,9 +97,11 @@ class GuiDrawer:
         """
         Draw a box in world-space or local-space (see pushTransform).
         """
+        # If server rendering is enabled:
         if self._sim_debug_line_render:
             self._sim_debug_line_render.draw_box(min, max, color)
 
+        # If remote rendering is enabled:
         if self._client_message_manager:
             # Networking not implemented
             pass
@@ -134,6 +142,7 @@ class GuiDrawer:
         Draw a line segment in world-space or local-space (see pushTransform) with interpolated color.
         Specify two colors to interpolate the line color.
         """
+        # If server rendering is enabled:
         if self._sim_debug_line_render:
             if to_color is None:
                 self._sim_debug_line_render.draw_transformed_line(
@@ -144,6 +153,7 @@ class GuiDrawer:
                     from_pos, to_pos, from_color, to_color
                 )
 
+        # If remote rendering is enabled:
         if self._client_message_manager:
             # Networking not implemented
             pass
@@ -160,11 +170,13 @@ class GuiDrawer:
         Draw a sequence of line segments with circles at the two endpoints.
         In world-space or local-space (see pushTransform).
         """
+        # If server rendering is enabled:
         if self._sim_debug_line_render:
             self._sim_debug_line_render.draw_path_with_endpoint_circles(
                 points, radius, color, num_segments, normal
             )
 
+        # If remote rendering is enabled:
         if self._client_message_manager:
             # Networking not implemented
             pass

--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -17,6 +17,7 @@ from habitat_hitl._internal.networking.average_rate_tracker import (
 from habitat_hitl._internal.networking.frequency_limiter import (
     FrequencyLimiter,
 )
+from habitat_hitl.core.gui_drawer import GuiDrawer
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.hydra_utils import omegaconf_to_object
 
@@ -124,12 +125,16 @@ def hitl_headed_main(hitl_config, app_config, create_app_state_lambda):
         debug_third_person_height=debug_third_person_height,
     )
 
+    debug_line_drawer = app_renderer._replay_renderer.debug_line_render(
+        0
+    )  # TODO: Null if headless
+
     driver = HitlDriver(
-        app_config,
-        gui_app_wrapper.get_sim_input(),
-        app_renderer._replay_renderer.debug_line_render(0),
-        app_renderer._text_drawer,
-        create_app_state_lambda,
+        config=app_config,
+        gui_input=gui_app_wrapper.get_sim_input(),
+        debug_line_drawer=debug_line_drawer,
+        text_drawer=app_renderer._text_drawer,
+        create_app_state_lambda=create_app_state_lambda,
     )
 
     gui_app_wrapper.set_driver_and_renderer(driver, app_renderer)

--- a/habitat-hitl/habitat_hitl/core/hitl_main.py
+++ b/habitat-hitl/habitat_hitl/core/hitl_main.py
@@ -17,7 +17,6 @@ from habitat_hitl._internal.networking.average_rate_tracker import (
 from habitat_hitl._internal.networking.frequency_limiter import (
     FrequencyLimiter,
 )
-from habitat_hitl.core.gui_drawer import GuiDrawer
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.hydra_utils import omegaconf_to_object
 
@@ -125,9 +124,7 @@ def hitl_headed_main(hitl_config, app_config, create_app_state_lambda):
         debug_third_person_height=debug_third_person_height,
     )
 
-    debug_line_drawer = app_renderer._replay_renderer.debug_line_render(
-        0
-    )  # TODO: Null if headless
+    debug_line_drawer = app_renderer._replay_renderer.debug_line_render(0)
 
     driver = HitlDriver(
         config=app_config,
@@ -219,28 +216,12 @@ def hitl_headless_main(hitl_config, config, create_app_state_lambda=None):
         debug_third_person_height=debug_third_person_height,
     )
 
-    class StubLineRender:
-        """
-        Stub version of DebugLineRender that does nothing.
-
-        DebugLineRender has a large public interface. Rather than duplicate it, let's just
-        allow any method to be called.
-        """
-
-        def __getattr__(self, name):
-            # This method is called for any attribute not found on the object
-            def any_method(*args, **kwargs):
-                # This function accepts any arguments and does nothing
-                return None
-
-            return any_method
-
     driver = HitlDriver(
-        config,
-        GuiInput(),
-        StubLineRender(),
-        HeadlessTextDrawer(),
-        create_app_state_lambda,
+        config=config,
+        gui_input=GuiInput(),
+        debug_line_drawer=None,
+        text_drawer=HeadlessTextDrawer(),
+        create_app_state_lambda=create_app_state_lambda,
     )
 
     _headless_app_loop(hitl_config, driver)

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -15,6 +15,7 @@ from habitat_hitl._internal.networking.average_rate_tracker import (
 from habitat_hitl._internal.networking.interprocess_record import (
     InterprocessRecord,
 )
+from habitat_hitl.core.gui_drawer import GuiDrawer
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.key_mapping import KeyCode
 
@@ -29,13 +30,13 @@ class RemoteClientState:
     def __init__(
         self,
         interprocess_record: InterprocessRecord,
-        debug_line_render,
+        gui_drawer: GuiDrawer,
         gui_input: GuiInput,
     ):
         self._gui_input = gui_input
         self._recent_client_states: List[Any] = []
         self._interprocess_record = interprocess_record
-        self._debug_line_render = debug_line_render
+        self._gui_drawer = gui_drawer
 
         self._receive_rate_tracker = AverageRateTracker(2.0)
 
@@ -189,7 +190,8 @@ class RemoteClientState:
 
     def debug_visualize_client(self):
         """Visualize the received VR inputs (head and hands)."""
-        if not self._debug_line_render:
+        line_renderer = self._gui_drawer.get_sim_debug_line_render()
+        if not line_renderer:
             return
 
         avatar_color = mn.Color3(0.3, 1, 0.3)
@@ -197,7 +199,7 @@ class RemoteClientState:
         pos, rot_quat = self.get_head_pose()
         if pos is not None and rot_quat is not None:
             trans = mn.Matrix4.from_(rot_quat.to_matrix(), pos)
-            self._debug_line_render.push_transform(trans)
+            line_renderer.push_transform(trans)
             color0 = avatar_color
             color1 = mn.Color4(
                 avatar_color.r, avatar_color.g, avatar_color.b, 0
@@ -205,48 +207,47 @@ class RemoteClientState:
             size = 0.5
 
             # Draw a frustum (forward is flipped (z+))
-            self._debug_line_render.draw_transformed_line(
+            line_renderer.draw_transformed_line(
                 mn.Vector3(0, 0, 0),
                 mn.Vector3(size, size, size),
                 color0,
                 color1,
             )
-            self._debug_line_render.draw_transformed_line(
+            line_renderer.draw_transformed_line(
                 mn.Vector3(0, 0, 0),
                 mn.Vector3(-size, size, size),
                 color0,
                 color1,
             )
-            self._debug_line_render.draw_transformed_line(
+            line_renderer.draw_transformed_line(
                 mn.Vector3(0, 0, 0),
                 mn.Vector3(size, -size, size),
                 color0,
                 color1,
             )
-            self._debug_line_render.draw_transformed_line(
+            line_renderer.draw_transformed_line(
                 mn.Vector3(0, 0, 0),
                 mn.Vector3(-size, -size, size),
                 color0,
                 color1,
             )
 
-            self._debug_line_render.pop_transform()
+            line_renderer.pop_transform()
 
         # Draw controller rays (forward is flipped (z+))
         for hand_idx in range(2):
             hand_pos, hand_rot_quat = self.get_hand_pose(hand_idx)
             if hand_pos is not None and hand_rot_quat is not None:
                 trans = mn.Matrix4.from_(hand_rot_quat.to_matrix(), hand_pos)
-                self._debug_line_render.push_transform(trans)
+                line_renderer.push_transform(trans)
                 pointer_len = 0.5
-                self._debug_line_render.draw_transformed_line(
+                line_renderer.draw_transformed_line(
                     mn.Vector3(0, 0, 0),
                     mn.Vector3(0, 0, pointer_len),
                     color0,
                     color1,
                 )
-
-                self._debug_line_render.pop_transform()
+                line_renderer.pop_transform()
 
     def _clean_history_by_connection_id(self, client_states):
         """

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -20,7 +20,6 @@ from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.key_mapping import KeyCode
 
 
-# todo: rename to RemoteClientState
 class RemoteClientState:
     """
     Class that tracks the state of a remote client.
@@ -40,7 +39,7 @@ class RemoteClientState:
 
         self._receive_rate_tracker = AverageRateTracker(2.0)
 
-        self._new_connection_records = None
+        self._new_connection_records: List[Any] = []
 
         # temp map VR button to key
         self._button_map = {

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -190,6 +190,7 @@ class RemoteClientState:
 
     def debug_visualize_client(self):
         """Visualize the received VR inputs (head and hands)."""
+        # Sloppy: Use internal debug_line_render to render on server only.
         line_renderer = self._gui_drawer.get_sim_debug_line_render()
         if not line_renderer:
             return

--- a/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
@@ -107,7 +107,7 @@ class GuiNavigationHelper:
                 adjusted_point.y = mn.Vector3(path.points[path_i + 1]).y
             path_points.append(adjusted_point)
 
-        self._app_service.line_render.draw_path_with_endpoint_circles(
+        self._app_service.gui_drawer.draw_path_with_endpoint_circles(
             path_points, path_endpoint_radius, path_color
         )
 
@@ -297,7 +297,7 @@ class GuiNavigationHelper:
                 normal = (pos - prev_pos).normalized()
                 color_with_alpha = mn.Color4(color)
                 color_with_alpha[3] *= alpha
-                self._app_service.line_render.draw_circle(
+                self._app_service.gui_drawer.draw_circle(
                     pos, radius, color_with_alpha, num_segments, normal
                 )
             prev_pos = pos

--- a/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
@@ -79,16 +79,9 @@ class GuiPickHelper:
 
     def _draw_circle(self, pos, color, radius, billboard):
         num_segments = 24
-        self._app_service.line_render.draw_circle(
-            pos,
-            radius,
-            color,
-            num_segments,
+        self._app_service.gui_drawer.draw_circle(
+            pos, radius, color, num_segments, billboard=billboard
         )
-        if self._app_service.client_message_manager:
-            self._app_service.client_message_manager.add_highlight(
-                pos, radius, billboard=billboard, color=color
-            )
 
     def _add_highlight_ring(
         self, pos, color, radius, do_pulse=False, billboard=True

--- a/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
@@ -120,13 +120,10 @@ class GuiPlacementHelper:
 
     def _draw_circle(self, pos, color, radius, billboard):
         num_segments = 24
-        self._app_service.line_render.draw_circle(
+        self._app_service.gui_drawer.draw_circle(
             pos,
             radius,
             color,
             num_segments,
+            billboard=billboard,
         )
-        if self._app_service.client_message_manager:
-            self._app_service.client_message_manager.add_highlight(
-                pos, radius, billboard=billboard, color=color
-            )

--- a/habitat-hitl/habitat_hitl/environment/gui_throw_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_throw_helper.py
@@ -66,7 +66,7 @@ class GuiThrowHelper:
         vel_vector, path_points = self.compute_velocity_throw(
             robot_root, target_on_floor
         )
-        # TODO: Only render on server.
+        # Sloppy: Use internal debug_line_render to render on server only.
         line_renderer = (
             self._app_service.gui_drawer.get_sim_debug_line_render()
         )

--- a/habitat-hitl/habitat_hitl/environment/gui_throw_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_throw_helper.py
@@ -66,11 +66,16 @@ class GuiThrowHelper:
         vel_vector, path_points = self.compute_velocity_throw(
             robot_root, target_on_floor
         )
-        self._app_service.line_render.draw_path_with_endpoint_circles(
-            path_points, path_endpoint_radius, path_color
+        # TODO: Only render on server.
+        line_renderer = (
+            self._app_service.gui_drawer.get_sim_debug_line_render()
         )
-        self._app_service.line_render.draw_path_with_endpoint_circles(
-            path_points, path_endpoint_radius, path_color
-        )
+        if line_renderer is not None:
+            line_renderer.draw_path_with_endpoint_circles(
+                path_points, path_endpoint_radius, path_color
+            )
+            line_renderer.draw_path_with_endpoint_circles(
+                path_points, path_endpoint_radius, path_color
+            )
 
         return vel_vector


### PR DESCRIPTION
## Motivation and Context

This adds a wrapper for `DebugLineRender`, which also supports networking via `ClientMessageManager`.
* If `DebugLineRender` is `None` (headless mode), server rendering is skipped.
* If `ClientMessageManager` is `None` (local mode), remote rendering is skipped.

Rendering for multiple clients would be supported by either adding a "destination" parameter to `GuiDrawer` functions (relayed to `ClientMessageManager`), or carrying an array of `GuiDrawers` and `ClientMessageManagers`. I think that the former would be simpler in the long run.

## How Has This Been Tested

Tested in all apps along with the Unity mouse/keyboard client.

## Types of changes

- **\[Refactoring\]**
- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
