### PR TITLE
Better Receptacle filtering refactor

### DIFF
--- a/test/test_rearrange_task.py
+++ b/test/test_rearrange_task.py
@@ -6,6 +6,7 @@
 
 import json
 import os.path as osp
+import random
 import time
 from glob import glob
 
@@ -311,6 +312,24 @@ def test_receptacle_parsing():
 
         # parse the metadata into Receptacle objects
         test_receptacles = hab_receptacle.find_receptacles(sim)
+
+        # test receptacle filtering in find
+        random_receptacle = random.choice(test_receptacles)
+        exclude_unique_name = random_receptacle.unique_name
+        test_filtered_receptacles = hab_receptacle.find_receptacles(
+            sim, exclude_filter_strings=[exclude_unique_name]
+        )
+        assert len(test_filtered_receptacles) == len(test_receptacles) - 1
+        assert (
+            len(
+                [
+                    rec
+                    for rec in test_filtered_receptacles
+                    if rec.unique_name == random_receptacle.unique_name
+                ]
+            )
+            == 0
+        )
 
         # test the Receptacle instances
         num_test_samples = 10


### PR DESCRIPTION
## Motivation and Context

We want to use the scene Receptacle filtering earlier in the process. Currently, filters are only taken into account during sampling which is too late. This means our generic lists of Receptacles in the scene contains many un-usable entries to sift through.

This PR refactors the functionality to load and leverage the filter files into a set of util functions which can be used at other stages. It also adds the option to provide filter strings directly to the `find_receptacles` function to get a pre-filtered list of Receptacle instances.

## How Has This Been Tested

Added a CI test to validate the functionality.

Example of using the new utils to get a pre-filtered list of Receptacles from the active scene:
```
import habitat.datasets.rearrange.samplers.receptacle as hab_receptacle
...
with habitat_sim.Simulator(cfg) as sim:
   scene_filter_filepath = hab_receptacle.get_scene_rec_filter_filepath(sim.metadata_mediator, sim.curr_scene_name)
   if scene_filter_filepath is not None:
      exclude_filter_strings = hab_receptacle.get_excluded_recs_from_filter_file(scene_filter_filepath)
      filtered_receptacles = hab_receptacle.find_receptacles(
         sim, 
        ignore_handles=None, #this is a list of object handles for parent objects to exclude
         exclude_filter_strings=exclude_filter_strings #this is a list of unique_name substrings to exclude.
      )
```

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
