### PR TITLE
HITL - Support multiple remote inputs.

### DIFF
--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -40,6 +40,8 @@ habitat_hitl:
     client_sync:
       # If enabled, the server main camera transform will be sent to the client. Disable if the client should control its own camera (e.g. VR), or if clients must use different camera transforms (e.g. multiplayer).
       server_camera: True
+      # If enabled, the first client input is relayed to the server's GuiInput. Disable if clients have independent controls from the server.
+      server_input: True
       # Enable transmission of skinned mesh poses. If 'camera.first_person_mode' is enabled, you should generally disable this as well as enable `hide_humanoid_in_gui` because the humanoid will occlude the camera.
       skinning: True
 

--- a/habitat-hitl/habitat_hitl/core/key_mapping.py
+++ b/habitat-hitl/habitat_hitl/core/key_mapping.py
@@ -69,7 +69,17 @@ class KeyCode(IntEnum, metaclass=KeyCodeMetaEnum):
     # fmt: on
 
 
-class MouseButton(IntEnum, metaclass=KeyCodeMetaEnum):
+class MouseButtonMetaEnum(EnumMeta):
+    keycode_value_cache: Set[int] = None
+
+    # Override 'in' keyword to check whether the specified integer exists in 'MouseButton'.
+    def __contains__(cls, value) -> bool:
+        if MouseButtonMetaEnum.keycode_value_cache == None:
+            MouseButtonMetaEnum.keycode_value_cache = set(MouseButton)
+        return value in MouseButtonMetaEnum.keycode_value_cache
+
+
+class MouseButton(IntEnum, metaclass=MouseButtonMetaEnum):
     """
     Mouse buttons available to control habitat-hitl.
     """


### PR DESCRIPTION
## Motivation and Context

This changes how we handle `GuiInput` as such:
* `RemoteClientState` creates one `GuiInput` for each user.
* Upon receiving input from a client, the associated input will be controlled. Right now, we only support one client.
* `networking.client_sync.server_input` controls whether `user 0` controls the server. This is the expected usual HITL behavior where the client perfectly mirrors the server and relays its input.

## How Has This Been Tested

Tested locally with remote Unity client.

## Types of changes

- **\[Development\]**

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
