### PR TITLE
HITL - Multiplayer GUI drawer.

### DIFF
--- a/examples/hitl/basic_viewer/basic_viewer.py
+++ b/examples/hitl/basic_viewer/basic_viewer.py
@@ -73,7 +73,6 @@ class AppStateBasicViewer(AppState):
             self._get_camera_lookat_pos(),
             radius,
             mn.Color3(255 / 255, 0 / 255, 0 / 255),
-            24,
         )
 
     @property

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -79,7 +79,9 @@ class AppStatePickThrowVr(AppState):
         assert not self._app_service.hitl_config.camera.first_person_mode
 
         self._nav_helper = GuiNavigationHelper(
-            self._app_service, self.get_gui_controlled_agent_index()
+            self._app_service,
+            self.get_gui_controlled_agent_index(),
+            user_index=0,
         )
         self._throw_helper = GuiThrowHelper(
             self._app_service, self.get_gui_controlled_agent_index()

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -485,12 +485,10 @@ class AppStatePickThrowVr(AppState):
         )
 
     def _draw_circle(self, pos, color, radius):
-        num_segments = 24
         self._app_service.gui_drawer.draw_circle(
             pos,
             radius,
             color,
-            num_segments,
         )
 
     def _add_target_object_highlight_ring(

--- a/examples/hitl/rearrange/rearrange.py
+++ b/examples/hitl/rearrange/rearrange.py
@@ -84,7 +84,9 @@ class AppStateRearrange(AppState):
         )
 
         self._nav_helper = GuiNavigationHelper(
-            self._app_service, self.get_gui_controlled_agent_index()
+            self._app_service,
+            self.get_gui_controlled_agent_index(),
+            user_index=0,
         )
         self._episode_helper = self._app_service.episode_helper
 

--- a/examples/hitl/rearrange/rearrange.py
+++ b/examples/hitl/rearrange/rearrange.py
@@ -123,7 +123,7 @@ class AppStateRearrange(AppState):
             color = mn.Color3(0, 255 / 255, 0)  # green
             goal_position = self._goal_positions[self._held_target_obj_idx]
             self._app_service.gui_drawer.draw_circle(
-                goal_position, end_radius, color, 24
+                goal_position, end_radius, color
             )
 
             self._nav_helper.draw_nav_hint_from_agent(
@@ -140,7 +140,6 @@ class AppStateRearrange(AppState):
                 can_place_position,
                 self._can_grasp_place_threshold,
                 mn.Color3(255 / 255, 255 / 255, 0),
-                24,
             )
 
             if self._app_service.gui_input.get_key_down(GuiInput.KeyNS.SPACE):
@@ -274,7 +273,6 @@ class AppStateRearrange(AppState):
                     can_grasp_position,
                     self._can_grasp_place_threshold,
                     mn.Color3(255 / 255, 255 / 255, 0),
-                    24,
                 )
 
     def get_gui_controlled_agent_index(self):

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -64,10 +64,10 @@ class AppStateRearrangeV2(AppState):
             self._app_service.gui_input,
         )
 
