### PR TITLE
HITL - Rename RemoteGuiInput to RemoteClientState.

### DIFF
--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -156,12 +156,12 @@ class AppStatePickThrowVr(AppState):
         assert not self._held_target_obj_idx
         self._recent_reach_pos = None
         self._recent_hand_idx = None
-        remote_gui_input = self._app_service.remote_gui_input
+        remote_client_state = self._app_service.remote_client_state
 
         hand_positions = []
         num_hands = 2
         for i in range(num_hands):
-            hand_pos, _ = remote_gui_input.get_hand_pose(i)
+            hand_pos, _ = remote_client_state.get_hand_pose(i)
             if hand_pos:
                 hand_positions.append(hand_pos)
         if len(hand_positions) == 0:
@@ -170,7 +170,7 @@ class AppStatePickThrowVr(AppState):
 
         grasped_objects_idxs = get_grasped_objects_idxs(self.get_sim())
 
-        remote_button_input = remote_gui_input.get_gui_input()
+        remote_button_input = remote_client_state.get_gui_input()
 
         found_obj_idx = None
         found_hand_idx = None
@@ -229,8 +229,8 @@ class AppStatePickThrowVr(AppState):
         assert self._held_target_obj_idx is not None
         assert self._remote_held_hand_idx is not None
 
-        remote_gui_input = self._app_service.remote_gui_input
-        remote_button_input = remote_gui_input.get_gui_input()
+        remote_client_state = self._app_service.remote_client_state
+        remote_button_input = remote_client_state.get_gui_input()
 
         do_throw = False
         for key in self.get_grasp_keys_by_hand(self._remote_held_hand_idx):
@@ -244,18 +244,18 @@ class AppStatePickThrowVr(AppState):
             rom_obj.collidable = True
 
             hand_idx = self._remote_held_hand_idx
-            history_len = remote_gui_input.get_history_length()
+            history_len = remote_client_state.get_history_length()
             assert history_len >= 2
             history_offset = 1
-            pos1, _ = remote_gui_input.get_hand_pose(
+            pos1, _ = remote_client_state.get_hand_pose(
                 hand_idx, history_index=history_offset
             )
-            pos0, _ = remote_gui_input.get_hand_pose(
+            pos0, _ = remote_client_state.get_hand_pose(
                 hand_idx, history_index=history_len - 1
             )
             if pos0 and pos1:
                 vel = (pos1 - pos0) / (
-                    remote_gui_input.get_history_timestep()
+                    remote_client_state.get_history_timestep()
                     * (history_len - history_offset)
                 )
                 rom_obj.linear_velocity = vel
@@ -266,7 +266,7 @@ class AppStatePickThrowVr(AppState):
             self._remote_held_hand_idx = None
         else:
             # snap to hand
-            hand_pos, hand_rotation = remote_gui_input.get_hand_pose(
+            hand_pos, hand_rotation = remote_client_state.get_hand_pose(
                 self._remote_held_hand_idx
             )
             assert hand_pos is not None
@@ -287,7 +287,7 @@ class AppStatePickThrowVr(AppState):
             walk_dir,
             distance_multiplier,
             forward_dir,
-        ) = self._nav_helper.get_humanoid_walk_hints_from_remote_gui_input(
+        ) = self._nav_helper.get_humanoid_walk_hints_from_remote_client_state(
             visualize_path=False
         )
 
@@ -651,7 +651,7 @@ class AppStatePickThrowVr(AppState):
                 self._app_service.gui_input.get_key_down(GuiInput.KeyNS.T)
                 or (
                     not self._is_remote_active_toggle
-                    and self._app_service.remote_gui_input.get_gui_input().get_any_key_down()
+                    and self._app_service.remote_client_state.get_gui_input().get_any_key_down()
                 )
             )
         ):

--- a/habitat-hitl/habitat_hitl/app_states/app_service.py
+++ b/habitat-hitl/habitat_hitl/app_states/app_service.py
@@ -12,7 +12,7 @@ from habitat import Env
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
 from habitat_hitl.core.client_message_manager import ClientMessageManager
 from habitat_hitl.core.gui_input import GuiInput
-from habitat_hitl.core.remote_gui_input import RemoteGuiInput
+from habitat_hitl.core.remote_client_state import RemoteClientState
 from habitat_hitl.core.serialize_utils import BaseRecorder
 from habitat_hitl.core.text_drawer import AbstractTextDrawer
 from habitat_hitl.environment.controllers.controller_abc import GuiController
@@ -28,7 +28,7 @@ class AppService:
         config,
         hitl_config,
         gui_input: GuiInput,
-        remote_gui_input: RemoteGuiInput,
+        remote_client_state: RemoteClientState,
         line_render: DebugLineRender,
         text_drawer: AbstractTextDrawer,
         get_anim_fraction: Callable,
@@ -46,7 +46,7 @@ class AppService:
         self._config = config
         self._hitl_config = hitl_config
         self._gui_input = gui_input
-        self._remote_gui_input = remote_gui_input
+        self._remote_client_state = remote_client_state
         self._line_render = line_render
         self._text_drawer = text_drawer
         self._get_anim_fraction = get_anim_fraction
@@ -74,8 +74,8 @@ class AppService:
         return self._gui_input
 
     @property
-    def remote_gui_input(self) -> RemoteGuiInput:
-        return self._remote_gui_input
+    def remote_client_state(self) -> RemoteClientState:
+        return self._remote_client_state
 
     @property
     def line_render(self) -> DebugLineRender:

