### PR TITLE
HITL - Add an event system to track connections and disconnections.

### DIFF
--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -22,6 +22,7 @@ from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.hitl_main import hitl_main
 from habitat_hitl.core.hydra_utils import register_hydra_plugins
 from habitat_hitl.core.text_drawer import TextOnScreenAlignment
+from habitat_hitl.core.types import ConnectionRecord, DisconnectionRecord
 from habitat_hitl.environment.camera_helper import CameraHelper
 from habitat_hitl.environment.controllers.gui_controller import (
     GuiHumanoidController,
@@ -138,6 +139,21 @@ class AppStateRearrangeV2(AppState):
 
         self._task_instruction = ""
         self._data_logger = DataLogger(app_service=self._app_service)
+
+        if self._app_service.hitl_config.networking.enable:
+            self._app_service.remote_client_state.on_client_connected.registerCallback(
+                self._on_client_connected
+            )
+            self._app_service.remote_client_state.on_client_disconnected.registerCallback(
+                self._on_client_disconnected
+            )
+            self._paused = True
+
+    def _on_client_connected(self, connection: ConnectionRecord):
+        self._paused = False
+
+    def _on_client_disconnected(self, disconnection: DisconnectionRecord):
+        self._paused = True
 
     # needed to avoid spurious mypy attr-defined errors
     @staticmethod

--- a/habitat-hitl/habitat_hitl/_internal/networking/interprocess_record.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/interprocess_record.py
@@ -11,6 +11,7 @@ from habitat_hitl.core.types import (
     ClientState,
     ConnectionRecord,
     DataDict,
+    DisconnectionRecord,
     Keyframe,
 )
 
@@ -25,6 +26,7 @@ class InterprocessRecord:
         self._keyframe_queue: Queue[Keyframe] = Queue()
         self._client_state_queue: Queue[ClientState] = Queue()
         self._connection_record_queue: Queue[ConnectionRecord] = Queue()
+        self._disconnection_record_queue: Queue[DisconnectionRecord] = Queue()
 
     def send_keyframe_to_networking_thread(self, keyframe: Keyframe) -> None:
         """Send a keyframe (outgoing data) to the networking thread."""
@@ -44,6 +46,13 @@ class InterprocessRecord:
         assert "connectionId" in connection_record
         assert "isClientReady" in connection_record
         self._connection_record_queue.put(connection_record)
+
+    def send_disconnection_record_to_main_thread(
+        self, disconnection_record: DisconnectionRecord
+    ) -> None:
+        """Send a disconnection record to the main thread."""
+        assert "connectionId" in disconnection_record
+        self._disconnection_record_queue.put(disconnection_record)
 
     def get_single_queued_keyframe(self) -> Optional[Keyframe]:
         """Dequeue one keyframe."""
@@ -75,3 +84,7 @@ class InterprocessRecord:
     def get_queued_connection_records(self) -> List[ConnectionRecord]:
         """Dequeue all connection records."""
         return self._dequeue_all(self._connection_record_queue)
+
+    def get_queued_disconnection_records(self) -> List[DisconnectionRecord]:
+        """Dequeue all disconnection records."""
+        return self._dequeue_all(self._disconnection_record_queue)

--- a/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
@@ -29,7 +29,12 @@ from habitat_hitl._internal.networking.keyframe_utils import (
     get_empty_keyframe,
     update_consolidated_keyframe,
 )
-from habitat_hitl.core.types import ClientState, ConnectionRecord, Keyframe
+from habitat_hitl.core.types import (
+    ClientState,
+    ConnectionRecord,
+    DisconnectionRecord,
+    Keyframe,
+)
 
 # Boolean variable to indicate whether to use SSL
 use_ssl = False
@@ -234,17 +239,18 @@ class NetworkManager:
         print(f"Closed connection to client  {websocket.remote_address}")
         del self._connected_clients[websocket_id]
 
+        disconnection_record: DisconnectionRecord = {}
+        disconnection_record["connectionId"] = websocket_id
+        self._interprocess_record.send_disconnection_record_to_main_thread(
+            disconnection_record
+        )
+
     def parse_connection_record(self, message: str) -> ConnectionRecord:
-        connection_record: ConnectionRecord
-        if message == "client ready!":
-            # legacy message format for initial client message
-            connection_record = {"isClientReady": True}
-        else:
-            connection_record = json.loads(message)
-            if "isClientReady" not in connection_record:
-                raise ValueError(
-                    "isClientReady key not found in initial client message."
-                )
+        connection_record: ConnectionRecord = json.loads(message)
+        if "isClientReady" not in connection_record:
+            raise ValueError(
+                "isClientReady key not found in initial client message."
+            )
         return connection_record
 
     async def handle_connection(self, websocket: ClientConnection) -> None:

--- a/habitat-hitl/habitat_hitl/core/event.py
+++ b/habitat-hitl/habitat_hitl/core/event.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, List
+
+
+class Event:
+    def __init__(self):
+        self._callbacks: List[Callable[[Any], None]] = []
+
+    def registerCallback(self, callback):
+        self._callbacks.append(callback)
+
+    def invoke(self, obj: Any):
+        for callback in self._callbacks:
+            callback(obj)

--- a/habitat-hitl/habitat_hitl/core/types.py
+++ b/habitat-hitl/habitat_hitl/core/types.py
@@ -17,3 +17,6 @@ ClientState = DataDict
 
 # Dictionary that contains data about a new connection.
 ConnectionRecord = DataDict
+
+# Dictionary that contains data about a terminated connection.
+DisconnectionRecord = DataDict


### PR DESCRIPTION
## Motivation and Context

Distributed HITL applications require changing state when a client connects or disconnects.
This PR aims to add a single source of truth in the main thread to emit these events.

Here, the application is paused when nobody is connected.
While this is currently handled at the application level, in the future, the events may instead be subscribed in the `HitlDriver` class.

## How Has This Been Tested

Tested on distributed prototype.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