-        self._pick_helper = GuiPickHelper(
-            self._app_service,
+        self._pick_helper = GuiPickHelper(self._app_service, user_index=0)
+        self._placement_helper = GuiPlacementHelper(
+            self._app_service, user_index=0
         )
-        self._placement_helper = GuiPlacementHelper(self._app_service)
         self._client_helper = None
         if self._app_service.hitl_config.networking.enable:
             self._client_helper = ClientHelper(self._app_service)

--- a/habitat-hitl/habitat_hitl/core/gui_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/gui_drawer.py
@@ -9,6 +9,7 @@ from typing import Final, List, Optional
 import magnum as mn
 
 from habitat_hitl.core.client_message_manager import ClientMessageManager
+from habitat_hitl.core.user_mask import Mask
 from habitat_sim.gfx import DebugLineRender
 
 
@@ -43,6 +44,7 @@ class GuiDrawer:
     def set_line_width(
         self,
         line_width: float,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         """
         Set global line width for all lines rendered by GuiDrawer.
@@ -59,6 +61,7 @@ class GuiDrawer:
     def push_transform(
         self,
         transform: mn.Matrix4,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         """
         Push (multiply) a transform onto the transform stack, affecting all line-drawing until popped.
@@ -75,6 +78,7 @@ class GuiDrawer:
 
     def pop_transform(
         self,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         """
         See push_transform.
@@ -93,6 +97,7 @@ class GuiDrawer:
         min_extent: mn.Vector3,
         max_extent: mn.Vector3,
         color: mn.Color4,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         """
         Draw a box in world-space or local-space (see pushTransform).
@@ -114,6 +119,7 @@ class GuiDrawer:
         num_segments: int = DEFAULT_SEGMENT_COUNT,
         normal: mn.Vector3 = DEFAULT_NORMAL,
         billboard: bool = False,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         """
         Draw a circle in world-space or local-space (see pushTransform).
@@ -128,7 +134,11 @@ class GuiDrawer:
         # If remote rendering is enabled:
         if self._client_message_manager:
             self._client_message_manager.add_highlight(
-                translation, radius, billboard=billboard, color=color
+                translation,
+                radius,
+                billboard=billboard,
+                color=color,
+                destination_mask=destination_mask,
             )
 
     def draw_transformed_line(
@@ -137,6 +147,7 @@ class GuiDrawer:
         to_pos: mn.Vector3,
         from_color: mn.Color4,
         to_color: mn.Color4 = None,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         """
         Draw a line segment in world-space or local-space (see pushTransform) with interpolated color.
@@ -165,6 +176,7 @@ class GuiDrawer:
         color: mn.Color4,
         num_segments: int = DEFAULT_SEGMENT_COUNT,
         normal: mn.Vector3 = DEFAULT_NORMAL,
+        destination_mask: Mask = Mask.ALL,
     ) -> None:
         """
         Draw a sequence of line segments with circles at the two endpoints.

--- a/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
@@ -12,6 +12,7 @@ import habitat_sim
 from habitat.datasets.rearrange.navmesh_utils import get_largest_island_index
 from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
 from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.user_mask import Mask
 from habitat_hitl.environment.hablab_utils import get_agent_art_obj_transform
 from habitat_sim.nav import ShortestPath
 
@@ -19,9 +20,12 @@ from habitat_sim.nav import ShortestPath
 class GuiNavigationHelper:
     """Helper for controlling an agent from the GUI."""
 
-    def __init__(self, gui_service: AppService, agent_idx: int) -> None:
+    def __init__(
+        self, gui_service: AppService, agent_idx: int, user_index: int
+    ) -> None:
         self._app_service = gui_service
         self._agent_idx = agent_idx
+        self._user_index = user_index
         self._largest_island_idx: Optional[int] = None
 
     def _get_sim(self) -> RearrangeSim:
@@ -298,6 +302,11 @@ class GuiNavigationHelper:
                 color_with_alpha = mn.Color4(color)
                 color_with_alpha[3] *= alpha
                 self._app_service.gui_drawer.draw_circle(
-                    pos, radius, color_with_alpha, num_segments, normal
+                    pos,
+                    radius,
+                    color_with_alpha,
+                    num_segments,
+                    normal,
+                    destination_mask=Mask.from_index(self._user_index),
                 )
             prev_pos = pos

--- a/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_navigation_helper.py
@@ -112,7 +112,10 @@ class GuiNavigationHelper:
             path_points.append(adjusted_point)
 
         self._app_service.gui_drawer.draw_path_with_endpoint_circles(
-            path_points, path_endpoint_radius, path_color
+            path_points,
+            path_endpoint_radius,
+            path_color,
+            destination_mask=Mask.from_index(self._user_index),
         )
 
     def get_humanoid_walk_hints_from_remote_client_state(

--- a/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
@@ -84,8 +84,8 @@ class GuiPickHelper:
         pos: mn.Vector3,
         radius: float,
         color: mn.Color3,
-        do_pulse=False,
-        billboard=True,
+        do_pulse: bool = False,
+        billboard: bool = True,
     ):
         if do_pulse:
             radius += self._app_service.get_anim_fraction() * RING_PULSE_SIZE

--- a/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
@@ -4,10 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Final
+from typing import Final, List
 
 import magnum as mn
 import numpy as np
+
+from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.user_mask import Mask
 
 DIST_HIGHLIGHT: Final[float] = 0.15
 COLOR_GRASPABLE: Final[mn.Color3] = mn.Color3(1, 0.75, 0)
@@ -21,15 +24,15 @@ RING_PULSE_SIZE: Final[float] = 0.03
 class GuiPickHelper:
     """Helper for picking up objects from the GUI."""
 
-    def __init__(self, gui_service):
-        self._app_service = gui_service
-        self._rom = self._get_sim().get_rigid_object_manager()
-        self._obj_ids = self._get_sim()._scene_obj_ids
-        self._dist_to_highlight_obj = DIST_HIGHLIGHT
-        self._pick_candidate_indices = []
+    def __init__(self, app_service: AppService, user_index: int):
+        self._app_service = app_service
+        self._user_index = user_index
+        self._sim = self._app_service.sim
 
-    def _get_sim(self):
-        return self._app_service.sim
+        self._rom = self._sim.get_rigid_object_manager()
+        self._obj_ids = self._sim._scene_obj_ids
+        self._dist_to_highlight_obj = DIST_HIGHLIGHT
+        self._pick_candidate_indices: List[int] = []
 
     def _closest_point_and_dist_to_ray(
         self, ray_origin, ray_direction_vector, points
@@ -46,9 +49,8 @@ class GuiPickHelper:
         return np.argmin(distances), np.min(distances)
 
     def on_environment_reset(self):
-        sim = self._get_sim()
-        self._rom = sim.get_rigid_object_manager()
-        self._obj_ids = sim._scene_obj_ids
+        self._rom = self._sim.get_rigid_object_manager()
+        self._obj_ids = self._sim._scene_obj_ids
         self._pick_candidate_indices = []
 
     def _closest_point_and_dist_to_query_position(self, points, query_pos):
@@ -77,18 +79,23 @@ class GuiPickHelper:
         else:
             return None
 
-    def _draw_circle(self, pos, color, radius, billboard):
-        num_segments = 24
-        self._app_service.gui_drawer.draw_circle(
-            pos, radius, color, num_segments, billboard=billboard
-        )
-
     def _add_highlight_ring(
-        self, pos, color, radius, do_pulse=False, billboard=True
+        self,
+        pos: mn.Vector3,
+        radius: float,
+        color: mn.Color3,
+        do_pulse=False,
+        billboard=True,
     ):
         if do_pulse:
             radius += self._app_service.get_anim_fraction() * RING_PULSE_SIZE
-        self._draw_circle(pos, color, radius, billboard)
+        self._app_service.gui_drawer.draw_circle(
+            pos,
+            radius,
+            color,
+            billboard=billboard,
+            destination_mask=Mask.from_index(self._user_index),
+        )
 
     def viz_objects(self):
         obj_positions = self._get_object_positions()

--- a/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_pick_helper.py
@@ -108,8 +108,8 @@ class GuiPickHelper:
                 ).transformation.translation
                 self._add_highlight_ring(
                     pos,
-                    COLOR_GRASP_PREVIEW,
                     RADIUS_GRASP_PREVIEW,
+                    COLOR_GRASP_PREVIEW,
                     do_pulse=False,
                 )
             self._pick_candidate_indices = []
@@ -120,7 +120,7 @@ class GuiPickHelper:
                     obj_id
                 ).transformation.translation
                 self._add_highlight_ring(
-                    pos, COLOR_GRASPABLE, RADIUS_GRASPABLE, do_pulse=True
+                    pos, RADIUS_GRASPABLE, COLOR_GRASPABLE, do_pulse=True
                 )
 
     # Reference code

--- a/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
@@ -9,6 +9,8 @@ from typing import Final
 
 import magnum as mn
 
+from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.user_mask import Mask
 from habitat_sim.physics import CollisionGroups
 
 COLOR_PLACE_PREVIEW_VALID: Final[mn.Color3] = mn.Color3(1, 1, 1)
@@ -23,8 +25,14 @@ DEFAULT_GRAVITY = mn.Vector3(0, -1, 0)
 class GuiPlacementHelper:
     """Helper for placing objects from the GUI."""
 
-    def __init__(self, app_service, gravity_dir=DEFAULT_GRAVITY):
+    def __init__(
+        self,
+        app_service: AppService,
+        user_index: int,
+        gravity_dir=DEFAULT_GRAVITY,
+    ):
         self._app_service = app_service
+        self._user_index = user_index
         self._gravity_dir = gravity_dir
 
     def _snap_or_hide_object(self, ray, query_obj) -> tuple[bool, mn.Vector3]:
@@ -101,29 +109,21 @@ class GuiPlacementHelper:
         query_obj.collidable = cached_is_collidable
 
         if success:
-            self._draw_circle(
+            self._app_service.gui_drawer.draw_circle(
                 hint_pos,
                 COLOR_PLACE_PREVIEW_VALID,
                 RADIUS_PLACE_PREVIEW_VALID,
                 billboard=False,
+                destination_mask=Mask.from_index(self._user_index),
             )
         else:
             query_obj.translation = FAR_AWAY_HIDDEN_POSITION
-            self._draw_circle(
+            self._app_service.gui_drawer.draw_circle(
                 hint_pos,
                 COLOR_PLACE_PREVIEW_INVALID,
                 RADIUS_PLACE_PREVIEW_INVALID,
                 billboard=True,
+                destination_mask=Mask.from_index(self._user_index),
             )
 
         return hint_pos if success else None
-
-    def _draw_circle(self, pos, color, radius, billboard):
-        num_segments = 24
-        self._app_service.gui_drawer.draw_circle(
-            pos,
-            radius,
-            color,
-            num_segments,
-            billboard=billboard,
-        )

--- a/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
@@ -29,7 +29,7 @@ class GuiPlacementHelper:
         self,
         app_service: AppService,
         user_index: int,
-        gravity_dir=DEFAULT_GRAVITY,
+        gravity_dir: mn.Vector3 = DEFAULT_GRAVITY,
     ):
         self._app_service = app_service
         self._user_index = user_index

--- a/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/gui_placement_helper.py
@@ -111,8 +111,8 @@ class GuiPlacementHelper:
         if success:
             self._app_service.gui_drawer.draw_circle(
                 hint_pos,
-                COLOR_PLACE_PREVIEW_VALID,
                 RADIUS_PLACE_PREVIEW_VALID,
+                COLOR_PLACE_PREVIEW_VALID,
                 billboard=False,
                 destination_mask=Mask.from_index(self._user_index),
             )
@@ -120,8 +120,8 @@ class GuiPlacementHelper:
             query_obj.translation = FAR_AWAY_HIDDEN_POSITION
             self._app_service.gui_drawer.draw_circle(
                 hint_pos,
-                COLOR_PLACE_PREVIEW_INVALID,
                 RADIUS_PLACE_PREVIEW_INVALID,
+                COLOR_PLACE_PREVIEW_INVALID,
                 billboard=True,
                 destination_mask=Mask.from_index(self._user_index),
             )


### PR DESCRIPTION
## Motivation and Context

This changeset adds a destination mask parameter to all `GuiDrawer` so that a draw commands can be sent to specific clients, rather than broadcasted.

We broadcast by default so that drawing works without change in single player cases.

## How Has This Been Tested

Tested with remote single-player and multi-player Unity clients.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
