### PR TITLE
Fixing rotational bug in `tasks.rearrange.utils.get_camera_transform`

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/utils.py
+++ b/habitat-lab/habitat/tasks/rearrange/utils.py
@@ -13,11 +13,10 @@ from functools import wraps
 from typing import List, Optional, Tuple
 
 import attr
+import habitat_sim
 import magnum as mn
 import numpy as np
 import quaternion
-
-import habitat_sim
 from habitat.articulated_agents.mobile_manipulator import MobileManipulator
 from habitat.articulated_agents.robots.spot_robot import SpotRobot
 from habitat.articulated_agents.robots.stretch_robot import StretchRobot
@@ -741,8 +740,13 @@ def get_camera_transform(cur_articulated_agent) -> mn.Matrix4:
         cam_info.attached_link_id
     ).transformation
     # Get the camera offset transformation
-    offset_trans = mn.Matrix4.translation(cam_info.cam_offset_pos)
-    cam_trans = link_trans @ offset_trans @ cam_info.relative_transform
+    # offset_trans = mn.Matrix4.translation(cam_info.cam_offset_pos)
+    cam_offset_transform = mn.Matrix4.look_at(
+        cam_info.cam_offset_pos,
+        cam_info.cam_look_at_pos,
+        mn.Vector3(0, 1, 0),
+    )
+    cam_trans = link_trans @ cam_offset_transform @ cam_info.relative_transform
     return cam_trans
 
 


### PR DESCRIPTION
## Motivation and Context

Fixes issue #1804 

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Dependency Upgrade\]** Upgrades one or several dependencies in habitat
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!
- **\[Experiment\]** A pull request that add new features to the [habitat-baselines](/habitat-baselines/) training codebase. Experiments Pull Requests can be any size, must have smoke/integration tests and be isolated from the rest of the code. Your code additions should not rely on other habitat-baselines code. This is to avoid dependencies between different parts of habitat-baselines. You must also include a README that will document how to use your new feature or trainer. **You** will be the maintainer of this code, if the code becomes stale or is not supported often enough, we will eventually remove it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
