### PR TITLE
Change server camera sync config name.

### DIFF
--- a/examples/hitl/pick_throw_vr/config/pick_throw_vr.yaml
+++ b/examples/hitl/pick_throw_vr/config/pick_throw_vr.yaml
@@ -28,7 +28,7 @@ habitat_hitl:
   networking:
     client_sync:
       # The client controls its own camera.
-      camera_transform: False
+      server_camera: False
       # This is a first-person application. We don't need to transmit skinned mesh poses.
       skinning: False
 

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -516,7 +516,7 @@ class HitlDriver(AppDriver):
 
         if self.network_server_enabled:
             if (
-                self._hitl_config.networking.client_sync.camera_transform
+                self._hitl_config.networking.client_sync.server_camera
                 and "cam_transform" in post_sim_update_dict
             ):
                 cam_transform: Optional[mn.Matrix4] = post_sim_update_dict[

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -38,8 +38,8 @@ habitat_hitl:
     client_max_idle_duration: ~
 
     client_sync:
-      # If enabled, the main camera transform will be sent to the client. Disable if the client should control its own camera (e.g. VR).
-      camera_transform: True
+      # If enabled, the server main camera transform will be sent to the client. Disable if the client should control its own camera (e.g. VR), or if clients must use different camera transforms (e.g. multiplayer).
+      server_camera: True
       # Enable transmission of skinned mesh poses. If 'camera.first_person_mode' is enabled, you should generally disable this as well as enable `hide_humanoid_in_gui` because the humanoid will occlude the camera.
       skinning: True
 


### PR DESCRIPTION
## Motivation and Context

This small change clarifies that the camera sync option controls whether the _server_ viewport camera is automatically "mirrored" on the clients.

This clarification makes the behavior easier to understand in VR or multiplayer.

## How Has This Been Tested

N/A

## Types of changes

- **\[Docs change\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
