### PR TITLE
Dataset Processing - Add support for groups, articulated scenes, episodes.

### DIFF
--- a/scripts/unity_dataset_processing/decimate.py
+++ b/scripts/unity_dataset_processing/decimate.py
@@ -216,10 +216,14 @@ def decimate(
     )
 
     # And ... done!
-    converter.end_file()
-    importer.close()
+    close()
 
     return (total_source_tris, total_target_tris, total_simplified_tris)
+
+
+def close():
+    converter.end_file()
+    importer.close()
 
 
 def main():

--- a/scripts/unity_dataset_processing/unity_dataset_processing.py
+++ b/scripts/unity_dataset_processing/unity_dataset_processing.py
@@ -10,20 +10,23 @@ import os
 import time
 from multiprocessing import Manager, Pool
 from pathlib import Path
-from typing import Callable, List, Set
+from typing import Any, Callable, Dict, List, Set, Tuple
+import gzip
 
 import decimate
 
-OUTPUT_DIR = "data/hitl_simplified/data/"
+OUTPUT_DIR = "data/_processing_output/"
 OMIT_BLACK_LIST = False
 OMIT_GRAY_LIST = False
 PROCESS_COUNT = os.cpu_count()
 
 
 class Job:
-    source_path: str
-    dest_path: str
-    simplify: bool
+    def __init__(self, asset_path: str, output_dir: str, groups: List[str], simplify: bool):
+        self.source_path = asset_path
+        self.dest_path = os.path.join(output_dir, asset_path)
+        self.groups = groups
+        self.simplify = simplify
 
 
 class Config:
@@ -33,9 +36,33 @@ class Config:
     use_multiprocessing: bool = False
 
 
+def file_is_object_config(filepath: str) -> bool:
+    """
+    Return whether or not the file is an object_config.json
+    """
+    return filepath.endswith(".object_config.json")
+
+def file_is_render_asset_config(filepath: str) -> bool:
+    """
+    Return if the file is either:
+    * object_config.json
+    * ao_config.json
+    * stage_config.json
+    All of these files are guaranteed to have a 'render_asset' field.
+    """
+    return (filepath.endswith(".object_config.json") or
+            filepath.endswith(".ao_config.json") or
+            filepath.endswith(".stage_config.json"))
+
+def file_is_scene_dataset_config(filepath: str) -> bool:
+    """
+    Return whether or not the file is a scene_dataset_config.json
+    """
+    return filepath.endswith(".scene_dataset_config.json")
+
 def file_is_scene_config(filepath: str) -> bool:
     """
-    Return whether or not the file is an scene_instance.json
+    Return whether or not the file is a scene_instance.json
     """
     return filepath.endswith(".scene_instance.json")
 
