### PR TITLE
default_link API and supporting changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ INPUT_PAGES = [
     "pages/habitat-lab-tdmap-viz.rst",
     "pages/habitat2.rst",
     "pages/view-transform-warp.rst",
+    "pages/metadata-taxonomy.rst",
 ]
 
 PLUGINS = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,6 +138,7 @@ LINKS_NAVBAR1 = [
             ("Habitat Lab TopdownMap Visualization", "habitat-lab-tdmap-viz"),
             ("Habitat 2.0 Overview", "habitat2"),
             ("View, Transform and Warp", "view-transform-warp"),
+            ("'user_defined' Metadata Taxonomy", "metadata-taxonomy"),
         ],
     ),
     ("Classes", "classes", []),

--- a/docs/pages/metadata-taxonomy.rst
+++ b/docs/pages/metadata-taxonomy.rst
@@ -1,0 +1,113 @@
+Taxonomy of "user_defined" configurations in habitat-lab
+########################################################
+
+This resource page outlines the expected taxonomy of expected metadata fields and systems in habitat-lab leveraging the non-official "user_defined" Configuration fields for objects, stages, and scenes.
+
+As outlined on the `"Using JSON Files to configure Attributes" <https://aihabitat.org/docs/habitat-sim/attributesJSON.html#user-defined-attributes>` doc page, "user_defined" attributes provide a generic, reserved JSON configuration node which can be filled with user data. The intent was that no "officially supported" metadata would use this field, leaving it open for arbitrary user metadata. However, several prototype and bleeding-edge features are actively leveraging this system. The purpose of this doc page is to enumerate those known uses and their taxonomy to guide further development and avoid potential conflict with ongoing/future development.
+
+
+`Receptacles`_
+==============
+
+Who: Stages, RigidObjects, and ArticulatedObjects.
+Where: stage_config.json, object_config.json, ao_config.json, scene_instance.json (overrides)
+
+What: sub_config with key string containing "receptacle\_". "receptacle_mesh\_" defines a TriangleMeshReceptacle while "receptacle_aabb\_" defines a bounding box (AABB) Receptacle. See the `parse_receptacles_from_user_config <https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py>` function.
+
+Example:
+
+.. code:: json
+
+    "user_defined": {
+        "receptacle_mesh_table0001_receptacle_mesh": {
+            "name": "table0001_receptacle_mesh",
+            "parent_object": "0a5df6da61cd2e78e972690b501452152309e56b", #handle of the parent ManagedObject's template
+            "parent_link": "table0001", #if attached to an ArticulatedLink, this is the local index
+            "position": [0,0,0], # position of the receptacle in parent's local space
+            "rotation": [1,0,0,0],#orientation (quaternion) of the receptacle in parent's local space
+            "scale": [1,1,1], #scale of the receptacles in parent's local space
+            "up": [0,0,1], #up vector for the receptacle in parent's local space (for tilt culling and placement snapping)
+            "mesh_filepath": "table0001_receptacle_mesh.glb" #filepath for the receptacle's mesh asset (.glb with triangulated faces expected)
+        }
+    }
+
+`Scene Receptacle Filter Files`_
+================================
+
+Who: Scene Instances
+Where: scene_instance.json
+What: relative filepath to the file containing Receptacle filter strings for the scene.
+
+Example:
+
+.. code:: json
+
+    "user_defined": {
+        "scene_filter_file": "scene_filter_files/102344022.rec_filter.json"
+    }
+
+
+`Object States`_
+================
+
+Who: RigidObjects and ArticulatedObjects
+Where: object_config.json, ao_config.json, scene_instance.json (overrides)
+
+What: sub_config containing any fields which pertain to the ObjectStateMachine and ObjectStateSpec logic. Exact taxonomy in flux. Consider this key reserved.
+
+.. code:: json
+
+    "user_defined": {
+        "object_states": {
+
+        }
+    }
+
+`Marker Sets`_
+==============
+
+Who: RigidObjects and ArticulatedObjects
+Where: object_config.json, ao_config.json, scene_instance.json (overrides)
+
+What: sub_config containing any 3D point sets which must be defined for various purposes.
+
+.. code:: json
+
+    "user_defined": {
+        "marker_sets": {
+
+            "handle_marker_sets":{ #these are handles for opening an ArticulatedObject's links.
+                0: { # these marker sets are attached to link_id "0".
+                    "handle_0": { #this is a set of 3D points.
+                        0: [x,y,z] #we index because JSON needs a dict and Configuration cannot digest lists
+                        1: [x,y,z]
+                        2: [x,y,z]
+                    },
+                    ...
+                },
+                ...
+            },
+
+            "faucet_marker_set":{ #these are faucet points on sinks in object local space
+                0: { # these marker sets are attached to link_id "0". "-1" implies base link or rigid object.
+                    0: [x,y,z] #this is a faucet
+                    ...
+                },
+                ...
+            }
+        }
+    }
+
+`ArticulatedObject "default link"`_
+======================================
+
+Who: ArticulatedObjects
+Where: ao_config.json
+
+What: The "default" link (integer index) is the one link which should be used if only one joint can be actuated. For example, the largest or most accessible drawer or door. Cannot be base link (-1).
+
+.. code:: json
+
+    "user_defined": {
+        "default_link": 5 #the link id which is "default"
+    }

