### PR TITLE
HITL - Remove interprocess semaphore.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -238,13 +238,8 @@ class HitlDriver(AppDriver):
         self._remote_client_state = None
         self._interprocess_record = None
         if self.network_server_enabled:
-            # How many frames we can simulate "ahead" of what keyframes have been sent.
-            # A larger value increases lag on the client, while ensuring a more reliable
-            # simulation rate in the presence of unreliable network comms.
-            # See also server.py max_send_rate
-            max_steps_ahead = 5
             self._interprocess_record = InterprocessRecord(
-                self._hitl_config.networking, max_steps_ahead
+                self._hitl_config.networking
             )
             launch_networking_process(self._interprocess_record)
             self._remote_client_state = RemoteClientState(


### PR DESCRIPTION
## Motivation and Context

The semaphore in `InterprocessRecord` was added in the initial version (P0) to avoid simulating ahead of the networking thread.

As of now, all keyframes are consolidated (combined) immediately after de-queuing. Therefore, it doesn't matter if the simulation is ahead.

## How Has This Been Tested

Tested on the cloud, in multiplayer.

## Types of changes

- **\[Refactoring\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