@@ -46,6 +73,33 @@ def file_is_glb(filepath: str) -> bool:
     """
     return filepath.endswith(".glb")
 
+
+def file_is_episode_set(filepath: str) -> bool:
+    """
+    Return whether or not the file is an json.gz
+    """
+    return filepath.endswith(".json.gz")
+
+
+def verify_jobs(jobs: List[Job], output_path: str) -> None:
+    source_set: Set[str] = set()
+    dest_set: Set[str] = set()
+    for job in jobs:
+        # Check that all assets exist.
+        assert Path(job.source_path).is_file(), f"Source path is not a file: '{job.source_path}'."
+        # Check that all source paths start with "data/".
+        prefix = "data/"
+        prefix_length = len(prefix)
+        assert str(job.source_path)[0:prefix_length] == prefix, f"Source path not in '{prefix}': '{job.source_path}'."
+        # Check that all dest paths start with "{output_path}/data/"
+        prefix = os.path.join(output_path, "data/")
+        prefix_length = len(prefix)
+        assert str(job.dest_path)[0:prefix_length] == prefix, f"Dest path not in '{prefix}': '{job.dest_path}'."
+        # Check that all job paths are unique.
+        assert not job.source_path in source_set, f"Duplicate source asset: '{job.source_path}'."
+        assert not job.dest_path in dest_set, f"Duplicate destination asset: '{job.dest_path}'."
+        source_set.add(job.source_path)
+        dest_set.add(job.dest_path)
 
 def find_files(
     root_dir: str, discriminator: Callable[[str], bool]
@@ -75,37 +129,251 @@ def find_files(
     return filepaths
 
 
-def get_model_ids_from_scene_instance_json(filepath: str) -> List[str]:
-    """
-    Scrape a list of all unique model ids from the scene instance file.
-    """
-    assert filepath.endswith(
-        ".scene_instance.json"
-    ), "Must be a scene instance JSON."
 
-    model_ids = []
+def search_dataset_render_assets(scene_dataset_dir: str, directory_search_patterns: List[str]) -> Dict[str, str]:
+    """
+    scene_dataset_dir: "data/scene_datasets/hssd-hab"
+    directory_search_patterns: ["objects/*", "objects/decomposed/*"]
+    """
+    output: Dict[str, str] = {}
+    object_config_json_path_cache: set[str] = set()
 
-    with open(filepath, "r") as f:
-        scene_conf = json.load(f)
-        if "object_instances" in scene_conf:
-            for obj_inst in scene_conf["object_instances"]:
-                model_ids.append(obj_inst["template_name"])
-        else:
-            print(
-                "No object instances field detected, are you sure this is scene instance file?"
+    for directory_search_pattern in directory_search_patterns:
+        # > "data/scene_datasets/hssd-hab/objects/*"
+        object_config_search_pattern = os.path.join(scene_dataset_dir, directory_search_pattern)
+        # > "data/scene_datasets/hssd-hab/objects"
+        object_config_search_dir = Path(object_config_search_pattern)
+        while not Path.is_dir(object_config_search_dir):
+            object_config_search_dir = object_config_search_dir.parent
+        # Find all object configs in the specified path
+        # > "data/scene_datasets/hssd-hab/objects/2/2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3.object_config.json"
+        object_config_json_paths = find_files(object_config_search_dir, file_is_render_asset_config)
+        for object_config_json_path in object_config_json_paths:
+            # Ignore object if already found.
+            if object_config_json_path in object_config_json_path_cache:
+                continue
+            object_config_json_path_cache.add(object_config_json_path)
+            object_config = load_json(object_config_json_path)
+            # > "2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3.glb"
+            object_render_asset_file_name = object_config["render_asset"]
+            # > "2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3
+            object_template_name = Path(object_render_asset_file_name).stem
+            # > "data/scene_datasets/hssd-hab/objects/2"
+            object_render_asset_dir = Path(object_config_json_path).parent
+            # > "data/scene_datasets/hssd-hab/objects/2/2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3.glb"
+            object_render_asset_path = os.path.join(object_render_asset_dir, object_render_asset_file_name)
+            output[object_template_name] = object_render_asset_path
+
+    return output
+
+
+class SceneDataset:
+    """
+    Upon construction, loads a scene_dataset_config.json file and exposes its content.
+    """
+    # Location of the scene_dataset_config.json.
+    # > "data/scene_datasets/hssd-hab"
+    scene_dataset_dir: str
+
+    # Maps of template_name to render_asset path.
+    # > Key: "2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3"
+    # > Value: "data/scene_datasets/hssd-hab/objects/2/2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3.glb"
+    objects: Dict[str, str] = {}
+    articulated_objects: Dict[str, str] = {}
+    stages: Dict[str, str] = {}
+
+    def __init__(self, scene_dataset_config_path: str):
+        self.scene_dataset_dir: str = Path(scene_dataset_config_path).parent
+        scene_dataset_config = load_json(scene_dataset_config_path)
+
+        # Find objects.
+        if "objects" in scene_dataset_config:
+            self.objects = search_dataset_render_assets(self.scene_dataset_dir,
+                                                scene_dataset_config["objects"]["paths"][".json"])
+
+        # Find articulated objects.
+        if "articulated_objects" in scene_dataset_config:
+            self.articulated_objects = search_dataset_render_assets(self.scene_dataset_dir,
+                                                            scene_dataset_config["articulated_objects"]["paths"][".json"])
+
+        # Find stages.
+        if "stages" in scene_dataset_config:
+            self.stages = search_dataset_render_assets(self.scene_dataset_dir,
+                                            scene_dataset_config["stages"]["paths"][".json"])
+    
+    def resolve_object(self, template_name: str) -> str:
+        stem = Path(template_name).stem
+        return self.objects[stem]
+    
+    def resolve_articulated_object(self, template_name: str) -> str:
+        stem = Path(template_name).stem
+        return self.articulated_objects[stem]
+    
+    def resolve_stage(self, template_name: str) -> str:
+        stem = Path(template_name).stem
+        return self.stages[stem]
+
+
+class ObjectDataset:
+    """
+    Represents a dataset that does not include a scene_dataset_config.json file.
+    Typically, this is a folder referenced from an episode's "additional_obj_config_paths" field.
+    These special datasets only contain regular objects - no stage or articulated objects.
+    """
+    render_assets: List[str] = []
+
+    def __init__(self, dataset_path: str):
+        assert Path(dataset_path).is_dir()
+        object_config_json_paths = find_files(dataset_path, file_is_object_config)
+        object_config_cache: Set[str] = set()
+        for object_config_json_path in object_config_json_paths:
+            # Ignore object if already found.
+            if object_config_json_path in object_config_cache:
+                continue
+            object_config_cache.add(object_config_json_path)
+            object_config = load_json(object_config_json_path)
+            # > "2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3.glb"
+            object_render_asset_file_name = object_config["render_asset"]
+            # > "data/scene_datasets/hssd-hab/objects/2"
+            object_render_asset_dir = Path(object_config_json_path).parent
+            # > "data/scene_datasets/hssd-hab/objects/2/2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3.glb"
+            object_render_asset_path = os.path.join(object_render_asset_dir, object_render_asset_file_name)
+            self.render_assets.append(object_render_asset_path)
+
+class SceneInstance:
+    """
+    Upon construction, loads a scene_instance.json file and exposes its content.
+    """
+    group_name: str
+    stage_render_asset: str
+    object_render_assets: List[str]
+    articulated_object_render_assets: List[str]
+
+    def __init__(self, group_name: str, scene_instance_config_path: str, scene_dataset: SceneDataset) -> None:
+        self.group_name = group_name
+        scene_instance_config = load_json(scene_instance_config_path)
+
+        template_name = scene_instance_config["stage_instance"]["template_name"]
+        self.stage_render_asset = scene_dataset.resolve_stage(template_name)
+
+        object_render_assets = set()
+        for instance in scene_instance_config["object_instances"]:
+            template_name = instance["template_name"]
+            object_render_assets.add(scene_dataset.resolve_object(template_name))
+        self.object_render_assets = list(object_render_assets)
+
+        articulated_object_render_assets = set()
+        for instance in scene_instance_config["articulated_object_instances"]:
+            template_name = instance["template_name"]
+            articulated_object_render_assets.add(scene_dataset.resolve_articulated_object(template_name))
+        self.articulated_object_render_assets = list(articulated_object_render_assets)
+
+
+
+
+class AssetInfo:
+    """
+    Asset and the groups that contain it.
+    Path is complete and relative to repository root (data/asset/blob.glb).
+    """
+    asset_path: str
+    groups: List[str]
+
+    def __init__(self, asset_path: str, groups: List[str]):
+        self.asset_path = asset_path
+        self.groups = groups
+
+class GroupedSceneAssets:
+    """
+    All assets in the scenes along with their groups.
+    Paths are complete and relative to repository root (data/asset/blob.glb).
+    """
+    stages: List[AssetInfo] = []
+    objects: List[AssetInfo] = []
+    articulated_objects: List[AssetInfo] = []
+
+    def __init__(self, scene_instances: List[SceneInstance]):
+        stage_groups: Dict[str, List[str]] = {}
+        object_groups: Dict[str, List[str]] = {}
+        articulated_object_groups: Dict[str, List[str]] = {}
+
+        def add_group_reference(asset_path: str, group_name: str, groups: Dict[str, List[str]]) -> None:
+            if asset_path not in groups:
+                groups[asset_path] = []
+            groups[asset_path].append(group_name)
+
+        for scene_instance in scene_instances:
+            add_group_reference(
+                scene_instance.stage_render_asset,
+                scene_instance.group_name,
+                stage_groups
             )
+            for obj in scene_instance.object_render_assets:
+                add_group_reference(
+                    obj,
+                    scene_instance.group_name,
+                    object_groups
+                )
+            for art_obj in scene_instance.articulated_object_render_assets:
+                add_group_reference(
+                    art_obj,
+                    scene_instance.group_name,
+                    articulated_object_groups
+                )
 
-    print(f" {filepath} has {len(model_ids)} object instances.")
-    model_ids = list(set(model_ids))
-    print(f" {filepath} has {len(model_ids)} unique objects.")
+        for asset_path, groups in stage_groups.items():
+            self.stages.append(AssetInfo(asset_path, groups))
+        for asset_path, groups in object_groups.items():
+            self.objects.append(AssetInfo(asset_path, groups))
+        for asset_path, groups in articulated_object_groups.items():
+            self.articulated_objects.append(AssetInfo(asset_path, groups))
+        
+        
+class EpisodeSet:
+    """
+    Loads and episode set and exposes its assets.
+    """
+    grouped_scene_assets: GroupedSceneAssets
+    additional_datasets: Dict[str, ObjectDataset] = {}
 
-    return model_ids
+    def __init__(self, episodes_path: str):
+        assert file_is_episode_set(episodes_path), "Episodes must be supplied as a '.json.gz' file."
+        with gzip.open(episodes_path, "rb") as file:
+            json_data = file.read().decode("utf-8")
+            loaded_data = json.loads(json_data)
+        episodes: List[Dict[Any]] = loaded_data["episodes"]
 
+        scene_datasets: Dict[str, SceneDataset] = {}
+        scene_instances: Dict[str, SceneInstance] = {}
+        additional_dataset_paths: Set[str] = set()
+        for episode in episodes:
+            # > "data/scene_datasets/hssd-hab/hssd-hab-uncluttered.scene_dataset_config.json"
+            scene_dataset_config_path = episode["scene_dataset_config"]
+            # Load dataset.
+            if scene_dataset_config_path not in scene_datasets:
+                scene_datasets[scene_dataset_config_path] = SceneDataset(scene_dataset_config_path)
+            scene_dataset = scene_datasets[scene_dataset_config_path]
+            # > "data/scene_datasets/hssd-hab/scenes-uncluttered/102344193.scene_instance.json"
+            scene_instance_config_path = episode["scene_id"]
+            # Load scene instance.
+            if scene_instance_config_path not in scene_instances:
+                scene_instances[scene_instance_config_path] = SceneInstance(
+                    group_name=scene_instance_config_path,
+                    scene_instance_config_path=scene_instance_config_path,
+                    scene_dataset=scene_dataset)
+            # Find additional datasets referenced by the episode.
+            if "additional_obj_config_paths" in episode:
+                for additional_dataset_path in episode["additional_obj_config_paths"]:
+                    # > "data/objects/ycb/configs/"
+                    additional_dataset_paths.add(additional_dataset_path)
 
-def validate_jobs(jobs: List[Job]):
-    for job in jobs:
-        assert Path(job.source_path).exists
-        assert job.dest_path != None and job.dest_path != ""
+        # Load additional datasets (e.g. ycb).
+        for additional_dataset_path in additional_dataset_paths:
+            self.additional_datasets[additional_dataset_path] = ObjectDataset(additional_dataset_path)
+
+        # Group assets per scene dependencies.            
+        self.grouped_scene_assets = GroupedSceneAssets(scene_instances.values())
+
 
 
 def process_model(args):
@@ -155,7 +423,9 @@ def process_model(args):
         "source_tris": source_tris,
         "simplified_tris": simplified_tris,
         "source_path": job.source_path,
+        "dest_path": job.dest_path,
         "status": "ok",
+        "groups": job.groups
     }
 
     if simplified_tris > target_tris * 2 and simplified_tris > 3000:
@@ -189,7 +459,6 @@ def simplify_models(jobs: List[Job], config: Config):
     total_skipped = 0
     total_error = 0
 
-    validate_jobs(jobs)
     total_models = len(jobs)
 
     # Initialize counter and lock
@@ -248,63 +517,34 @@ def simplify_models(jobs: List[Job], config: Config):
             print("    " + item + ",")
         print("]")
 
+    # Create the dataset.json file containing all dependencies.
+    groups: Dict[str, List[str]] = {}
+    for result in results:
+        if result["status"] == "ok" and "groups" in result:
+            pkgs = result["groups"]
+            for pkg in pkgs:
+                file_rel_path = result["dest_path"].removeprefix(OUTPUT_DIR)
+                if pkg not in groups:
+                    groups[pkg] = []
+                groups[pkg].append(file_rel_path)
+    groups_json_path = os.path.join(OUTPUT_DIR, "dataset.json")
+    with open(groups_json_path, 'w') as f:
+        json.dump(groups, f, ensure_ascii=False)
+
     elapsed_time = time.time() - start_time
     print(f"Elapsed time (s): {elapsed_time}")
     if not config.use_multiprocessing:
         print("Add --use-multiprocessing to speed-up processing.")
 
 
-def find_model_paths_in_scenes(hssd_hab_root_dir, scene_ids) -> List[str]:
-    model_filepaths: Set[str] = set()
-    config_root_dir = os.path.join(hssd_hab_root_dir, "scenes-uncluttered")
-    configs = find_files(config_root_dir, file_is_scene_config)
-    obj_root_dir = os.path.join(hssd_hab_root_dir, "objects")
-    glb_files = find_files(obj_root_dir, file_is_glb)
-    render_glbs = [
-        f
-        for f in glb_files
-        if (".collider" not in f and ".filteredSupportSurface" not in f)
-    ]
-
-    for filepath in configs:
-        # these should be removed, but screen them for now
-        if "orig" in filepath:
-            print(f"Skipping alleged 'original' instance file {filepath}")
-            continue
-        for scene_id in scene_ids:
-            # NOTE: add the extension back here to avoid partial matches
-            if scene_id + ".scene_instance.json" in filepath:
-                print(f"filepath '{filepath}' matches scene_id '{scene_id}'")
-                model_ids = get_model_ids_from_scene_instance_json(filepath)
-                for model_id in model_ids:
-                    for render_glb in render_glbs:
-                        if model_id + ".glb" in render_glb:
-                            if "part" in render_glb and "part" not in model_id:
-                                continue
-                            model_filepaths.add(render_glb)
-
-    return list(model_filepaths)
-
+def load_json(path: str) -> Dict[str, Any]:
+    with open(path) as file:
+        output = json.load(file)
+        return output
 
 def main():
     parser = argparse.ArgumentParser(
         description="Get all .glb render asset files associated with a given scene."
-    )
-    parser.add_argument(
-        "--hssd-hab-root-dir",
-        type=str,
-        help="Path to the hssd-hab root directory containing 'hssd-hab-uncluttered.scene_dataset_config.json'.",
-    )
-    parser.add_argument(
-        "--hssd-models-root-dir",
-        type=str,
-        help="Path to hssd-models root directory.",
-    )
-    parser.add_argument(
-        "--scenes",
-        nargs="+",
-        type=str,
-        help="one or more scene ids",
     )
     parser.add_argument(
         "--verbose",
@@ -318,82 +558,74 @@ def main():
         default=False,
         help="Enable multiprocessing.",
     )
-
     args = parser.parse_args()
     config = Config()
     config.verbose = args.verbose
     config.use_multiprocessing = args.use_multiprocessing
 
-    # Force input paths to have a trailing slash
-    if args.hssd_hab_root_dir[-1] != "/":
-        args.hssd_hab_root_dir += "/"
-    if args.hssd_models_root_dir[-1] != "/":
-        args.hssd_models_root_dir += "/"
+    # TODO: Parameterize
+    episodes_raw = "data/episodes/rearrange_ep_dataset.json.gz"
+
+    # Load episodes.
+    episode_set = EpisodeSet(episodes_raw)
 
     jobs: List[Job] = []
-    scene_ids = list(dict.fromkeys(args.scenes)) if args.scenes else []
 
-    # Define relative directory for the dataset
-    # E.g. data/scene_datasets/hssd-hab -> scene_datasets/hssd-hab
-    hssd_hab_rel_dir = str(args.hssd_hab_root_dir)[len("data/") :]
+    # Add scene stages.
+    # Grouped by scenes.
+    for obj in episode_set.grouped_scene_assets.stages:
+        jobs.append(Job(
+            asset_path=obj.asset_path,
+            output_dir=OUTPUT_DIR,
+            groups=obj.groups,
+            simplify=False,
+        ))
 
-    # Add stages
-    for scene_id in scene_ids:
-        rel_path = os.path.join("stages", scene_id + ".glb")
-        job = Job()
-        job.source_path = os.path.join(args.hssd_hab_root_dir, rel_path)
-        job.dest_path = os.path.join(OUTPUT_DIR, hssd_hab_rel_dir, rel_path)
-        job.simplify = False
-        jobs.append(job)
+    # Add scene objects.
+    # Grouped by scenes.
+    for obj in episode_set.grouped_scene_assets.objects:
+        jobs.append(Job(
+            asset_path=obj.asset_path,
+            output_dir=OUTPUT_DIR,
+            groups=obj.groups,
+            simplify=True,
+        ))
 
-    # Add all models contained in the scenes
-    scene_models = find_model_paths_in_scenes(
-        args.hssd_hab_root_dir, scene_ids
-    )
-    for scene_model in scene_models:
-        rel_path = scene_model[len(args.hssd_hab_root_dir) :]
-        if "decomposed" not in scene_model:
-            job = Job()
-            source_path = os.path.join(args.hssd_models_root_dir, rel_path)
-            parts = source_path.split(
-                "/objects/"
-            )  # Remove 'objects/' from path
-            job.source_path = os.path.join(parts[0], parts[1])
-            assert len(parts) == 2
-            job.dest_path = os.path.join(
-                OUTPUT_DIR, hssd_hab_rel_dir, rel_path
-            )
-            job.simplify = False
-            jobs.append(job)
-        else:
-            job = Job()
-            job.source_path = os.path.join(args.hssd_hab_root_dir, rel_path)
-            job.dest_path = os.path.join(
-                OUTPUT_DIR, hssd_hab_rel_dir, rel_path
-            )
-            job.simplify = False
-            jobs.append(job)
+    # Add articulated objects.
+    # Grouped by scenes.
+    for obj in episode_set.grouped_scene_assets.articulated_objects:
+        jobs.append(Job(
+            asset_path=obj.asset_path,
+            output_dir=OUTPUT_DIR,
+            groups=obj.groups,
+            simplify=False,
+        ))
 
-    # Add ycb objects
-    for filename in Path("data/objects/ycb/meshes").rglob("*.glb"):
-        rel_path = str(filename)[len("data/") :]
-        job = Job()
-        job.source_path = os.path.join("data", rel_path)
-        job.dest_path = os.path.join(OUTPUT_DIR, rel_path)
-        job.simplify = False
-        jobs.append(job)
+    # Add additional datasets.
+    for dataset in episode_set.additional_datasets.values():
+        for asset_path in dataset.render_assets:
+            jobs.append(Job(
+                asset_path=asset_path,
+                output_dir=OUTPUT_DIR,
+                groups=[],
+                simplify=False,
+            ))
 
     # Add spot models
     for filename in Path("data/robots/hab_spot_arm/meshesColored").rglob(
         "*.glb"
     ):
-        rel_path = str(filename)[len("data/") :]
-        job = Job()
-        job.source_path = os.path.join("data", rel_path)
-        job.dest_path = os.path.join(OUTPUT_DIR, rel_path)
-        job.simplify = False
-        jobs.append(job)
+        jobs.append(Job(
+            asset_path=filename,
+            output_dir=OUTPUT_DIR,
+            groups=[],
+            simplify=False,
+        ))
 
+    # Verify jobs.
+    verify_jobs(jobs, OUTPUT_DIR)
+    
+    # Start processing.
     simplify_models(jobs, config)
 
 

--- a/scripts/unity_dataset_processing/unity_dataset_processing.py
+++ b/scripts/unity_dataset_processing/unity_dataset_processing.py
@@ -852,6 +852,8 @@ def main():
     additional_asset_group_size = 50
     objects_in_current_group = 0
     current_group_index = 0
+    error_count = 0
+    invalid_files: Set[str] = set()
     # shared_scene_objects: Set[str] = set()  # Objects that are both in scenes and episodes
     processed_objects: Set[str] = set()
     for episode in episode_set.episodes:
@@ -873,7 +875,12 @@ def main():
             #        for resolved in resolved_rigid_objs:
             #            shared_scene_objects.add(resolved)
             #        continue
-            assert len(resolved_rigid_objs) > 0
+
+            # HACK: Object is wrongly instantiated from scene dataset. Search there.
+            if len(resolved_rigid_objs) == 0:
+                error_count += 1
+                invalid_files.add(rigid_obj[0])
+                continue
             for resolved_rigid_obj in resolved_rigid_objs:
                 jobs.append(
                     Job(
@@ -982,6 +989,8 @@ def main():
 
     # Start processing.
     simplify_models(jobs, config)
+    print(f"{error_count} errors")
+    print(invalid_files)
 
 
 if __name__ == "__main__":

--- a/scripts/unity_dataset_processing/unity_dataset_processing.py
+++ b/scripts/unity_dataset_processing/unity_dataset_processing.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, List, Set
 
 import decimate
 
+METADATA_FILE_VERSION = 1
 OUTPUT_DIR = "data/_processing_output/"
 OMIT_BLACK_LIST = False
 OMIT_GRAY_LIST = False
@@ -487,6 +488,7 @@ def create_metadata_file(results: List[Dict[str, Any]]):
     This file is consumed by custom external asset pipelines (e.g. Unity) to manage assets.
 
     Contents:
+    * version: Version of the file format. Bump when breaking backward compatibility.
     * local_group_name: Name of the local group. See 'LOCAL_GROUP_NAME'.
     * groups: List of groups and their assets.
               Groups are used to determine how to package remote assets.
@@ -507,6 +509,7 @@ def create_metadata_file(results: List[Dict[str, Any]]):
 
     # Compose file content.
     content: Dict[str, Any] = {}
+    content["version"] = METADATA_FILE_VERSION
     content["local_group_name"] = LOCAL_GROUP_NAME
     content["groups"] = groups
 

--- a/scripts/unity_dataset_processing/unity_dataset_processing.py
+++ b/scripts/unity_dataset_processing/unity_dataset_processing.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-from enum import Enum
 import gzip
 import json
 import os
@@ -13,6 +12,7 @@ import re
 import shutil
 import time
 from dataclasses import dataclass
+from enum import Enum
 from multiprocessing import Manager, Pool
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Set
@@ -45,6 +45,7 @@ def resolve_relative_path(path: str) -> str:
         else:
             output_path.append(component)
     return os.path.join("", *output_path)
+
 
 class JobType(Enum):
     # Copy the asset as-is, skipping all processing.
@@ -369,9 +370,7 @@ class ObjectDataset:
                 object_render_asset_dir, object_render_asset_file_name
             )
             resolved_path = resolve_relative_path(object_render_asset_path)
-            self.render_assets.add(
-                resolve_relative_path(resolved_path)
-            )
+            self.render_assets.add(resolve_relative_path(resolved_path))
             # > "2a0a80bf0b1b247799ed3a49bfdc9f9bf4fcf2b3"
             stem = Path(object_config_json_path).stem.split(".")[0]
             self.stem_to_resolved_path[stem] = resolved_path
@@ -483,7 +482,7 @@ class GroupedSceneAssets:
             self.articulated_objects.append(AssetInfo(asset_path, groups))
 
 
-#class EpisodeObjectAssets:
+# class EpisodeObjectAssets:
 #    """
 #    All objects used in a episode.
 #    """