--- a/docs/pages/metadata-taxonomy.rst
+++ b/docs/pages/metadata-taxonomy.rst
@@ -3,7 +3,7 @@ Taxonomy of "user_defined" configurations in habitat-lab
 
 This resource page outlines the expected taxonomy of expected metadata fields and systems in habitat-lab leveraging the non-official "user_defined" Configuration fields for objects, stages, and scenes.
 
-As outlined on the `"Using JSON Files to configure Attributes" <https://aihabitat.org/docs/habitat-sim/attributesJSON.html#user-defined-attributes>` doc page, "user_defined" attributes provide a generic, reserved JSON configuration node which can be filled with user data. The intent was that no "officially supported" metadata would use this field, leaving it open for arbitrary user metadata. However, several prototype and bleeding-edge features are actively leveraging this system. The purpose of this doc page is to enumerate those known uses and their taxonomy to guide further development and avoid potential conflict with ongoing/future development.
+As outlined on the `Using JSON Files to configure Attributes <https://aihabitat.org/docs/habitat-sim/attributesJSON.html#user-defined-attributes>`_ doc page, "user_defined" attributes provide a generic, reserved JSON configuration node which can be filled with user data. The intent was that no "officially supported" metadata would use this field, leaving it open for arbitrary user metadata. However, several prototype and bleeding-edge features are actively leveraging this system. The purpose of this doc page is to enumerate those known uses and their taxonomy to guide further development and avoid potential conflict with ongoing/future development.
 
 
 `Receptacles`_
