### PR TITLE
Add remote text rendering to HITL.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -189,6 +189,9 @@ class HitlDriver(AppDriver):
             self.ctrl_helper.get_gui_agent_controllers()
         )
 
+        # TODO: Dependency injection
+        text_drawer._client_message_manager = self._client_message_manager
+
         self._app_service = AppService(
             config=config,
             hitl_config=self._hitl_config,

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -73,18 +73,22 @@ class ClientMessageManager:
                 ]
             message["highlights"].append(highlight_dict)
 
-    def add_text(self, text: str, pos: list[float]):
+    def add_text(
+        self, text: str, pos: list[float], destination_mask: Mask = Mask.ALL
+    ):
         r"""
         Draw text at the specified screen coordinates.
         """
-        if len(text) == 0:
-            return
-        assert len(pos) == 2
-        if "texts" not in self._message:
-            self._message["texts"] = []
-        self._message["texts"].append(
-            {"text": text, "position": [pos[0], pos[1]]}
-        )
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            if len(text) == 0:
+                return
+            assert len(pos) == 2
+            if "texts" not in message:
+                message["texts"] = []
+            message["texts"].append(
+                {"text": text, "position": [pos[0], pos[1]]}
+            )
 
     def change_humanoid_position(
         self, pos: List[float], destination_mask: Mask = Mask.ALL

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -73,6 +73,19 @@ class ClientMessageManager:
                 ]
             message["highlights"].append(highlight_dict)
 
+    def add_text(self, text: str, pos: list[float]):
+        r"""
+        Draw text at the specified screen coordinates.
+        """
+        if len(text) == 0:
+            return
+        assert len(pos) == 2
+        if "texts" not in self._message:
+            self._message["texts"] = []
+        self._message["texts"].append(
+            {"text": text, "position": [pos[0], pos[1]]}
+        )
+
     def change_humanoid_position(
         self, pos: List[float], destination_mask: Mask = Mask.ALL
     ) -> None:


### PR DESCRIPTION
## Motivation and Context

This changeset adds remote text rendering to the HITL server.

It works by relaying all text commands sent to `TextDrawer` to the client. If networking is disabled (local), `client_message_manager` is null.

* Depends on: https://github.com/0mdc/siro_hitl_unity_client/pull/10

https://github.com/facebookresearch/habitat-lab/assets/110583667/6bb4f6a8-6fd7-4c1c-b7ce-09f541d800d7

## How Has This Been Tested

Tested locally and remotely.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