@@ -491,7 +490,7 @@ class GroupedSceneAssets:
 #        for asset in assets:
 #            scene_objects = scene_dataset.resolve_object(asset)
 #            for scene_object in scene_objects:
-                
+
 
 class EpisodeSet:
     """
@@ -605,7 +604,7 @@ def create_metadata_file(results: List[Dict[str, Any]]):
             # Hack: Package obj mtl and png.
             paths: List[str] = list(result["additional_dest_paths"])
             paths.append(result["dest_path"])
-                        
+
             for group in result["groups"]:
                 for path in paths:
                     file_rel_path = path.removeprefix(OUTPUT_DIR)
@@ -626,9 +625,10 @@ def create_metadata_file(results: List[Dict[str, Any]]):
 
 
 def absoluteFilePaths(directory):
-    for dirpath,_,filenames in os.walk(directory):
+    for dirpath, _, filenames in os.walk(directory):
         for f in filenames:
             yield os.path.abspath(os.path.join(dirpath, f))
+
 
 def process_model(args):
     job, counter, lock, total_models, verbose = args
@@ -667,7 +667,7 @@ def process_model(args):
                 print(dest)
         result["status"] = "copied"
         return result
-    job_type: JobType = job.job_type    
+    job_type: JobType = job.job_type
     if job_type == JobType.COPY:
         shutil.copyfile(job.source_path, job.dest_path, follow_symlinks=True)
         result["status"] = "copied"
@@ -852,7 +852,7 @@ def main():
     additional_asset_group_size = 50
     objects_in_current_group = 0
     current_group_index = 0
-    #shared_scene_objects: Set[str] = set()  # Objects that are both in scenes and episodes
+    # shared_scene_objects: Set[str] = set()  # Objects that are both in scenes and episodes
     processed_objects: Set[str] = set()
     for episode in episode_set.episodes:
         rigid_objs = episode["rigid_objs"]
@@ -861,11 +861,13 @@ def main():
             rigid_obj_stem = Path(rigid_obj[0]).stem.split(".")[0]
             for object_dataset in episode_set.additional_datasets.values():
                 if rigid_obj_stem in object_dataset.stem_to_resolved_path:
-                    resolved_rigid_objs = [object_dataset.stem_to_resolved_path[rigid_obj_stem]]
+                    resolved_rigid_objs = [
+                        object_dataset.stem_to_resolved_path[rigid_obj_stem]
+                    ]
                     continue
             # Look for the object in the scene dataset.
             # HACK: We create duplicates for these objects.
-            #for scene_dataset in episode_set.scene_datasets.values():
+            # for scene_dataset in episode_set.scene_datasets.values():
             #    if rigid_obj_stem in scene_dataset.objects:
             #        resolved_rigid_objs = scene_dataset.objects[rigid_obj_stem]
             #        for resolved in resolved_rigid_objs:
@@ -888,7 +890,7 @@ def main():
             objects_in_current_group -= additional_asset_group_size
             current_group_index += 1
     ## Sloppy: Add missing assets.
-    #for dataset in episode_set.additional_datasets.values():
+    # for dataset in episode_set.additional_datasets.values():
     #    for asset_path in dataset.render_assets:
     #        jobs.append(
     #            Job(
@@ -918,7 +920,7 @@ def main():
     # Add scene objects.
     # Grouped by scenes, excluding objects also in episodes.
     for obj in episode_set.grouped_scene_assets.objects:
-        #if obj.asset_path in shared_scene_objects:
+        # if obj.asset_path in shared_scene_objects:
         #    continue
         jobs.append(
             Job(
@@ -955,9 +957,7 @@ def main():
         )
 
     # Add humanoid models
-    for filename in Path("data/humanoids/humanoid_data").rglob(
-        "*.glb"
-    ):
+    for filename in Path("data/humanoids/humanoid_data").rglob("*.glb"):
         jobs.append(
             Job(
                 asset_path=str(filename),
@@ -971,13 +971,13 @@ def main():
     # Verify jobs.
     verify_jobs(jobs, OUTPUT_DIR)
 
-    #groups = {}
-    #for job in jobs:
+    # groups = {}
+    # for job in jobs:
     #    for group in job.groups:
     #        if group not in groups:
     #            groups[group] = 0
     #        groups[group] += 1
-    #for group, count in groups.items():
+    # for group, count in groups.items():
     #    print(f"{group}: {str(count)}")
 
     # Start processing.

--- a/scripts/unity_dataset_processing/unity_dataset_processing.py
+++ b/scripts/unity_dataset_processing/unity_dataset_processing.py
@@ -108,13 +108,6 @@ def file_is_scene_config(filepath: str) -> bool:
     return filepath.endswith(".scene_instance.json")
 
 
-def file_is_glb(filepath: str) -> bool:
-    """
-    Return whether or not the file is a glb.
-    """
-    return filepath.endswith(".glb")
-
-
 def file_is_episode_set(filepath: str) -> bool:
     """
     Return whether or not the file is an json.gz