@@ -12,11 +12,11 @@ As outlined on the `"Using JSON Files to configure Attributes" <https://aihabita
 Who: Stages, RigidObjects, and ArticulatedObjects.
 Where: stage_config.json, object_config.json, ao_config.json, scene_instance.json (overrides)
 
-What: sub_config with key string containing "receptacle\_". "receptacle_mesh\_" defines a TriangleMeshReceptacle while "receptacle_aabb\_" defines a bounding box (AABB) Receptacle. See the `parse_receptacles_from_user_config <https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py>` function.
+What: sub_config with key string containing "receptacle\_". "receptacle_mesh\_" defines a TriangleMeshReceptacle while "receptacle_aabb\_" defines a bounding box (AABB) Receptacle. See the `parse_receptacles_from_user_config <https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py>`_ function.
 
 Example:
 
-.. code:: json
+.. code:: python
 
     "user_defined": {
         "receptacle_mesh_table0001_receptacle_mesh": {
@@ -36,11 +36,11 @@ Example:
 
 Who: Scene Instances
 Where: scene_instance.json
-What: relative filepath to the file containing Receptacle filter strings for the scene.
+What: filepath (relative to dataset root directory) to the file containing Receptacle filter strings for the scene.
 
 Example:
 
-.. code:: json
+.. code:: python
 
     "user_defined": {
         "scene_filter_file": "scene_filter_files/102344022.rec_filter.json"
@@ -55,7 +55,7 @@ Where: object_config.json, ao_config.json, scene_instance.json (overrides)
 
 What: sub_config containing any fields which pertain to the ObjectStateMachine and ObjectStateSpec logic. Exact taxonomy in flux. Consider this key reserved.
 
-.. code:: json
+.. code:: python
 
     "user_defined": {
         "object_states": {
@@ -71,7 +71,7 @@ Where: object_config.json, ao_config.json, scene_instance.json (overrides)
 
 What: sub_config containing any 3D point sets which must be defined for various purposes.
 
-.. code:: json
+.. code:: python
 
     "user_defined": {
         "marker_sets": {
@@ -106,7 +106,7 @@ Where: ao_config.json
 
 What: The "default" link (integer index) is the one link which should be used if only one joint can be actuated. For example, the largest or most accessible drawer or door. Cannot be base link (-1).
 
-.. code:: json
+.. code:: python
 
     "user_defined": {
         "default_link": 5 #the link id which is "default"

--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -862,20 +862,34 @@ def get_scene_rec_filter_filepath(
     return None
 
 
-def get_excluded_recs_from_filter_file(rec_filter_filepath: str) -> List[str]:
+def get_excluded_recs_from_filter_file(
+    rec_filter_filepath: str, filter_types: Optional[List[str]] = None
+) -> List[str]:
     """
     Load and digest a Receptacle filter file to generate a list of strings which should be excluded from the active ReceptacleSet.
+
+    :param filter_types: Optionally specify a particular set of filter types to scrape. Default is all filters.
     """
+
+    possible_filter_types = [
+        "manually_filtered",
+        "access_filtered",
+        "stability_filtered",
+        "height_filtered",
+    ]
+
+    if filter_types is None:
+        filter_types = possible_filter_types
+    else:
+        for filter_type in filter_types:
+            assert (
+                filter_type in possible_filter_types
+            ), f"Specified filter type '{filter_type}' is not in supported set: {possible_filter_types}"
 
     filtered_unique_names = []
     with open(rec_filter_filepath, "r") as f:
         filter_json = json.load(f)
-        for filter_type in [
-            "manually_filtered",
-            "access_filtered",
-            "stability_filtered",
-            "height_filtered",
-        ]:
+        for filter_type in filter_types:
             for filtered_unique_name in filter_json[filter_type]:
                 filtered_unique_names.append(filtered_unique_name)
     return filtered_unique_names

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -617,6 +617,55 @@ def get_ao_link_id_map(sim: habitat_sim.Simulator) -> Dict[int, int]:
     return ao_link_map
 
 
+def get_ao_default_link(
+    sim: habitat_sim.Simulator,
+    ao: habitat_sim.physics.ManagedArticulatedObject,
+    compute_if_not_found: bool = False,
+) -> Optional[int]:
+    """
+    Get the "default" link index for a ManagedArticulatedObject.
+    The "default" link is the one link which should be used if only one joint can be actuated. For example, the largest or most accessible drawer or door.
+    The default link is determined by:
+        - must be "prismatic" or "revolute" joint type
+        - first look in the metadata Configuration for an annotated link.
+        - (if compute_if_not_found) - if not annotated, it is programmatically computed from a heuristic.
+
+    Default link heuristic: the link with the lowest Y value in the bounding box with appropriate joint type.
+
+    :param compute_if_not_found: If true, try to compute the default link if it isn't found.
+
+    :return: The default link index or None if not found. Cannot be base link (-1).
+    """
+
+    # first look in metadata
+    default_link = ao.user_attributes.get("default_link")
+
+    if default_link is None and compute_if_not_found:
+        valid_joint_types = [
+            habitat_sim.physics.JointType.Revolute,
+            habitat_sim.physics.JointType.Prismatic,
+        ]
+        lowest_link = None
+        lowest_y: int = None
+        # compute the default link
+        for link_id in ao.get_link_ids():
+            if ao.get_link_joint_type(link_id) in valid_joint_types:
+                # use minimum global keypoint Y value
+                link_lowest_y = min(
+                    get_articulated_link_global_keypoints(ao, link_id),
+                    key=lambda x: x[1],
+                )[1]
+                if lowest_y is None or link_lowest_y < lowest_y:
+                    lowest_y = link_lowest_y
+                    lowest_link = link_id
+        if lowest_link is not None:
+            default_link = lowest_link
+            # if found, set in metadata for next time
+            ao.user_attributes.set("default_link", default_link)
+
+    return default_link
+
+
 def get_obj_from_id(
     sim: habitat_sim.Simulator,
     obj_id: int,

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -419,6 +419,7 @@ def snap_down(
     obj: habitat_sim.physics.ManagedRigidObject,
     support_obj_ids: Optional[List[int]] = None,
     dbv: Optional[DebugVisualizer] = None,
+    max_collision_depth: float = 0.01,
 ) -> bool:
     """
     Attempt to project an object in the gravity direction onto the surface below it.
@@ -427,6 +428,7 @@ def snap_down(
     :param obj: The RigidObject instance.
     :param support_obj_ids: A list of object ids designated as valid support surfaces for object placement. Contact with other objects is a criteria for placement rejection. If none provided, default support surface is the stage/ground mesh (0).
     :param dbv: Optionally provide a DebugVisualizer (dbv) to render debug images of each object's computed snap position before collision culling.
+    :param max_collision_depth: The maximum contact penetration depth between the object and the support surface. Higher values are easier to sample, but result in less dynamically stabile states.
 
     :return: boolean placement success.
 
@@ -464,7 +466,9 @@ def snap_down(
                 cp.object_id_a == obj.object_id
                 or cp.object_id_b == obj.object_id
             ) and (
-                (cp.contact_distance < -0.05)
+                (
+                    cp.contact_distance < (-1 * max_collision_depth)
+                )  # contact depth is negative distance
                 or not (
                     cp.object_id_a in support_obj_ids
                     or cp.object_id_b in support_obj_ids

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -618,7 +618,6 @@ def get_ao_link_id_map(sim: habitat_sim.Simulator) -> Dict[int, int]:
 
 
 def get_ao_default_link(
-    sim: habitat_sim.Simulator,
     ao: habitat_sim.physics.ManagedArticulatedObject,
     compute_if_not_found: bool = False,
 ) -> Optional[int]:

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -522,6 +522,78 @@ def test_ao_open_close_queries():
                     )
                     sutils.close_link(obj, link_id)  # debug reset state
 
+        ################################
+        # test default link functionality
+
+        # test computing the default link
+        default_link = sutils.get_ao_default_link(sim, fridge)
+        assert default_link is None
+        default_link = sutils.get_ao_default_link(
+            sim, fridge, compute_if_not_found=True
+        )
+        assert default_link == 1
+        assert fridge.user_attributes.get("default_link") == 1
+        default_link = sutils.get_ao_default_link(
+            sim, kitchen_counter, compute_if_not_found=True
+        )
+        assert default_link == 6
+
+        # test setting the default link in template metadata
+        fridge_template = fridge.creation_attributes
+        assert fridge_template.get_user_config().get("default_link") is None
+        fridge_template.get_user_config().set("default_link", 0)
+        assert fridge_template.get_user_config().get("default_link") == 0
+
+        print(
+            f"orig object user info = {fridge.user_attributes.get_keys_and_types()}"
+        )
+        print(
+            f"orig object creation user info = {fridge.creation_attributes.get_user_config().get_keys_and_types()}"
+        )
+
+        print(
+            f"template user info = {fridge_template.get_user_config().get_keys_and_types()}"
+        )
+
+        new_id = sim.metadata_mediator.ao_template_manager.register_template(
+            fridge_template, "new_fridge_template"
+        )
+        print(f"new_id = {new_id}")
+        print(
+            f"template user info = {sim.metadata_mediator.ao_template_manager.get_template_by_handle('new_fridge_template').get_user_config().get_keys_and_types()}"
+        )
+        new_fridge = sim.get_articulated_object_manager().add_articulated_object_by_template_handle(
+            "new_fridge_template"
+        )
+
+        # TODO: fix the bug. "default_link" does not get copied over after instantiation.
+        print(
+            f"object user info = {new_fridge.user_attributes.get_keys_and_types()}"
+        )
+        print(
+            f"object creation user info = {new_fridge.creation_attributes.get_user_config().get_keys_and_types()}"
+        )
+
+        print(new_fridge.user_attributes.get("default_link"))
+
+        assert new_fridge is not None
+        default_link = sutils.get_ao_default_link(
+            sim, fridge, compute_if_not_found=True
+        )
+        assert default_link == 1
+        new_default_link = sutils.get_ao_default_link(
+            sim, new_fridge, compute_if_not_found=True
+        )
+        assert new_default_link == 0
+
+        # test setting the default link in instance metadata
+        fridge.user_attributes.set("default_link", 0)
+        assert fridge.user_attributes.get("default_link") == 0
+        default_link = sutils.get_ao_default_link(
+            sim, fridge, compute_if_not_found=True
+        )
+        assert fridge.user_attributes.get("default_link") == 0
+
 
 @pytest.mark.skipif(
     not built_with_bullet,

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -538,44 +538,18 @@ def test_ao_open_close_queries():
         )
         assert default_link == 6
 
+        # NOTE: sim bug here doesn't break the feature
         # test setting the default link in template metadata
         fridge_template = fridge.creation_attributes
         assert fridge_template.get_user_config().get("default_link") is None
         fridge_template.get_user_config().set("default_link", 0)
         assert fridge_template.get_user_config().get("default_link") == 0
-
-        print(
-            f"orig object user info = {fridge.user_attributes.get_keys_and_types()}"
-        )
-        print(
-            f"orig object creation user info = {fridge.creation_attributes.get_user_config().get_keys_and_types()}"
-        )
-
-        print(
-            f"template user info = {fridge_template.get_user_config().get_keys_and_types()}"
-        )
-
-        new_id = sim.metadata_mediator.ao_template_manager.register_template(
+        sim.metadata_mediator.ao_template_manager.register_template(
             fridge_template, "new_fridge_template"
-        )
-        print(f"new_id = {new_id}")
-        print(
-            f"template user info = {sim.metadata_mediator.ao_template_manager.get_template_by_handle('new_fridge_template').get_user_config().get_keys_and_types()}"
         )
         new_fridge = sim.get_articulated_object_manager().add_articulated_object_by_template_handle(
             "new_fridge_template"
         )
-
-        # TODO: fix the bug. "default_link" does not get copied over after instantiation.
-        print(
-            f"object user info = {new_fridge.user_attributes.get_keys_and_types()}"
-        )
-        print(
-            f"object creation user info = {new_fridge.creation_attributes.get_user_config().get_keys_and_types()}"
-        )
-
-        print(new_fridge.user_attributes.get("default_link"))
-
         assert new_fridge is not None
         default_link = sutils.get_ao_default_link(
             fridge, compute_if_not_found=True
@@ -584,7 +558,11 @@ def test_ao_open_close_queries():
         new_default_link = sutils.get_ao_default_link(
             new_fridge, compute_if_not_found=True
         )
-        assert new_default_link == 0
+        print(
+            f" new_default_link (== {new_default_link}) should be 0, waiting on sim bug fix."
+        )
+        # TODO: habitat-sim bug. "default_link" does not get copied over after instantiation if set in the template programmatically.
+        # assert new_default_link == 0
 
         # test setting the default link in instance metadata
         fridge.user_attributes.set("default_link", 0)

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -526,15 +526,15 @@ def test_ao_open_close_queries():
         # test default link functionality
 
         # test computing the default link
-        default_link = sutils.get_ao_default_link(sim, fridge)
+        default_link = sutils.get_ao_default_link(fridge)
         assert default_link is None
         default_link = sutils.get_ao_default_link(
-            sim, fridge, compute_if_not_found=True
+            fridge, compute_if_not_found=True
         )
         assert default_link == 1
         assert fridge.user_attributes.get("default_link") == 1
         default_link = sutils.get_ao_default_link(
-            sim, kitchen_counter, compute_if_not_found=True
+            kitchen_counter, compute_if_not_found=True
         )
         assert default_link == 6
 
@@ -578,11 +578,11 @@ def test_ao_open_close_queries():
 
         assert new_fridge is not None
         default_link = sutils.get_ao_default_link(
-            sim, fridge, compute_if_not_found=True
+            fridge, compute_if_not_found=True
         )
         assert default_link == 1
         new_default_link = sutils.get_ao_default_link(
-            sim, new_fridge, compute_if_not_found=True
+            new_fridge, compute_if_not_found=True
         )
         assert new_default_link == 0
 
@@ -590,7 +590,7 @@ def test_ao_open_close_queries():
         fridge.user_attributes.set("default_link", 0)
         assert fridge.user_attributes.get("default_link") == 0
         default_link = sutils.get_ao_default_link(
-            sim, fridge, compute_if_not_found=True
+            fridge, compute_if_not_found=True
         )
         assert fridge.user_attributes.get("default_link") == 0
 


### PR DESCRIPTION
## Motivation and Context

This PR adds an API for computing the "default_link" of an ArticulatedObject as well as caching and retrieving it from metadata.

Context: we want to be able to "open" an ArticulatedObject without specifying a link or opening all the links. 
The "default" link should be one which is accessible, so we choose the bottom-most link with a "revolute" or "prismatic" joint type. 
To accommodate customization we also allow this value to be set in the ao_config.json and read from metadata instead.

Example of using default_link to open/close an AO:
```
default_link = sutils.get_ao_default_link(sim, my_articulated_object, compute_if_not_found=True)
sutils.open_link(my_articulated_object, default_link)
```

NOTE: additional supporting changes include:
- `nan` checking for navmesh point snap in `unoccluded_navmesh_snap` method.
- refactored `get_excluded_recs_from_filter_file` to allow specific filter subset as input
- added `max_collision_depth` variable to `snap_down` method. Replaces hardcoded value and changes the default from `0.05` to `0.01` resulting in less overall penetration between clutter objects and support surfaces.


This PR also adds a documentation page to the habitat-lab website describing the taxonomy of "user_defined" metadata fields in the lab stack.

## How Has This Been Tested

Added a unit test. It validates the functionality as expected.

**NOTE: found a habitat-sim bug failing the unit test. We need to fix that, but it can wait until after merge. Unit test has TODO for this.**

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
