### PR TITLE
HITL: Add client message destination mask.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -44,6 +44,7 @@ from habitat_hitl.core.serialize_utils import (
     save_as_pickle_gzip,
 )
 from habitat_hitl.core.text_drawer import AbstractTextDrawer
+from habitat_hitl.core.user_mask import Users
 from habitat_hitl.environment.controllers.controller_helper import (
     ControllerHelper,
 )
@@ -172,7 +173,9 @@ class HitlDriver(AppDriver):
 
         self._client_message_manager = None
         if self.network_server_enabled:
-            self._client_message_manager = ClientMessageManager()
+            # TODO: Only one user is currently supported.
+            users = Users(1)
+            self._client_message_manager = ClientMessageManager(users)
 
         gui_drawer = GuiDrawer(debug_line_drawer, self._client_message_manager)
         gui_drawer.set_line_width(self._hitl_config.debug_line_width)
@@ -538,10 +541,11 @@ class HitlDriver(AppDriver):
                     if "rigUpdates" in keyframe_obj:
                         del keyframe_obj["rigUpdates"]
                 # Insert server->client message into the keyframe
-                message = self._client_message_manager.get_message_dict()
+                # TODO: Only one user is currently supported.
+                message = self._client_message_manager.get_messages()[0]
                 if len(message) > 0:
                     keyframe_obj["message"] = message
