### PR TITLE
HITL - Clear mouse held buttons in remote client state.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -253,6 +253,7 @@ class RemoteClientState:
         )
 
         gui_input._key_held.clear()
+        gui_input._mouse_button_held.clear()
 
         if input_json is not None:
             for button in input_json["buttonHeld"]:


### PR DESCRIPTION
## Motivation and Context

This solves a bug where mouse buttons would stay "held" indefinitely when done from a remote client.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
