### PR TITLE
HITL - Check for any input to determine idleness.

### DIFF
--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -405,8 +405,8 @@ class AppStateRearrangeV2(AppState):
         lookat = agent_root.translation + lookat_y_offset
         return lookat
 
-    def is_user_idle_this_frame(self):
-        return not self._app_service.gui_input.get_any_key_down()
+    def is_user_idle_this_frame(self) -> bool:
+        return not self._app_service.gui_input.get_any_input()
 
     def _check_change_episode(self):
         if self._paused or not self._app_service.gui_input.get_key_down(

--- a/habitat-hitl/habitat_hitl/core/gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/gui_input.py
@@ -40,6 +40,15 @@ class GuiInput:
     def get_any_key_down(self):
         return len(self._key_down) > 0
 
+    def get_any_input(self) -> bool:
+        """Returns true if any input is active."""
+        return (
+            len(self._key_down) > 0
+            or len(self._key_up) > 0
+            or len(self._mouse_button_down) > 0
+            or len(self._mouse_button_up) > 0
+        )
+
     def get_key_down(self, key):
         GuiInput.validate_key(key)
         return key in self._key_down


### PR DESCRIPTION
## Motivation and Context

Previously, to determine whether a client is idle, we were only looking for key presses.
Now that the mouse is frequently used, it makes sense to also check it to determine idleness.

The `get_any_input` will also be used to determine which frame is worth recording in the context of a HITL experiment.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
