### PR TITLE
Pass ao scaling through to scale the receptacle meshes also

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -304,6 +304,7 @@ class TriangleMeshReceptacle(Receptacle):
         parent_object_handle: str = None,
         parent_link: Optional[int] = None,
         up: Optional[mn.Vector3] = None,
+        scale: Union[float, mn.Vector3] = None,
     ) -> None:
         """
         Initialize the TriangleMeshReceptacle from mesh data and pre-compute the area weighted accumulator.
@@ -313,9 +314,19 @@ class TriangleMeshReceptacle(Receptacle):
         :param parent_object_handle: The rigid or articulated object instance handle for the parent object to which the Receptacle is attached. None for globally defined stage Receptacles.
         :param parent_link: Index of the link to which the Receptacle is attached if the parent is an ArticulatedObject. -1 denotes the base link. None for rigid objects and stage Receptacles.
         :param up: The "up" direction of the Receptacle in local AABB space. Used for optionally culling receptacles in un-supportive states such as inverted surfaces.
+        :param scale: The scaling vector (or uniform scaling float) to be applied to the mesh.
         """
         super().__init__(name, parent_object_handle, parent_link, up)
         self.mesh_data = mesh_data
+
+        # apply the scale
+        if scale is not None:
+            m_verts = self.mesh_data.mutable_attribute(
+                mn.trade.MeshAttribute.POSITION
+            )
+            for vix, v in enumerate(m_verts):
+                m_verts[vix] = v * scale
+
         self.area_weighted_accumulator = (
             []
         )  # normalized float weights for each triangle for sampling
@@ -695,6 +706,7 @@ def parse_receptacles_from_user_config(
                             up=up,
                             parent_object_handle=parent_object_handle,
                             parent_link=parent_link_ix,
+                            scale=ao_uniform_scaling,
                         )
                     )
             else:


### PR DESCRIPTION
## Motivation and Context

Currently, no AO scaling is applied to child receptacles. This PR passes that scaling information into the receptacle mesh loading process.

## How Has This Been Tested

Locally with scaled scene instances.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
