### PR TITLE
[CI] Pin numpy version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
           name: setup
           command: |
               pip install black==23.1.0 --progress-bar off
-              pip install "isort[pyproject]" numpy --progress-bar off
+              pip install "isort[pyproject]" --progress-bar off
+              pip install "numpy>=1.20.0,<1.24.0" --progress-bar off
               pip install mypy==0.991 types-mock types-Pillow types-tqdm types-PyYAML --progress-bar off
               pip install -r habitat-lab/requirements.txt --progress-bar off
       - run:
@@ -335,7 +336,7 @@ jobs:
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-lab/
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-baselines/
       - run:
-          name: Ensure sdist and bdist intall work
+          name: Ensure sdist and bdist install work
           command: |
               cd habitat-lab
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
         additional_dependencies:
          - attrs>=19.1.0
          - hydra-core>=1.2.0
-         - numpy>=1.20.0
+         - "numpy>=1.20.0,<1.24.0"
          - omegaconf>=2.2.3
          - types-mock
          - types-Pillow

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -L -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3
     chmod +x ~/miniconda.sh &&\
     ~/miniconda.sh -b -p /opt/conda &&\
     rm ~/miniconda.sh &&\
-    /opt/conda/bin/conda install numpy pyyaml scipy ipython mkl mkl-include &&\
+    /opt/conda/bin/conda install "numpy>=1.20.0,<1.24.0" pyyaml scipy ipython mkl mkl-include &&\
     /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH
 

--- a/habitat-lab/requirements.txt
+++ b/habitat-lab/requirements.txt
@@ -1,5 +1,5 @@
 gym>=0.22.0,<0.23.1
-numpy>=1.20.0
+numpy>=1.20.0,<1.24.0
 numpy-quaternion>=2019.3.18.14.33.20
 attrs>=19.1.0
 opencv-python>=3.3.0


### PR DESCRIPTION
## Motivation and Context

`habitat-sim` requires `numpy` to be constrained as such: `numpy>=1.20.0,<1.24.0`.

This is a preventive change - An error currently shows up in CI logs, but it does not yet cause CI issues.

## How Has This Been Tested

Tested on CI.

## Types of changes

- **\[Bug Fix\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
