### PR TITLE
RearrangeSim: Allow rigid objects to be collidable in kinematic mode

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -631,7 +631,6 @@ class RearrangeSim(HabitatSim):
             )
             if self._kinematic_mode:
                 ro.motion_type = habitat_sim.physics.MotionType.KINEMATIC
-                ro.collidable = False
 
             if should_add_objects:
                 self._scene_obj_ids.append(ro.object_id)


### PR DESCRIPTION
## Motivation and Context

For object to be detected by contact_test, discrete collision detection, or raycasting, they must be collidable. This PR rolls back a change making all added episode objects non-collidable for rearrange tasks in kinematic mode.

Context: we want to be able to select objects with raycast, snap objects onto surfaces, etc...

This could have some performance overhead, but unlikely to be significant. If we notice regressions we'll deal with them another way.

## How Has This Been Tested

CI test was fine (until pypi deployment test error which seems unrelated). Re-running in hopes of green light. No benchmark regression, but I believe we are running dynamic mode there.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
