### PR TITLE
HITL - Remote keyboard input redirection.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/gui_application.py
+++ b/habitat-hitl/habitat_hitl/_internal/gui_application.py
@@ -51,7 +51,8 @@ class InputHandlerApplication(Application):
         key = MagnumKeyConverter.convert(event.key)
         if key:
             for wrapper in self._gui_inputs:
-                wrapper._key_held.remove(key)
+                if key in wrapper._key_held:
+                    wrapper._key_held.remove(key)
                 wrapper._key_up.add(key)
 
     def mouse_press_event(self, event: Application.MouseEvent) -> None:

--- a/habitat-hitl/habitat_hitl/_internal/gui_application.py
+++ b/habitat-hitl/habitat_hitl/_internal/gui_application.py
@@ -12,6 +12,7 @@ import magnum as mn
 from magnum.platform.glfw import Application
 
 from habitat_hitl.core.gui_input import GuiInput
+from habitat_hitl.core.key_mapping import MagnumKeyConverter
 
 
 class GuiAppRenderer:
@@ -37,21 +38,21 @@ class InputHandlerApplication(Application):
         self._gui_inputs.append(gui_input)
 
     def key_press_event(self, event: Application.KeyEvent) -> None:
-        key = event.key
-        GuiInput.validate_key(key)
-        for wrapper in self._gui_inputs:
-            # If the key is already held, this is a repeat press event and we should
-            # ignore it.
-            if key not in wrapper._key_held:
-                wrapper._key_held.add(key)
-                wrapper._key_down.add(key)
+        key = MagnumKeyConverter.convert(event.key)
+        if key:
+            for wrapper in self._gui_inputs:
+                # If the key is already held, this is a repeat press event and we should
+                # ignore it.
+                if key not in wrapper._key_held:
+                    wrapper._key_held.add(key)
+                    wrapper._key_down.add(key)
 
     def key_release_event(self, event: Application.KeyEvent) -> None:
-        key = event.key
-        GuiInput.validate_key(key)
-        for wrapper in self._gui_inputs:
-            wrapper._key_held.remove(key)
-            wrapper._key_up.add(key)
+        key = MagnumKeyConverter.convert(event.key)
+        if key:
+            for wrapper in self._gui_inputs:
+                wrapper._key_held.remove(key)
+                wrapper._key_up.add(key)
 
     def mouse_press_event(self, event: Application.MouseEvent) -> None:
         mouse_button = event.button

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -31,6 +31,7 @@ from habitat_hitl._internal.networking.networking_process import (
 from habitat_hitl.app_states.app_service import AppService
 from habitat_hitl.app_states.app_state_abc import AppState
 from habitat_hitl.core.client_message_manager import ClientMessageManager
+from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.hydra_utils import omegaconf_to_object
 from habitat_hitl.core.remote_gui_input import RemoteGuiInput
 from habitat_hitl.core.serialize_utils import (
@@ -167,7 +168,7 @@ class HitlDriver(AppDriver):
 
         self._episode_helper = EpisodeHelper(self.habitat_env)
 
-        self._check_init_server(line_render)
+        self._check_init_server(line_render, gui_input)
 
         def local_end_episode(do_reset=False):
             self._end_episode(do_reset)
@@ -223,7 +224,7 @@ class HitlDriver(AppDriver):
     def network_server_enabled(self) -> bool:
         return self._hitl_config.networking.enable
 
-    def _check_init_server(self, line_render):
+    def _check_init_server(self, line_render, gui_input: GuiInput):
         self._remote_gui_input = None
         self._interprocess_record = None
         if self.network_server_enabled:
@@ -237,7 +238,7 @@ class HitlDriver(AppDriver):
             )
             launch_networking_process(self._interprocess_record)
             self._remote_gui_input = RemoteGuiInput(
-                self._interprocess_record, line_render
+                self._interprocess_record, line_render, gui_input
             )
 
     def _check_terminate_server(self):

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -86,13 +86,6 @@ class HitlDriver(AppDriver):
         self._dataset_config = config.habitat.dataset
         self._play_episodes_filter_str = self._hitl_config.episodes_filter
         self._num_recorded_episodes = 0
-        if (
-            not self._hitl_config.experimental.headless
-            and gui_input.is_stub_implementation
-        ):
-            raise RuntimeError(
-                "HitlDriver with experimental.headless=False requires a non-stub-implementation GuiInput."
-            )
         self._gui_input = gui_input
 
         line_render.set_line_width(self._hitl_config.debug_line_width)

--- a/habitat-hitl/habitat_hitl/core/gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/gui_input.py
@@ -4,70 +4,17 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# GuiInput relies on the magnum.platform.glfw.Application.KeyEvent.Key enum and similar for mouse buttons. On headless systems, we may be unable to import magnum.platform.glfw.Application. Fall back to a stub implementation of GuiInput in that case.
-do_agnostic_gui_input = False
-try:
-    from magnum.platform.glfw import Application
-except ImportError:
-    print(
-        "GuiInput warning: Failed to magnum.platform.glfw. Falling back to agnostic implementation for use with headless server. Local keyboard/mouse input won't work."
-    )
-    do_agnostic_gui_input = True
+from habitat_hitl.core.key_mapping import KeyCode
 
-if do_agnostic_gui_input:
-    from enum import Enum
 
-    # physical key enum from USB HID Usage Tables
-    # https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf, page 53
-    # add missing keys here as necessary
-    class AgnosticKeyNS(Enum):
-        A = 0x04
-        B = 0x05
-        C = 0x06
-        D = 0x07
-        E = 0x08
-        F = 0x09
-        G = 0x0A
-        H = 0x0B
-        I = 0x0C
-        J = 0x0D
-        K = 0x0E
-        L = 0x0F
-        M = 0x10
-        N = 0x11
-        O = 0x12
-        P = 0x13
-        Q = 0x14
-        R = 0x15
-        S = 0x16
-        T = 0x17
-        U = 0x18
-        V = 0x19
-        W = 0x1A
-        X = 0x1B
-        Y = 0x1C
-        Z = 0x1D
-        ZERO = 0x27
-        ONE = 0x1E
-        TWO = 0x1F
-        THREE = 0x20
-        FOUR = 0x21
-        FIVE = 0x22
-        SIX = 0x23
-        SEVEN = 0x24
-        EIGHT = 0x25
-        NINE = 0x26
-        ESC = 0x29
-        SPACE = 0x2C
-        TAB = 0x2B
+class StubNSMeta(type):
+    def __getattr__(cls, name):
+        return None
 
-    class StubNSMeta(type):
-        def __getattr__(cls, name):
-            return None
 
-    # Stub version of Application.MouseEvent.Button
-    class StubMouseNS(metaclass=StubNSMeta):
-        pass
+# Stub version of Application.MouseEvent.Button
+class StubMouseNS(metaclass=StubNSMeta):
+    pass
 
 
 class GuiInput:
@@ -77,12 +24,8 @@ class GuiInput:
     This class isn't usable by itself for getting input from the underlying OS. I.e. it won't self-populate from underlying OS input APIs. See also gui_application.py InputHandlerApplication.
     """
 
-    if do_agnostic_gui_input:
-        KeyNS = AgnosticKeyNS
-        MouseNS = StubMouseNS
-    else:
-        KeyNS = Application.KeyEvent.Key
-        MouseNS = Application.MouseEvent.Button
+    KeyNS = KeyCode
+    MouseNS = StubMouseNS
 
     def __init__(self):
         self._key_held = set()
@@ -97,16 +40,8 @@ class GuiInput:
         self._mouse_scroll_offset = 0
         self._mouse_ray = None
 
-    @property
-    def is_stub_implementation(self):
-        """
-        Indicates whether this is a stub implementation. If so, it'll return False for all queries like get_key_down(...).
-        """
-        return do_agnostic_gui_input
-
     def validate_key(key):
-        if not do_agnostic_gui_input:
-            assert isinstance(key, Application.KeyEvent.Key)
+        assert isinstance(key, KeyCode)
 
     def get_key(self, key):
         GuiInput.validate_key(key)
@@ -124,8 +59,9 @@ class GuiInput:
         return key in self._key_up
 
     def validate_mouse_button(mouse_button):
-        if not do_agnostic_gui_input:
-            assert isinstance(mouse_button, Application.MouseEvent.Button)
+        # if not do_agnostic_gui_input:
+        #    assert isinstance(mouse_button, Application.MouseEvent.Button)
+        pass
 
     def get_mouse_button(self, mouse_button):
         GuiInput.validate_mouse_button(mouse_button)

--- a/habitat-hitl/habitat_hitl/core/key_mapping.py
+++ b/habitat-hitl/habitat_hitl/core/key_mapping.py
@@ -4,11 +4,21 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from enum import Enum
-from typing import Any, Dict, Optional
+from enum import EnumMeta, IntEnum
+from typing import Any, Dict, Optional, Set
 
 
-class KeyCode(Enum):
+class KeyCodeMetaEnum(EnumMeta):
+    keycode_value_cache: Set[int] = None
+
+    # Override 'in' keyword to check whether the specified integer exists in 'KeyCode'.
+    def __contains__(cls, value) -> bool:
+        if KeyCodeMetaEnum.keycode_value_cache == None:
+            KeyCodeMetaEnum.keycode_value_cache = set(KeyCode)
+        return value in KeyCodeMetaEnum.keycode_value_cache
+
+
+class KeyCode(IntEnum, metaclass=KeyCodeMetaEnum):
     """
     Input keys available to control habitat-hitl.
     """

--- a/habitat-hitl/habitat_hitl/core/key_mapping.py
+++ b/habitat-hitl/habitat_hitl/core/key_mapping.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class KeyCode(Enum):
+    """
+    Input keys available to control habitat-hitl.
+    """
+
+    # Physical key enum from USB HID Usage Tables
+    # https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf, page 53
+
+    # fmt: off
+    A       = 0x04
+    B       = 0x05
+    C       = 0x06
+    D       = 0x07
+    E       = 0x08
+    F       = 0x09
+    G       = 0x0A
+    H       = 0x0B
+    I       = 0x0C
+    J       = 0x0D
+    K       = 0x0E
+    L       = 0x0F
+    M       = 0x10
+    N       = 0x11
+    O       = 0x12
+    P       = 0x13
+    Q       = 0x14
+    R       = 0x15
+    S       = 0x16
+    T       = 0x17
+    U       = 0x18
+    V       = 0x19
+    W       = 0x1A
+    X       = 0x1B
+    Y       = 0x1C
+    Z       = 0x1D
+    ZERO    = 0x27
+    ONE     = 0x1E
+    TWO     = 0x1F
+    THREE   = 0x20
+    FOUR    = 0x21
+    FIVE    = 0x22
+    SIX     = 0x23
+    SEVEN   = 0x24
+    EIGHT   = 0x25
+    NINE    = 0x26
+    ESC     = 0x29
+    SPACE   = 0x2C
+    TAB     = 0x2B
+    # fmt: on
+
+
+# On headless systems, we may be unable to import magnum.platform.glfw.Application.
+try:
+    from magnum.platform.glfw import Application
+
+    magnum_enabled = True
+except ImportError:
+    print(
+        "GuiInput warning: Failed to magnum.platform.glfw. Falling back to agnostic implementation for use with headless server. Local keyboard/mouse input won't work."
+    )
+    magnum_enabled = False
+if magnum_enabled:
+    magnum_keymap: Dict[Application.KeyEvent.Key, KeyCode] = {
+        # fmt: off
+        Application.KeyEvent.Key.A       : KeyCode.A     ,
+        Application.KeyEvent.Key.B       : KeyCode.B     ,
+        Application.KeyEvent.Key.C       : KeyCode.C     ,
+        Application.KeyEvent.Key.D       : KeyCode.D     ,
+        Application.KeyEvent.Key.E       : KeyCode.E     ,
+        Application.KeyEvent.Key.F       : KeyCode.F     ,
+        Application.KeyEvent.Key.G       : KeyCode.G     ,
+        Application.KeyEvent.Key.H       : KeyCode.H     ,
+        Application.KeyEvent.Key.I       : KeyCode.I     ,
+        Application.KeyEvent.Key.J       : KeyCode.J     ,
+        Application.KeyEvent.Key.K       : KeyCode.K     ,
+        Application.KeyEvent.Key.L       : KeyCode.L     ,
+        Application.KeyEvent.Key.M       : KeyCode.M     ,
+        Application.KeyEvent.Key.N       : KeyCode.N     ,
+        Application.KeyEvent.Key.O       : KeyCode.O     ,
+        Application.KeyEvent.Key.P       : KeyCode.P     ,
+        Application.KeyEvent.Key.Q       : KeyCode.Q     ,
+        Application.KeyEvent.Key.R       : KeyCode.R     ,
+        Application.KeyEvent.Key.S       : KeyCode.S     ,
+        Application.KeyEvent.Key.T       : KeyCode.T     ,
+        Application.KeyEvent.Key.U       : KeyCode.U     ,
+        Application.KeyEvent.Key.V       : KeyCode.V     ,
+        Application.KeyEvent.Key.W       : KeyCode.W     ,
+        Application.KeyEvent.Key.X       : KeyCode.X     ,
+        Application.KeyEvent.Key.Y       : KeyCode.Y     ,
+        Application.KeyEvent.Key.Z       : KeyCode.Z     ,
+        Application.KeyEvent.Key.ZERO    : KeyCode.ZERO  ,
+        Application.KeyEvent.Key.ONE     : KeyCode.ONE   ,
+        Application.KeyEvent.Key.TWO     : KeyCode.TWO   ,
+        Application.KeyEvent.Key.THREE   : KeyCode.THREE ,
+        Application.KeyEvent.Key.FOUR    : KeyCode.FOUR  ,
+        Application.KeyEvent.Key.FIVE    : KeyCode.FIVE  ,
+        Application.KeyEvent.Key.SIX     : KeyCode.SIX   ,
+        Application.KeyEvent.Key.SEVEN   : KeyCode.SEVEN ,
+        Application.KeyEvent.Key.EIGHT   : KeyCode.EIGHT ,
+        Application.KeyEvent.Key.NINE    : KeyCode.NINE  ,
+        Application.KeyEvent.Key.ESC     : KeyCode.ESC   ,
+        Application.KeyEvent.Key.SPACE   : KeyCode.SPACE ,
+        Application.KeyEvent.Key.TAB     : KeyCode.TAB   ,
+        # fmt: on
+    }
+
+
+class MagnumKeyConverter:
+    def convert(key: Any) -> Optional[KeyCode]:
+        if magnum_enabled and key in magnum_keymap:
+            return magnum_keymap[key]
+        return None

--- a/habitat-hitl/habitat_hitl/core/remote_gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/remote_gui_input.py
@@ -15,6 +15,7 @@ from habitat_hitl._internal.networking.interprocess_record import (
     InterprocessRecord,
 )
 from habitat_hitl.core.gui_input import GuiInput
+from habitat_hitl.core.key_mapping import KeyCode
 
 
 # todo: rename to RemoteClientState
@@ -132,50 +133,41 @@ class RemoteGuiInput:
         if not len(client_states):
             return
 
-        # gather all recent keyDown and keyUp events
+        # Gather all recent keyDown and keyUp events
         for client_state in client_states:
-            # Beware client_state input has dicts of bools (unlike GuiInput, which uses sets)
-            if "input" not in client_state:
-                continue
+            input_json = (
+                client_state["input"] if "input" in client_state else None
+            )
+            # TODO: Add mouse support
+            # mouse_json = (
+            #    client_state["mouse"] if "mouse" in client_state else None
+            # )
 
-            input_json = client_state["input"]
-
-            if "buttonHeld" not in input_json:
-                continue
-
-            # assume button containers are sets of buttonIndices
             for button in input_json["buttonDown"]:
-                if button not in self._button_map:
-                    print(f"button {button} not mapped!")
+                if button not in KeyCode:
                     continue
-                if True:
-                    self._gui_input._key_down.add(self._button_map[button])
+                self._gui_input._key_down.add(KeyCode(button))
             for button in input_json["buttonUp"]:
-                if button not in self._button_map:
-                    print(f"key {button} not mapped!")
+                if button not in KeyCode:
                     continue
-                if True:
-                    self._gui_input._key_up.add(self._button_map[button])
+                self._gui_input._key_up.add(KeyCode(button))
 
         # todo: think about ambiguous GuiInput states (key-down and key-up events in the same
         # frame and other ways that keyHeld, keyDown, and keyUp can be inconsistent.
         client_state = client_states[-1]
-        if "input" not in client_state:
-            return
 
-        input_json = client_state["input"]
+        input_json = client_state["input"] if "input" in client_state else None
+        # TODO: Add mouse support
+        # mouse_json = client_state["mouse"] if "mouse" in client_state else None
 
+        self._gui_input._key_held.clear()
         if "buttonHeld" not in input_json:
             return
 
-        self._gui_input._key_held.clear()
-
         for button in input_json["buttonHeld"]:
-            if button not in self._button_map:
-                print(f"button {button} not mapped!")
+            if button not in KeyCode:
                 continue
-            if True:  # input_json["buttonHeld"][button]:
-                self._gui_input._key_held.add(self._button_map[button])
+            self._gui_input._key_held.add(KeyCode(button))
 
     def debug_visualize_client(self):
         if not self._debug_line_render:

--- a/habitat-hitl/habitat_hitl/core/remote_gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/remote_gui_input.py
@@ -11,12 +11,21 @@ import magnum as mn
 from habitat_hitl._internal.networking.average_rate_tracker import (
     AverageRateTracker,
 )
+from habitat_hitl._internal.networking.interprocess_record import (
+    InterprocessRecord,
+)
 from habitat_hitl.core.gui_input import GuiInput
 
 
 # todo: rename to RemoteClientState
 class RemoteGuiInput:
-    def __init__(self, interprocess_record, debug_line_render):
+    def __init__(
+        self,
+        interprocess_record: InterprocessRecord,
+        debug_line_render,
+        gui_input: GuiInput,
+    ):
+        self._gui_input = gui_input
         self._recent_client_states = []
         self._interprocess_record = interprocess_record
         self._debug_line_render = debug_line_render
@@ -32,8 +41,6 @@ class RemoteGuiInput:
             2: GuiInput.KeyNS.TWO,
             3: GuiInput.KeyNS.THREE,
         }
-
-        self._gui_input = GuiInput()
 
     def get_gui_input(self):
         return self._gui_input

--- a/habitat-hitl/habitat_hitl/core/remote_gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/remote_gui_input.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from typing import Any, List
 
 import magnum as mn
 
@@ -27,7 +28,7 @@ class RemoteGuiInput:
         gui_input: GuiInput,
     ):
         self._gui_input = gui_input
-        self._recent_client_states = []
+        self._recent_client_states: List[Any] = []
         self._interprocess_record = interprocess_record
         self._debug_line_render = debug_line_render
 


### PR DESCRIPTION
## Motivation and Context

This changeset enables remote keyboard input redirection.

It works by assigning `RemoteGuiInput`'s internal `GuiInput` to the application `GuiInput`. Therefore, any key received from a client will update the state as if they were local.
Beware that `RemoteGuiInput` will be renamed to `RemoteClientState`: https://github.com/facebookresearch/habitat-lab/pull/1852

The following changes are applied:
* Add keyboard redirection.
* Move key mapping to its own file.
* Remove `AbstractKeyNS` - only maintain a single keymap for local or remote (`KeyCode` enum).
* Map Magnum keys to `KeyCode`.

## How Has This Been Tested

Tested locally with a Unity client.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