--- a/habitat-hitl/habitat_hitl/core/client_helper.py
+++ b/habitat-hitl/habitat_hitl/core/client_helper.py
@@ -37,7 +37,7 @@ class ClientHelper:
         self._show_idle_kick_warning = False
 
         connection_records = (
-            self._app_service.remote_gui_input.get_new_connection_records()
+            self._app_service.remote_client_state.get_new_connection_records()
         )
         if len(connection_records):
             assert (
@@ -76,7 +76,7 @@ class ClientHelper:
 
     def _update_frame_counter_and_display_latency(self, server_sps):
         recent_server_keyframe_id = (
-            self._app_service.remote_gui_input.pop_recent_server_keyframe_id()
+            self._app_service.remote_client_state.pop_recent_server_keyframe_id()
         )
         if recent_server_keyframe_id is not None:
             new_avg = self._client_frame_latency_avg_helper.add(

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -82,7 +82,7 @@ class ClientMessageManager:
 
     def signal_kick_client(self, connection_id):
         r"""
-        Signal NetworkManager to kick a client identified by connection_id. See also RemoteGuiInput.get_new_connection_records()[i]["connectionId"]. Sloppy: this is a message to NetworkManager, not the client.
+        Signal NetworkManager to kick a client identified by connection_id. See also RemoteClientState.get_new_connection_records()[i]["connectionId"]. Sloppy: this is a message to NetworkManager, not the client.
         """
         self._message["kickClient"] = connection_id
 

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -20,7 +20,7 @@ from habitat_hitl.core.key_mapping import KeyCode
 
 
 # todo: rename to RemoteClientState
-class RemoteGuiInput:
+class RemoteClientState:
     def __init__(
         self,
         interprocess_record: InterprocessRecord,

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -21,6 +21,11 @@ from habitat_hitl.core.key_mapping import KeyCode
 
 # todo: rename to RemoteClientState
 class RemoteClientState:
+    """
+    Class that tracks the state of a remote client.
+    This includes handling of remote input and client messages.
+    """
+
     def __init__(
         self,
         interprocess_record: InterprocessRecord,
@@ -45,12 +50,15 @@ class RemoteClientState:
         }
 
     def get_gui_input(self):
+        """Internal GuiInput class."""
         return self._gui_input
 
     def get_history_length(self):
+        """Length of client state history preserved. Anything beyond this horizon is discarded."""
         return 4
 
     def get_history_timestep(self):
+        """Frequency at which client states are read."""
         return 1 / 60
 
     def pop_recent_server_keyframe_id(self):
@@ -78,6 +86,10 @@ class RemoteClientState:
         return self._recent_client_states[-(1 + history_index)]
 
     def get_head_pose(self, history_index=0):
+        """
+        Get the latest head transform.
+        Beware that this is in agent-space. Agents are flipped 180 degrees on the y-axis such as their z-axis faces forward.
+        """
         client_state = self.get_recent_client_state_by_history_index(
             history_index
         )
@@ -103,6 +115,10 @@ class RemoteClientState:
         return pos, rot_quat
 
     def get_hand_pose(self, hand_idx, history_index=0):
+        """
+        Get the latest hand transforms.
+        Beware that this is in agent-space. Agents are flipped 180 degrees on the y-axis such as their z-axis faces forward.
+        """
         client_state = self.get_recent_client_state_by_history_index(
             history_index
         )
@@ -131,6 +147,7 @@ class RemoteClientState:
         return pos, rot_quat
 
     def _update_input_state(self, client_states):
+        """Update mouse/keyboard input based on new client states."""
         if not len(client_states):
             return
 
@@ -171,6 +188,7 @@ class RemoteClientState:
             self._gui_input._key_held.add(KeyCode(button))
 
     def debug_visualize_client(self):
+        """Visualize the received VR inputs (head and hands)."""
         if not self._debug_line_render:
             return
 
@@ -231,6 +249,10 @@ class RemoteClientState:
                 self._debug_line_render.pop_transform()
 
     def _clean_history_by_connection_id(self, client_states):
+        """
+        Clear history by connection id.
+        Typically done after a client disconnect.
+        """
         if not len(client_states):
             return
 
@@ -256,6 +278,7 @@ class RemoteClientState:
             self.clear_history()
 
     def update(self):
+        """Get the latest received remote client states."""
         self._new_connection_records = (
             self._interprocess_record.get_queued_connection_records()
         )

--- a/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
@@ -111,7 +111,7 @@ class GuiNavigationHelper:
             path_points, path_endpoint_radius, path_color
         )
 
-    def get_humanoid_walk_hints_from_remote_gui_input(
+    def get_humanoid_walk_hints_from_remote_client_state(
         self, visualize_path: bool = True
     ) -> Tuple[Optional[mn.Vector3], float, Optional[mn.Vector3]]:
         """Get humanoid controller hints using the remote client head pose."""
@@ -121,7 +121,7 @@ class GuiNavigationHelper:
         (
             target_pos,
             target_rot_quat,
-        ) = self._app_service.remote_gui_input.get_head_pose()
+        ) = self._app_service.remote_client_state.get_head_pose()
 
         forward_dir = None
         if target_pos and target_rot_quat:


### PR DESCRIPTION
## Motivation and Context

This renames `RemoteGuiInput` to `RemoteClientState`.
As we extend networking features to support multiplayer and large-scale web apps, the responsibility of this class changing. It used to only track remote input - it now tracks all information coming from a client.

## How Has This Been Tested

Tested locally with a Unity client.

## Types of changes

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
