### PR TITLE
"on_floor" query util

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -166,9 +166,10 @@ def get_bb_for_object_id(
 
     obj = get_obj_from_id(sim, obj_id, ao_link_map)
 
-    assert (
-        obj is not None
-    ), f"object id {obj_id} is not found, this is unexpected. Invalid/stale object id?"
+    if obj is None:
+        raise AssertionError(
+            f"object id {obj_id} is not found, this is unexpected. Invalid/stale object id?"
+        )
 
     if isinstance(obj, habitat_sim.physics.ManagedRigidObject):
         return (obj.root_scene_node.cumulative_bb, obj.transformation)
@@ -974,14 +975,14 @@ def on_floor(
     ao_aabbs: Dict[int, mn.Range3D] = None,
 ) -> bool:
     """
-    Gets whether or not the object is on the "floor" using the navmesh as an abstraction.
+    Checks if the object is heuristically considered to be "on the floor" using the navmesh as an abstraction. This function assumes the PathFinder and parameters provided approximate the navigable floor space well.
     NOTE: alt_pathfinder option can be used to provide an alternative navmesh sized for objects. This would allow objects to be, for example, under tables or in corners and still be considered on the navmesh.
 
     :param sim: The Simulator instance.
     :param object_a: The object instance.
     :param distance_threshold: Maximum allow-able displacement between current object position and navmesh snapped position.
     :param alt_pathfinder:Optionally provide an alternative PathFinder specifically configured for this check. Defaults to sim.pathfinder.
-    :param island_index: Optionally limit allowed navmesh to a specific island. Default (-1) is full navmesh.
+    :param island_index: Optionally limit allowed navmesh to a specific island. Default (-1) is full navmesh. Note the default is likely not good since large furniture objets could have isolated islands on them which are not the floor.
     :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id.
     :param ao_aabbs: A pre-computed map from ArticulatedObject object_ids to their local bounding boxes. If not provided, recomputed as necessary.
 

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -15,18 +15,23 @@ from habitat.sims.habitat_simulator.sim_utilities import (
     get_all_object_ids,
     get_all_objects,
     get_ao_link_id_map,
+    get_ao_root_bbs,
+    get_bb_for_object_id,
     get_obj_from_handle,
     get_obj_from_id,
+    get_obj_size_along,
     get_object_regions,
     object_in_region,
     object_keypoint_cast,
+    on_floor,
     ontop,
+    size_regularized_distance,
     snap_down,
     within,
 )
 from habitat_sim import Simulator, built_with_bullet, stage_id
 from habitat_sim.metadata import MetadataMediator
-from habitat_sim.physics import MotionType
+from habitat_sim.physics import ManagedRigidObject, MotionType
 from habitat_sim.utils.settings import default_sim_settings, make_cfg
 
 
@@ -548,3 +553,132 @@ def test_ontop_util():
             container_object.object_id
         ]
         assert ontop(sim, counter_object.object_id, False) == on_counter
+
+
+@pytest.mark.skipif(
+    not built_with_bullet,
+    reason="Collision detection API requires Bullet physics.",
+)
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/"),
+    reason="Requires ReplicaCAD dataset.",
+)
+def test_on_floor_util():
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    sim_settings["scene"] = "apt_0"
+    hab_cfg = make_cfg(sim_settings)
+    with Simulator(hab_cfg) as sim:
+        all_objects = get_all_object_ids(sim)
+        ao_link_map = get_ao_link_id_map(sim)
+        ao_aabbs = get_ao_root_bbs(sim)
+
+        for obj_id, handle in all_objects.items():
+            obj = get_obj_from_id(sim, obj_id, ao_link_map)
+            if isinstance(obj, ManagedRigidObject):
+                obj_on_floor = on_floor(
+                    sim, obj, ao_link_map=ao_link_map, ao_aabbs=ao_aabbs
+                )
+                print(f"{handle}: {obj_on_floor}")
+                # check a known set of relationships in this scene
+                if "plant" in handle:
+                    assert obj_on_floor, "All potted plants are on the floor."
+                if "lamp" in handle:
+                    assert (
+                        not obj_on_floor
+                    ), "All lamps are on furniture off the floor."
+                if "chair" in handle:
+                    assert (
+                        obj_on_floor
+                    ), "All chairs are furniture on the floor."
+                if "rug" in handle:
+                    assert obj_on_floor, "All rugs are on the floor."
+                if "remote-control" in handle:
+                    assert (
+                        not obj_on_floor
+                    ), "All remotes are on furniture, off the floor."
+                if "picture" in handle:
+                    assert (
+                        not obj_on_floor
+                    ), "All pictures are on furniture, off the floor."
+                if "beanbag" in handle:
+                    assert (
+                        obj_on_floor
+                    ), "All beanbags are furniture on the floor."
+
+        # also test the regularized distance functions directly
+        table_object = get_obj_from_handle(sim, "frl_apartment_table_02_:0000")
+        objects_in_table = [
+            "frl_apartment_choppingboard_02_:0000",
+            "frl_apartment_kitchen_utensil_01_:0000",
+            "frl_apartment_pan_01_:0000",
+            "frl_apartment_bowl_07_:0000",
+            "frl_apartment_kitchen_utensil_05_:0000",
+        ]
+        for obj_handle in objects_in_table:
+            obj = get_obj_from_handle(sim, obj_handle)
+            l2_dist = (obj.translation - table_object.translation).length()
+            reg_dist = size_regularized_distance(
+                sim,
+                table_object.object_id,
+                obj.object_id,
+                ao_link_map,
+                ao_aabbs,
+            )
+            # since the objects are in the shelves of the table, regularized distance is o
+            assert reg_dist == 0, f"{obj_handle}"
+            # L2 distance is computed from CoM or anchor point and will be non-zero
+            assert l2_dist > 0
+
+        objects_on_table = [
+            "frl_apartment_lamp_02_:0001",
+            "frl_apartment_lamp_02_:0000",
+        ]
+        for obj_handle in objects_on_table:
+            obj = get_obj_from_handle(sim, obj_handle)
+            l2_dist = (obj.translation - table_object.translation).length()
+            reg_dist = size_regularized_distance(
+                sim,
+                table_object.object_id,
+                obj.object_id,
+                ao_link_map,
+                ao_aabbs,
+            )
+            # since the objects are "on" the table surface, regularized distance is small, but non-zero
+            assert reg_dist != 0, f"{obj_handle}"
+            assert reg_dist < 0.1, f"{obj_handle}"
+            # L2 distance is computed from CoM or anchor point and will be non-zero
+            assert l2_dist > 0
+            assert l2_dist > reg_dist
+
+        # test distance between two large neighboring objects
+        sofa = get_obj_from_handle(sim, "frl_apartment_sofa_:0000")
+        shelf = get_obj_from_handle(sim, "frl_apartment_wall_cabinet_01_:0000")
+        reg_dist = size_regularized_distance(
+            sim, sofa.object_id, shelf.object_id, ao_link_map, ao_aabbs
+        )
+        assert (
+            reg_dist < 0.1
+        ), "sofa and shelf should be very close heuristically"
+        l2_dist = (sofa.translation - shelf.translation).length()
+        assert l2_dist > reg_dist
+        assert (
+            l2_dist > 1.0
+        ), "sofa is more than 1 meter from center to end, so l2 distance to neighbors is typically large."
+
+        # test the bb size heuristic with known directions
+        sofa.transformation = mn.Matrix4.identity_init()
+        sofa_bb, transform = get_bb_for_object_id(
+            sim, sofa.object_id, ao_link_map, ao_aabbs
+        )
+        assert transform == mn.Matrix4.identity_init()
+        # check the obvious axis-aligned vectors
+        for axis in range(3):
+            vec = mn.Vector3()
+            vec[axis] = 1.0
+            axis_size_along, _center = get_obj_size_along(
+                sim, sofa.object_id, vec, ao_link_map, ao_aabbs
+            )
+            assert axis_size_along == sofa_bb.size()[axis] / 2.0


### PR DESCRIPTION
## Motivation and Context

This PR adds the `on_floor` utility function for heuristically checking whether an object is "on the floor".

Context: we want to know if objects are on the navigable area of the floor for rearrangement. This function checks that the heuristic point-to-surface distance between the object and its nearest navmesh snap point is within an error threshold.

Supporting utilities:
- `get_bb_for_object_id` - a generic utility for getting the local bounding box and transform of any object or link from its object_id integer.
- `get_obj_size_along` - a function to approximate the object's size in a particular global direction from its bounding box size. Uses aabb scale to transform the vector, essentially finding a point on the best-fit ellipsoid within the aabb.
-  `size_regularized_distance` - a function to get estimated surface-to-surface distance between two objects or links using the `get_obj_size_along` function to truncate the center-to-center distance between the objects.

Also includes a few minor refactors to other utilities.

## How Has This Been Tested

Added a set of pytests.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