-                    self._client_message_manager.clear_message_dict()
+                    self._client_message_manager.clear_messages()
                 # Send the keyframe
                 self._interprocess_record.send_keyframe_to_networking_thread(
                     keyframe_obj

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -4,29 +4,38 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import magnum as mn
+
+from habitat_hitl.core.user_mask import Mask, Users
 
 
 class ClientMessageManager:
     r"""
-    Extends gfx-replay keyframes to include server messages to be interpreted by the client.
+    Extends gfx-replay keyframes to include server messages to be interpreted by the clients.
+    Unlike keyframes, messages are client-specific.
     """
-    _message: Dict = {}
+    Message = Dict[str, Any]
+    _messages: List[Message]
+    _users: Users
 
-    def get_message_dict(self) -> Dict:
-        r"""
-        Get the server message to be communicated to the client.
-        Add a field to this dict to send a message to the client at the end of the frame.
-        """
-        return self._message
+    def __init__(self, users: Users):
+        self._users = users
+        self.clear_messages()
 
-    def clear_message_dict(self) -> None:
+    def get_messages(self) -> List[Message]:
         r"""
-        Resets the message dict.
+        Get the messages to be communicated to each client.
+        The list is indexed by user ID.
         """
-        self._message = {}
+        return self._messages
+
+    def clear_messages(self) -> None:
+        r"""Resets the messages."""
+        self._messages = []
+        for _ in range(self._users.max_user_count):
+            self._messages.append({})
 
     def add_highlight(
         self,
@@ -34,6 +43,7 @@ class ClientMessageManager:
         radius: float,
         billboard: bool = True,
         color: Optional[Union[mn.Color4, mn.Color3]] = None,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         r"""
         Draw a highlight circle around the specified position.
@@ -41,55 +51,80 @@ class ClientMessageManager:
         assert pos
         assert len(pos) == 3
 
-        if "highlights" not in self._message:
-            self._message["highlights"] = []
-        highlight_dict = {"t": [pos[0], pos[1], pos[2]], "r": radius}
-        if billboard:
-            highlight_dict["b"] = 1
-        if color is not None:
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            if "highlights" not in message:
+                message["highlights"] = []
+            highlight_dict = {"t": [pos[0], pos[1], pos[2]], "r": radius}
+            if billboard:
+                highlight_dict["b"] = 1
+            if color is not None:
 
-            def conv(channel):
-                # sloppy: using int 0-255 to reduce serialized data size
-                return int(channel * 255.0)
+                def conv(channel):
+                    # sloppy: using int 0-255 to reduce serialized data size
+                    return int(channel * 255.0)
 
-            alpha = 1.0 if isinstance(color, mn.Color3) else color.a
-            highlight_dict["c"] = [
-                conv(color.r),
-                conv(color.g),
-                conv(color.b),
-                conv(alpha),
-            ]
-        self._message["highlights"].append(highlight_dict)
+                alpha = 1.0 if isinstance(color, mn.Color3) else color.a
+                highlight_dict["c"] = [
+                    conv(color.r),
+                    conv(color.g),
+                    conv(color.b),
+                    conv(alpha),
+                ]
+            message["highlights"].append(highlight_dict)
 
-    def change_humanoid_position(self, pos: List[float]) -> None:
+    def change_humanoid_position(
+        self, pos: List[float], destination_mask: Mask = Mask.ALL
+    ) -> None:
         r"""
         Change the position of the humanoid.
         Used to synchronize the humanoid position in the client when changing scene.
         """
-        self._message["teleportAvatarBasePosition"] = [pos[0], pos[1], pos[2]]
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            message["teleportAvatarBasePosition"] = [pos[0], pos[1], pos[2]]
 
-    def signal_scene_change(self) -> None:
+    def signal_scene_change(self, destination_mask: Mask = Mask.ALL) -> None:
         r"""
         Signals the client that the scene is being changed during this frame.
         """
-        self._message["sceneChanged"] = True
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            message["sceneChanged"] = True
 
-    def signal_app_ready(self):
+    def signal_app_ready(self, destination_mask: Mask = Mask.ALL):
         r"""
         See hitl_defaults.yaml wait_for_app_ready_signal documentation. Sloppy: this is a message to NetworkManager, not the client.
         """
-        self._message["isAppReady"] = True
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            message["isAppReady"] = True
 
-    def signal_kick_client(self, connection_id):
+    def signal_kick_client(
+        self, connection_id: int, destination_mask: Mask = Mask.ALL
+    ):
         r"""
         Signal NetworkManager to kick a client identified by connection_id. See also RemoteClientState.get_new_connection_records()[i]["connectionId"]. Sloppy: this is a message to NetworkManager, not the client.
         """
-        self._message["kickClient"] = connection_id
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            message["kickClient"] = connection_id
 
-    def set_server_keyframe_id(self, keyframe_id):
-        self._message["serverKeyframeId"] = keyframe_id
+    def set_server_keyframe_id(
+        self, keyframe_id: int, destination_mask: Mask = Mask.ALL
+    ):
+        r"""
+        Set the current keyframe ID.
+        """
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            message["serverKeyframeId"] = keyframe_id
 
-    def update_navmesh_triangles(self, triangle_vertices):
+    def update_navmesh_triangles(
+        self,
+        triangle_vertices: List[List[float]],
+        destination_mask: Mask = Mask.ALL,
+    ):
         r"""
         Send a navmesh. triangle_vertices should be a list of vertices, 3 per triangle.
         Each vertex should be a 3-tuple or similar Iterable of floats.
@@ -97,30 +132,39 @@ class ClientMessageManager:
         assert len(triangle_vertices) > 0
         assert len(triangle_vertices) % 3 == 0
         assert len(triangle_vertices[0]) == 3
-        # flatten to a list of floats for more efficient serialization
-        self._message["navmeshVertices"] = [
-            component for sublist in triangle_vertices for component in sublist
-        ]
 
-    def update_camera_transform(self, cam_transform: mn.Matrix4) -> None:
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            # flatten to a list of floats for more efficient serialization
+            message["navmeshVertices"] = [
+                component
+                for sublist in triangle_vertices
+                for component in sublist
+            ]
+
+    def update_camera_transform(
+        self, cam_transform: mn.Matrix4, destination_mask: Mask = Mask.ALL
+    ) -> None:
         r"""
         Update the main camera transform.
         """
-        pos = cam_transform.translation
-        cam_rotation = mn.Quaternion.from_matrix(cam_transform.rotation())
-        rot_vec = cam_rotation.vector
-        rot = [
-            cam_rotation.scalar,
-            rot_vec[0],
-            rot_vec[1],
-            rot_vec[2],
-        ]
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            pos = cam_transform.translation
+            cam_rotation = mn.Quaternion.from_matrix(cam_transform.rotation())
+            rot_vec = cam_rotation.vector
+            rot = [
+                cam_rotation.scalar,
+                rot_vec[0],
+                rot_vec[1],
+                rot_vec[2],
+            ]
 
-        self._message["camera"] = {}
-        self._message["camera"]["translation"] = [pos[0], pos[1], pos[2]]
-        self._message["camera"]["rotation"] = [
-            rot[0],
-            rot[1],
-            rot[2],
-            rot[3],
-        ]
+            message["camera"] = {}
+            message["camera"]["translation"] = [pos[0], pos[1], pos[2]]
+            message["camera"]["rotation"] = [
+                rot[0],
+                rot[1],
+                rot[2],
+                rot[3],
+            ]

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+from enum import IntFlag
+from math import log2
+from typing import Any, Final, Generator, List
+
+class Mask(IntFlag):
+    """
+    Represents a mask.
+    This is an IntFlag object - bitwise operators can be used.
+    - Example:\n
+    .. code-block:: python
+    user_1_and_3 = Mask.from_index(1) | Mask.from_index(3)
+    """
+    NONE: Final[int] = 0
+    ALL: Final[int] = ~0
+    MAX_VALUE: Final[int] = 32
+
+    @staticmethod
+    def from_index(index: int) -> Mask:
+        """Create a Mask from an index."""
+        return Mask(1 << index)
+    
+    @staticmethod
+    def from_indices(indices: List[int]) -> Mask:
+        """Create a Mask from a list of indices."""
+        mask = Mask(0)
+        for index in indices:
+            mask |= Mask.from_index(index)
+        return mask
+
+    @staticmethod
+    def all_except_index(index: int) -> Mask:
+        """Create a Mask for all indices except one."""
+        return ~(Mask.from_index(index))
+    
+    @staticmethod
+    def all_except_indices(indices: List[int]) -> Mask:
+        """Create a Mask for all indices except a list of indices."""
+        return ~(Mask.from_indices(indices))
+
+class Users():
+    """
+    Represents a set of users with a max_user_count upper bound.
+    """
+    _max_user_mask: Mask
+    _max_user_count: int
+
+    def __init__(self, max_user_count: int) -> None:
+        assert(max_user_count >= 0)
+        assert(max_user_count <= Mask.MAX_VALUE)
+        self._max_user_count = max_user_count
+        self._max_user_mask = 0
+        for _ in range(max_user_count):
+            self._max_user_mask = (self._max_user_mask << 1) + 1
+
+    def indices(self, user_mask: Mask) -> Generator[float, Any, None]:
+        """
+        Generator that allows for iterating upon the specified Mask.
+        - Example:\n
+        .. code-block:: python
+        for user_index in users.indices(Mask.all_except_indices([0,2])):
+            ...
+        """
+        bitset = user_mask & self._max_user_mask
+        while bitset != 0:
+            user_bit = bitset & -bitset
+            user_index = log2(user_bit)
+            yield int(user_index)
+            bitset ^= user_bit
+
+    def to_index_list(self, user_mask: Mask) -> List[float]:
+        """Returns a list of user indices from the specified Mask."""
+        output: List[float] = []
+        for user_index in self.indices(user_mask):
+            output.append(user_index)
+        return output
+    
+    @property
+    def max_user_count(self) -> int:
+        """Returns the size of the user set."""
+        return self._max_user_count
+
+
+if __name__ == "__main__":
+    # TODO: Move this to a unit test when testing is added habitat-hitl.
+    four_users = Users(4)
+    assert(4 == four_users.max_user_count)
+    assert(4 == len(four_users.to_index_list(Mask.ALL)))
+    assert(0 == len(four_users.to_index_list(Mask.NONE)))
+    user_indices = four_users.to_index_list(Mask.from_index(1) | Mask.from_index(2) | Mask.from_index(11))
+    assert(1 in user_indices)
+    assert(2 in user_indices)
+    assert(11 not in user_indices)
+    user_indices = four_users.to_index_list(Mask.all_except_index(1))
+    assert(0 in user_indices)
+    assert(1 not in user_indices)
+    assert(2 in user_indices)
+    assert(3 in user_indices)
+    assert(4 not in user_indices)
+
+    six_users = Users(6)
+    assert(6 == six_users.max_user_count)
+    assert(6 == len(six_users.to_index_list(Mask.ALL)))
+    assert(0 == len(six_users.to_index_list(Mask.NONE)))
+    user_indices = six_users.to_index_list(Mask.all_except_indices([0,2]))
+    assert(0 not in user_indices)
+    assert(1 in user_indices)
+    assert(2 not in user_indices)
+    assert(3 in user_indices)
+    assert(4 in user_indices)
+    assert(5 in user_indices)
+    assert(6 not in user_indices)
+
+    two_users = Users(2)
+    assert(2 == two_users.max_user_count)
+    assert(2 == len(two_users.to_index_list(Mask.ALL)))
+    assert(0 == len(two_users.to_index_list(Mask.NONE)))
+    user_indices = two_users.to_index_list(Mask.from_indices([1,2]))
+    assert(0 not in user_indices)
+    assert(1 in user_indices)
+    assert(2 not in user_indices)
+
+    max_users = Users(32)
+    assert(32 == max_users.max_user_count)
+    assert(32 == len(max_users.to_index_list(Mask.ALL)))
+    assert(0 == len(max_users.to_index_list(Mask.NONE)))
+    assert(30 == len(max_users.to_index_list(Mask.all_except_indices([17, 22]))))
+    assert(2 == len(max_users.to_index_list(Mask.from_indices([3, 15]))))

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -57,7 +57,7 @@ class Users:
     _max_user_count: int
 
     def __init__(self, max_user_count: int) -> None:
-        assert max_user_count >= 0
+        assert max_user_count > 0
         assert max_user_count <= Mask.MAX_VALUE
         self._max_user_count = max_user_count
 


### PR DESCRIPTION
## Motivation and Context

This is the first change that will allow the HITL framework to handle multiplayer.
It introduces a destination mask and a user container, both of which can be used to specify where to relay a specific message.

In this context, a "message" is a portion of a `gfx-replay` keyframe authored by the HITL server. The keyframes are global (they are relayed to all clients), but the message is client-specific.

Right now, by default, all messages are broadcasted. Since we only support 1 client. Therefore, this PR is essentially a noop.

## How Has This Been Tested

Tested locally and on multiplayer prototype.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