@@ -246,6 +239,7 @@ class SceneDataset:
     stages: Dict[str, str] = {}
 
     def __init__(self, scene_dataset_config_path: str):
+        assert file_is_scene_dataset_config(scene_dataset_config_path)
         self.scene_dataset_dir = str(Path(scene_dataset_config_path).parent)
         scene_dataset_config = load_json(scene_dataset_config_path)
 
@@ -333,6 +327,7 @@ class SceneInstance:
         scene_instance_config_path: str,
         scene_dataset: SceneDataset,
     ) -> None:
+        assert file_is_scene_config(scene_instance_config_path)
         self.group_name = group_name
         scene_instance_config = load_json(scene_instance_config_path)
 


### PR DESCRIPTION
## Motivation and Context

Motivations:
* We need to support articulated scenes in Unity.
* HSSD is massive. In WebGL, we only want to download assets we need, not include the entire dataset with the WebGL app.
* The unit of work is an episode set. It captures all dependencies for a "project", along with all paths.

Context:
* The `unity_dataset_processing.py` script is used to convert/decimate Habitat datasets into a format usable by Unity.
* The premise is that `Unity` has a clone of the `data` folder. A relative path from the data folder resolves both in Habitat and Unity (or any other external engine, like Blender).

This changeset entirely refactors the `Habitat -> Unity` dataset processing pipeline such as:
* An episode set is supplied as input instead of a list of scenes.
* Datasets are automatically gathered (not hard-coded).
* Articulated scenes are supported.
* A `metadata.json` file is produced, containing `groups`.
    * Each group contains the list of assets they depend on. Currently, groups match 1-1 with the concept of a scene.
    * This file is consumed by external asset pipelines (e.g. Unity) to determine how assets should be packaged.
    * The default "local" group hints that the asset should be packaged locally (along with the build).
    * Grouped assets hint that they will be used together and should be batched when downloading from a remote location.
* Refactoring. This will enable the dataset pipeline to be driven by `hydra` config.
    * This will be a future refactoring that will allow each "project" to define how to process this data.
    * Decimation level, included datasets and other parameters will be configurable per-dataset via config.
    * More target engines may be included (e.g. Blender).

## How Has This Been Tested

Tested with existing episode sets and new articulated scenes.

## Types of changes

- **\[Refactoring\]**
- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
