### PR TITLE
[3.1] Fix missing org name changes.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
-Facebook has adopted a Code of Conduct that we expect project participants to adhere to.
+Meta has adopted a Code of Conduct that we expect project participants to adhere to.
 Please read the [full text](https://code.fb.com/codeofconduct/)
 so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ __Note:__ Pull Requests are not the only way to share your work with habitat. Yo
 
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need
-to do this once to work on any of Facebook's open source projects.
+to do this once to work on any of Meta's open source projects.
 
 Complete your CLA here: <https://code.facebook.com/cla>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ LINKS_NAVBAR2 = [
 ]
 
 FINE_PRINT = f"""
-| {PROJECT_TITLE} {PROJECT_SUBTITLE}. Copyright © 2021 Facebook AI Research.
+| {PROJECT_TITLE} {PROJECT_SUBTITLE}. Copyright © Meta Platforms.
 | `Terms of Use </terms-of-use>`_ `Data Policy </data-policy>`_ `Cookie Policy </cookie-policy>`_
 | Created with `m.css Python doc generator <https://mcss.mosra.cz/documentation/python/>`_."""
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/hrl_rollout_storage.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hrl_rollout_storage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 


### PR DESCRIPTION
## Motivation and Context

This fixes a few missing `Facebook` -> `Meta` org name changes.

## How Has This Been Tested

N/A

## Types of changes

- **\[Docs change\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
