### PR TITLE
HITL - Automatically create output directories for recorder.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/serialize_utils.py
+++ b/habitat-hitl/habitat_hitl/core/serialize_utils.py
@@ -11,6 +11,7 @@ import os
 import pickle
 from abc import abstractmethod
 from datetime import datetime
+from pathlib import Path
 from typing import Any, List
 
 import magnum as mn
@@ -26,7 +27,7 @@ def pickle_vector3(obj):
     return unpickle_vector3, (pickled_data,)
 
 
-# fix for unpickable type; run once at startup
+# fix for unpicklable type; run once at startup
 copyreg.pickle(mn.Vector3, pickle_vector3)
 
 
@@ -79,6 +80,8 @@ def save_as_json_gzip(obj, filepath):
 def save_as_gzip(data, filepath, mode="wb"):
     if os.path.exists(filepath):
         raise FileExistsError(filepath)
+    if len(Path(filepath).parents) > 0:
+        Path(filepath).parent.mkdir(parents=True, exist_ok=True)
     with gzip.open(filepath, mode) as file:
         file.write(data)
     print("wrote " + filepath)


### PR DESCRIPTION
## Motivation and Context

This automatically creates output directories for the recorder. This simplifies deploying the application on servers that may be cleaning up temporary files on-the-go. 

## How Has This Been Tested

Tested on web servers and locally.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
