### PR TITLE
HITL - Mouse-based UI.

### DIFF
--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -160,6 +160,7 @@ class AppStateRearrangeV2(AppState):
         self,
     ) -> List[Tuple[List[int], List[int]]]:
         """Parse the current episode and returns the goal object-receptacle pairs."""
+        sim = self.get_sim()
         paired_goal_ids: List[Tuple[List[int], List[int]]] = []
         current_episode = self._app_service.env.current_episode
         if current_episode.info.get("extra_info") is not None:
@@ -169,16 +170,14 @@ class AppStateRearrangeV2(AppState):
                 object_ids: List[int] = []
                 object_handles = proposition["args"]["object_handles"]
                 for object_handle in object_handles:
-                    obj = sim_utilities.get_obj_from_handle(
-                        self.get_sim(), object_handle
-                    )
+                    obj = sim_utilities.get_obj_from_handle(sim, object_handle)
                     object_id = obj.object_id
                     object_ids.append(object_id)
                 receptacle_ids: List[int] = []
                 receptacle_handles = proposition["args"]["receptacle_handles"]
                 for receptacle_handle in receptacle_handles:
                     obj = sim_utilities.get_obj_from_handle(
-                        self.get_sim(), receptacle_handle
+                        sim, receptacle_handle
                     )
                     object_id = obj.object_id
                     # TODO: Support for finding links by handle.
@@ -270,7 +269,7 @@ class AppStateRearrangeV2(AppState):
 
     def _check_change_episode(self):
         if self._paused or not self._app_service.gui_input.get_key_down(
-            GuiInput.KeyNS.N
+            GuiInput.KeyNS.ZERO
         ):
             return
 
@@ -318,7 +317,7 @@ class AppStateRearrangeV2(AppState):
 
     def record_state(self):
         task_completed = self._app_service.gui_input.get_key_down(
-            GuiInput.KeyNS.N
+            GuiInput.KeyNS.ZERO
         )
         self._data_logger.record_state(task_completed=task_completed)
 

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -223,10 +223,13 @@ class AppStateRearrangeV2(AppState):
         return controls_str
 
     def _get_status_text(self):
+        if self._paused:
+            return ""
+
         status_str = ""
 
         if len(self._task_instruction) > 0:
-            status_str += "\nInstruction: " + self._task_instruction + "\n"
+            status_str += "Instruction: " + self._task_instruction + "\n"
         if (
             self._client_helper
             and self._client_helper.do_show_idle_kick_warning
@@ -238,12 +241,6 @@ class AppStateRearrangeV2(AppState):
         return status_str
 
     def _update_help_text(self):
-        controls_str = self._get_controls_text()
-        if len(controls_str) > 0:
-            self._app_service.text_drawer.add_text(
-                controls_str, TextOnScreenAlignment.TOP_LEFT
-            )
-
         status_str = self._get_status_text()
         if len(status_str) > 0:
             self._app_service.text_drawer.add_text(
@@ -251,6 +248,12 @@ class AppStateRearrangeV2(AppState):
                 TextOnScreenAlignment.TOP_CENTER,
                 text_delta_x=-280,
                 text_delta_y=-50,
+            )
+
+        controls_str = self._get_controls_text()
+        if len(controls_str) > 0:
+            self._app_service.text_drawer.add_text(
+                controls_str, TextOnScreenAlignment.TOP_LEFT
             )
 
     def _get_camera_lookat_pos(self):

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from datetime import datetime, timedelta
+import os
+from pathlib import Path
+import shutil
+import time
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
+from habitat_hitl.core.gui_drawer import GuiDrawer
+from habitat_hitl.core.types import ConnectionRecord, DisconnectionRecord
+from habitat_hitl.environment.controllers.controller_abc import GuiController
+import hydra
+import magnum as mn
+import numpy as np
+
+from habitat.sims.habitat_simulator import sim_utilities
+from habitat.tasks.rearrange.articulated_agent_manager import (
+    ArticulatedAgentManager,
+)
+from habitat_hitl._internal.networking.average_rate_tracker import (
+    AverageRateTracker,
+)
+from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.app_states.app_state_abc import AppState
+from habitat_hitl.core.client_helper import ClientHelper
+from habitat_hitl.core.gui_input import GuiInput
+from habitat_hitl.core.hitl_main import hitl_main
+from habitat_hitl.core.hydra_utils import register_hydra_plugins
+from habitat_hitl.core.key_mapping import KeyCode, MouseButton
+from habitat_hitl.core.text_drawer import TextOnScreenAlignment
+from habitat_hitl.core.user_mask import Mask, Users
+from habitat_hitl.environment.camera_helper import CameraHelper
+from habitat_hitl.environment.controllers.gui_controller import (
+    GuiHumanoidController,
+    GuiRobotController,
+)
+from habitat_hitl.environment.hablab_utils import get_agent_art_obj_transform
+from habitat_sim.geo import Ray
+from habitat_sim.physics import ManagedArticulatedObject, RayHitInfo
+from habitat_sim.utils.common import quat_from_magnum, quat_to_coeffs
+
+from habitat_hitl.core.selection import Selection
+
+# Verticality threshold for successful placement.
+MINIMUM_DROP_VERTICALITY: float = 0.9
+
+# Maximum delay between two clicks to be registered as a double-click.
+DOUBLE_CLICK_DELAY: float = 0.33
+
+_HI = 0.8
+_LO = 0.4
+# Color for a valid action.
+COLOR_VALID = mn.Color4(0.0, _HI, 0.0, 1.0)  # Green
+# Color for an invalid action.
+COLOR_INVALID = mn.Color4(_HI, 0.0, 0.0, 1.0)  # Red
+# Color for goal object-receptacle pairs.
+COLOR_GOALS: List[mn.Color4] = [
+    mn.Color4(0.0, _HI, _HI, 1.0),  # Cyan
+    mn.Color4(_HI, 0.0, _HI, 1.0),  # Magenta
+    mn.Color4(_HI, _HI, 0.0, 1.0),  # Yellow
+    mn.Color4(_HI, 0.0, _LO, 1.0),  # Purple
+    mn.Color4(_LO, _HI, 0.0, 1.0),  # Orange
+]
+
+class UI:
+    """
+    User interface for the rearrange_v2 app.
+    Each user has their own UI class.
+    """
+    def __init__(self, hitl_config, user_index: int, gui_controller: GuiController, sim: RearrangeSim, gui_input: GuiInput, gui_drawer: GuiDrawer, camera_helper: CameraHelper):
+        self._user_index = user_index
+        self._dest_mask = Mask.from_index(self._user_index)
+        self._gui_controller = gui_controller
+        self._sim = sim
+        self._gui_input = gui_input
+        self._gui_drawer = gui_drawer
+        self._camera_helper = camera_helper
+
+        self._can_grasp_place_threshold = hitl_config.can_grasp_place_threshold
+
+        # ID of the object being held. None if no object is held.
+        self._held_object_id: Optional[int] = None
+        # Cache of all link IDs and their parent articulated objects.
+        self._link_id_to_ao_map: Dict[int, int] = {}
+        # Cache of all opened articulated object links.
+        self._opened_link_set: Set = set()
+        # Cache of pickable objects IDs.
+        self._pickable_object_ids: Set[int] = set()
+        # Cache of interactable objects IDs.
+        self._interactable_object_ids: Set[int] = set()
+        # Last time a click was done. Used to track double-clicking.
+        self._last_click_time: datetime = datetime.now()
+        # Cache of goal object-receptacle pairs.
+        self._paired_goal_ids: List[Tuple[List[int], List[int]]] = []
+
+        # Selection trackers.
+        self._selections: List[Selection] = []
+        # Track hovered object.
+        self._hover_selection = Selection(
+            self._sim,
+            self._gui_input,
+            Selection.hover_fn
+        )
+        self._selections.append(self._hover_selection)
+        # Track left-clicked object.
+        self._click_selection = Selection(
+            self._sim,
+            self._gui_input,
+            Selection.left_click_fn,
+        )
+        self._selections.append(self._click_selection)
+        # Track drop placement.
+        def place_selection_fn(gui_input: GuiInput) -> bool:
+            return gui_input.get_mouse_button(MouseButton.RIGHT) or gui_input.get_mouse_button_up(MouseButton.RIGHT)
+        self._place_selection = Selection(
+            self._sim,
+            self._gui_input,
+            place_selection_fn,
+        )
+        self._selections.append(self._place_selection)
+    
+    def reset(self, paired_goal_ids: List[Tuple[List[int], List[int]]]) -> None:
+        """
+        Reset the UI. Call on simulator reset.
+        """
+        sim = self._sim
+        
+        self._held_object_id = None
+        self._link_id_to_ao_map = sim_utilities.get_ao_link_id_map(sim)
+        self._opened_link_set = set()
+        self._paired_goal_ids = paired_goal_ids
+        self._last_click_time = datetime.now()
+        for selection in self._selections:
+            selection.deselect()
+                
+        self._pickable_object_ids = set(sim._scene_obj_ids)
+        for pickable_obj_id in self._pickable_object_ids:
+            rigid_obj = self._get_rigid_object(pickable_obj_id)
+            # Ensure that rigid objects are collidable.
+            rigid_obj.collidable = True
+
+        # Get set of interactable articulated object links.
+        # Exclude all agents.
+        agent_ao_object_ids: Set[int] = set()
+        agent_manager: ArticulatedAgentManager = sim.agents_mgr
+        for agent_index in range(len(agent_manager)):
+            agent = agent_manager[agent_index]
+            agent_ao = agent.articulated_agent.sim_obj
+            agent_ao_object_ids.add(agent_ao.object_id)
+        self._interactable_object_ids = set()
+        aom = sim.get_articulated_object_manager()
+        all_ao: List[
+            ManagedArticulatedObject
+        ] = aom.get_objects_by_handle_substring().values()
+        # All add non-root links that are not agents.
+        for ao in all_ao:
+            if ao.object_id not in agent_ao_object_ids:
+                for link_object_id in ao.link_object_ids:
+                    if link_object_id != ao.object_id:
+                        self._interactable_object_ids.add(link_object_id)
+
+    def update(self) -> None:
+        """
+        Handle user actions and update the UI.
+        """
+        def _handle_double_click() -> bool:
+            time_since_last_click = datetime.now() - self._last_click_time
+            double_clicking = time_since_last_click < timedelta(seconds=DOUBLE_CLICK_DELAY)
+            if not double_clicking:
+                self._last_click_time = datetime.now()
+            return double_clicking
+        
+        for selection in self._selections:
+            selection.update()
+
+        if self._gui_input.get_mouse_button_down(MouseButton.LEFT):
+            clicked_object_id = self._click_selection.object_id
+            if _handle_double_click():
+                # Double-click to select pickable.
+                if self._is_object_pickable(clicked_object_id):
+                    self._pick_object(clicked_object_id)
+                # Double-click to interact.
+                elif self._is_object_interactable(clicked_object_id):
+                    self._interact_with_object(clicked_object_id)
+
+        # Drop when releasing right click.
+        if self._gui_input.get_mouse_button_up(MouseButton.RIGHT):
+            self._place_object()
+            self._place_selection.deselect()
+    
+    def draw_ui(self) -> None:
+        """
+        Draw the UI.
+        """
+        self._draw_place_selection()
+        self._draw_hovered_interactable()
+        self._draw_hovered_pickable()
+        self._draw_goals()
+
+    def _pick_object(self, object_id: int) -> None:
+        """Pick the specified object_id. The object must be pickable."""
+        if not self._is_holding_object() and self._is_object_pickable(object_id):
+            rigid_object = self._get_rigid_object(object_id)
+            if rigid_object is not None:
+                rigid_pos = rigid_object.translation
+                if self._is_within_reach(rigid_pos):
+                    # Pick the object.
+                    self._held_object_id = object_id
+                    self._place_selection.deselect()
+
+    def _place_object(self) -> None:
+        """Place the currently held object."""
+        if not self._place_selection.selected:
+            return
+        
+        object_id = self._held_object_id
+        place_point = self._place_selection.point
+        place_normal = self._place_selection.normal
+        if (
+            object_id is not None and
+            object_id != self._place_selection.object_id and
+            self._is_location_suitable_for_placement(place_normal)
+        ):
+            # Drop the object.
+            rigid_object = self._get_rigid_object(object_id)
+            rigid_object.translation = place_point + mn.Vector3(0.0, rigid_object.collision_shape_aabb.size_y() / 2, 0.0)
+            self._held_object_id = None
+            self._place_selection.deselect()
+
+    def _interact_with_object(self, object_id: int) -> None:
+        """Open/close the selected object. Must be interactable."""
+        if self._is_object_interactable(object_id):
+            link_id = object_id
+            link_index = self._get_link_index(link_id)
+            if link_index:
+                ao_id = self._link_id_to_ao_map[link_id]
+                ao = self._get_articulated_object(ao_id)
+                link_node = ao.get_link_scene_node(link_index)
+                link_pos = link_node.translation
+                if self._is_within_reach(link_pos):
+                    # Open/close object.
+                    if link_id in self._opened_link_set:
+                        sim_utilities.close_link(ao, link_index)
+                        self._opened_link_set.remove(link_id)
+                    else:
+                        sim_utilities.open_link(ao, link_index)
+                        self._opened_link_set.add(link_id)
+
+    def _update_held_object_placement(self) -> None:
+        """Update the location of the held object."""
+        object_id = self._held_object_id
+        if not object_id:
+            return
+
+        eye_position = self._camera_helper.get_eye_pos()
+        forward_vector = (
+            self._camera_helper.get_lookat_pos()
+            - self._camera_helper.get_eye_pos()
+        ).normalized()
+
+        rigid_object = (
+            self._sim
+            .get_rigid_object_manager()
+            .get_object_by_id(object_id)
+        )
+        rigid_object.translation = eye_position + forward_vector
+
+    def _user_pos(self) -> mn.Vector3:
+        """Get the translation of the agent controlled by the user."""
+        return get_agent_art_obj_transform(
+            self._sim, self._gui_controller._agent_idx
+        ).translation
+
+    def _get_rigid_object(self, object_id: int) -> Optional[Any]:
+        """Get the rigid object with the specified ID. Returns None if unsuccessful."""
+        rom = self._sim.get_rigid_object_manager()
+        return rom.get_object_by_id(object_id)
+
+    def _get_articulated_object(self, object_id: int) -> Optional[Any]:
+        """Get the articulated object with the specified ID. Returns None if unsuccessful."""
+        aom = self._sim.get_articulated_object_manager()
+        return aom.get_object_by_id(object_id)
+
+    def _get_link_index(self, object_id: int) -> int:
+        """Get the index of a link. Returns None if unsuccessful."""
+        link_id = object_id
+        if link_id in self._link_id_to_ao_map:
+            ao_id = self._link_id_to_ao_map[link_id]
+            ao = self._get_articulated_object(ao_id)
+            link_id_to_index: Dict[int, int] = ao.link_object_ids
+            if link_id in link_id_to_index:
+                return link_id_to_index[link_id]
+        return None
+
+    def _horizontal_distance(self, a: mn.Vector3, b: mn.Vector3) -> float:
+        """Compute the distance between two points on the horizontal plane."""
+        displacement = a - b
+        displacement.y = 0.0
+        return mn.Vector3(displacement.x, 0.0, displacement.z).length()
+
+    def _is_object_pickable(self, object_id: int) -> bool:
+        """Returns true if the object can be picked."""
+        return object_id is not None and object_id in self._pickable_object_ids
+
+    def _is_object_interactable(self, object_id: int) -> bool:
+        """Returns true if the object can be opened or closed."""
+        return (
+            object_id is not None and
+            object_id in self._interactable_object_ids and
+            object_id in self._link_id_to_ao_map
+        )
+
+    def _is_holding_object(self) -> bool:
+        """Returns true if the user is holding an object."""
+        return self._held_object_id is not None
+
+    def _is_within_reach(
+        self, target_pos: mn.Vector3
+    ) -> bool:
+        """Returns true if the target can be reached by the user."""
+        return (
+            self._horizontal_distance(self._user_pos(), target_pos)
+            < self._can_grasp_place_threshold
+        )
+
+    def _is_location_suitable_for_placement(self, point: mn.Vector3, normal: mn.Vector3) -> bool:
+        """Returns true if the target location is suitable for placement."""
+        placement_verticality = mn.math.dot(normal, mn.Vector3(0, 1, 0))
+        placement_valid = placement_verticality > MINIMUM_DROP_VERTICALITY
+        return placement_valid and self._is_within_reach(point)
+    
+    def _draw_aabb(self, aabb: mn.Range3D, transform: mn.Matrix4, color: mn.Color3) -> None:
+        """Draw an AABB."""
+        self._gui_drawer.push_transform(
+            transform, destination_mask=self._dest_mask
+        )
+        self._gui_drawer.draw_box(
+            min_extent=aabb.back_bottom_left,
+            max_extent=aabb.front_top_right,
+            color=color,
+            destination_mask=self._dest_mask,
+        )
+        self._gui_drawer.pop_transform(
+            destination_mask=self._dest_mask
+        )
+    
+    def _draw_place_selection(self) -> None:
+        """Draw the object placement selection."""
+        if not self._place_selection.selected or self._held_object_id is None:
+            return
+        
+        point = self._place_selection.point
+        normal = self._place_selection.normal
+        placement_valid = self._is_location_suitable_for_placement(normal)
+        color = COLOR_VALID if placement_valid else COLOR_INVALID
+        radius = 0.15 if placement_valid else 0.05
+        self._gui_drawer.draw_circle(
+            translation=point,
+            radius=radius,
+            color=color,
+            normal=normal,
+            billboard=False,
+            destination_mask=self._dest_mask,
+        )
+
+    def _draw_hovered_interactable(self) -> None:
+        """Highlight the hovered interactable object."""
+        if not self._hover_selection.selected:
+            return
+        
+        object_id = self._hover_selection.object_id
+        if not self._is_object_interactable(object_id):
+            return
+        
+        link_index = self._get_link_index(object_id)
+        if link_index:
+            ao = sim_utilities.get_obj_from_id(
+                self._sim, object_id, self._link_id_to_ao_map
+            )
+            link_node = ao.get_link_scene_node(link_index)
+            aabb = link_node.cumulative_bb
+            reachable = self._is_within_reach(link_node.translation
+            )
+            color = COLOR_VALID if reachable else COLOR_INVALID
+            self._draw_aabb(aabb, link_node.transformation, color)
+
+    def _draw_hovered_pickable(self) -> None:
+        """Highlight the hovered pickable object."""
+        if not self._hover_selection.selected or self._is_holding_object():
+            return
+        
+        object_id = self._hover_selection.object_id
+        if not self._is_object_pickable(object_id):
+            return
+        
+        managed_object = sim_utilities.get_obj_from_id(
+            self._sim, object_id, self._link_id_to_ao_map
+        )
+        translation = managed_object.translation
+        reachable = self._is_within_reach(translation)
+        color = COLOR_VALID if reachable else COLOR_INVALID
+        aabb = managed_object.collision_shape_aabb
+        self._draw_aabb(aabb, managed_object.transformation, color)
+
+    def _draw_goals(self) -> None:
+        """Draw goal object-receptacle pairs."""
+        # TODO: Cache
+        for i in range(len(self._paired_goal_ids)):
+            rigid_ids = self._paired_goal_ids[i][0]
+            receptacle_ids = self._paired_goal_ids[i][1]
+            goal_pair_color = COLOR_GOALS[i % len(COLOR_GOALS)]
+            for rigid_id in rigid_ids:
+                if self._hover_selection.object_id == rigid_id:
+                    continue
+                managed_object = sim_utilities.get_obj_from_id(
+                    self._sim, rigid_id, self._link_id_to_ao_map
+                )
+                translation = managed_object.translation
+                self._gui_drawer.draw_circle(
+                    translation=translation,
+                    radius=0.25,
+                    color=goal_pair_color,
+                    billboard=True,
+                    destination_mask=self._dest_mask,
+                )
+            for receptacle_id in receptacle_ids:
+                managed_object = sim_utilities.get_obj_from_id(
+                    self._sim, receptacle_id, self._link_id_to_ao_map
+                )
+                aabb = None
+                if hasattr(managed_object, "collision_shape_aabb"):
+                    aabb = managed_object.collision_shape_aabb
+                else:
+                    link_index = self._get_link_index(receptacle_id)
+                    if link_index is not None:
+                        link_node = managed_object.get_link_scene_node(
+                            link_index
+                        )
+                        aabb = link_node.cumulative_bb
+                if aabb is not None:
+                    self._draw_aabb(aabb, managed_object.transformation, goal_pair_color)

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -415,8 +415,6 @@ class UI:
             receptacle_ids = self._object_receptacle_pairs[i][1]
             goal_pair_color = COLOR_GOALS[i % len(COLOR_GOALS)]
             for rigid_id in rigid_ids:
-                if self._hover_selection.object_id == rigid_id:
-                    continue
                 managed_object = sim_utilities.get_obj_from_id(
                     self._sim, rigid_id, self._link_id_to_ao_map
                 )

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -410,37 +410,36 @@ class UI:
     def _draw_goals(self) -> None:
         """Draw goal object-receptacle pairs."""
         # TODO: Cache
-        for i in range(len(self._object_receptacle_pairs)):
-            rigid_ids = self._object_receptacle_pairs[i][0]
-            receptacle_ids = self._object_receptacle_pairs[i][1]
+        sim = self._sim
+        obj_receptacle_pairs = self._object_receptacle_pairs
+        link_id_to_ao_map = self._link_id_to_ao_map
+        dest_mask = self._dest_mask
+        get_obj_from_id = sim_utilities.get_obj_from_id
+        draw_gui_circle = self._gui_drawer.draw_circle
+        draw_gui_aabb = self._draw_aabb
+
+        for i in range(len(obj_receptacle_pairs)):
+            rigid_ids = obj_receptacle_pairs[i][0]
+            receptacle_ids = obj_receptacle_pairs[i][1]
             goal_pair_color = COLOR_GOALS[i % len(COLOR_GOALS)]
             for rigid_id in rigid_ids:
-                managed_object = sim_utilities.get_obj_from_id(
-                    self._sim, rigid_id, self._link_id_to_ao_map
+                managed_object = get_obj_from_id(
+                    sim, rigid_id, link_id_to_ao_map
                 )
                 translation = managed_object.translation
-                self._gui_drawer.draw_circle(
+                draw_gui_circle(
                     translation=translation,
                     radius=0.25,
                     color=goal_pair_color,
                     billboard=True,
-                    destination_mask=self._dest_mask,
+                    destination_mask=dest_mask,
                 )
             for receptacle_id in receptacle_ids:
-                managed_object = sim_utilities.get_obj_from_id(
-                    self._sim, receptacle_id, self._link_id_to_ao_map
+                managed_object = get_obj_from_id(
+                    sim, receptacle_id, link_id_to_ao_map
                 )
-                aabb = None
-                if hasattr(managed_object, "collision_shape_aabb"):
-                    aabb = managed_object.collision_shape_aabb
-                else:
-                    link_index = self._get_link_index(receptacle_id)
-                    if link_index is not None:
-                        link_node = managed_object.get_link_scene_node(
-                            link_index
-                        )
-                        aabb = link_node.cumulative_bb
+                aabb, matrix = sim_utilities.get_bb_for_object_id(
+                    sim, receptacle_id, link_id_to_ao_map
+                )
                 if aabb is not None:
-                    self._draw_aabb(
-                        aabb, managed_object.transformation, goal_pair_color
-                    )
+                    draw_gui_aabb(aabb, matrix, goal_pair_color)

--- a/habitat-hitl/habitat_hitl/core/selection.py
+++ b/habitat-hitl/habitat_hitl/core/selection.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Optional
+
+from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
+from habitat_hitl.core.gui_input import GuiInput
+from habitat_hitl.core.key_mapping import MouseButton
+import magnum as mn
+
+from habitat_sim.geo import Ray
+from habitat_sim.physics import RayHitInfo
+
+class Selection:
+    """
+    Class that handles selection by tracking a given GuiInput.
+    """
+    def hover_fn(_gui_input: GuiInput) -> bool:
+        """Select the object under the cursor every frame."""
+        return True
+
+    def left_click_fn(_gui_input: GuiInput) -> bool:
+        """Select the object under the cursor when left clicking."""
+        return _gui_input.get_mouse_button_down(MouseButton.LEFT)
+    
+    def right_click_fn(_gui_input: GuiInput) -> bool:
+        """Select the object under the cursor when right clicking."""
+        return _gui_input.get_mouse_button_down(MouseButton.RIGHT)
+
+    def default_discriminator(_object_id: int) -> bool:
+        """Pick any object ID."""
+        return True
+
+    def __init__(self,
+                 simulator: HabitatSim,
+                 gui_input: GuiInput,
+                 selection_fn: Callable[[GuiInput], bool],
+                 object_id_discriminator: Callable[[int], bool] = default_discriminator,
+                 ):
+        """
+        :param simulator: Simulator that is raycast upon.
+        :param gui_input: GuiInput to track.
+        :param selection_fn: Function that returns true if gui_input is attempting selection.
+        :param object_id_discriminator: Function that determines whether an object ID is selectable.
+                                        By default, all objects are selectable.
+        """
+        self._sim = simulator
+        self._gui_input = gui_input
+        self._discriminator = object_id_discriminator
+        self._selection_fn = selection_fn
+
+        self._selected = False
+        self._object_id: Optional[int] = None
+        self._point: Optional[mn.Vector3] = None
+        self._normal: Optional[mn.Vector3] = None
+
+    @property
+    def selected(self) -> bool:
+        """Returns true if something is selected."""
+        return self._selected
+    
+    @property
+    def object_id(self) -> Optional[int]:
+        """Currently selected object ID."""
+        return self._object_id
+
+    @property
+    def point(self) -> Optional[mn.Vector3]:
+        """Point of the currently selected location."""
+        return self._point 
+
+    @property
+    def normal(self) -> Optional[mn.Vector3]:
+        """Normal at the currently selected location."""
+        return self._normal 
+
+    def deselect(self) -> None:
+        """Clear selection."""
+        self._selected = False
+        self._object_id = None
+        self._point = None
+        self._normal = None
+
+    def update(self) -> None:
+        """Update selection."""
+        if self._selection_fn(self._gui_input):
+            ray = self._gui_input.mouse_ray
+            if ray is not None:
+                hit_info = self._raycast(ray)
+                if hit_info is None:
+                    self.deselect()
+                    return
+                
+                object_id: int = hit_info.object_id
+
+                if self._discriminator(object_id):
+                    self._selected = True
+                    self._object_id = object_id
+                    self._point = hit_info.point
+                    self._normal = hit_info.normal
+                else:
+                    self.deselect()
+
+    def _raycast(self, ray: Ray) -> Optional[RayHitInfo]:
+        raycast_results = self._sim.cast_ray(ray=ray)
+        if not raycast_results.has_hits():
+            return None
+        # Results are sorted by distance. [0] is the nearest one.
+        hit_info = raycast_results.hits[0]
+        return hit_info

--- a/habitat-hitl/habitat_hitl/core/selection.py
+++ b/habitat-hitl/habitat_hitl/core/selection.py
@@ -20,23 +20,19 @@ class Selection:
     Class that handles selection by tracking a given GuiInput.
     """
 
-    @staticmethod
-    def hover_fn(_gui_input: GuiInput) -> bool:
+    def hover_fn(_gui_input: GuiInput) -> bool:  # type: ignore
         """Select the object under the cursor every frame."""
         return True
 
-    @staticmethod
-    def left_click_fn(_gui_input: GuiInput) -> bool:
+    def left_click_fn(_gui_input: GuiInput) -> bool:  # type: ignore
         """Select the object under the cursor when left clicking."""
         return _gui_input.get_mouse_button_down(MouseButton.LEFT)
 
-    @staticmethod
-    def right_click_fn(_gui_input: GuiInput) -> bool:
+    def right_click_fn(_gui_input: GuiInput) -> bool:  # type: ignore
         """Select the object under the cursor when right clicking."""
         return _gui_input.get_mouse_button_down(MouseButton.RIGHT)
 
-    @staticmethod
-    def default_discriminator(_object_id: int) -> bool:
+    def default_discriminator(_object_id: int) -> bool:  # type: ignore
         """Pick any object ID."""
         return True
 

--- a/habitat-hitl/habitat_hitl/core/selection.py
+++ b/habitat-hitl/habitat_hitl/core/selection.py
@@ -6,40 +6,47 @@
 
 from typing import Callable, Optional
 
+import magnum as mn
+
 from habitat.sims.habitat_simulator.habitat_simulator import HabitatSim
 from habitat_hitl.core.gui_input import GuiInput
 from habitat_hitl.core.key_mapping import MouseButton
-import magnum as mn
-
 from habitat_sim.geo import Ray
 from habitat_sim.physics import RayHitInfo
+
 
 class Selection:
     """
     Class that handles selection by tracking a given GuiInput.
     """
+
+    @staticmethod
     def hover_fn(_gui_input: GuiInput) -> bool:
         """Select the object under the cursor every frame."""
         return True
 
+    @staticmethod
     def left_click_fn(_gui_input: GuiInput) -> bool:
         """Select the object under the cursor when left clicking."""
         return _gui_input.get_mouse_button_down(MouseButton.LEFT)
-    
+
+    @staticmethod
     def right_click_fn(_gui_input: GuiInput) -> bool:
         """Select the object under the cursor when right clicking."""
         return _gui_input.get_mouse_button_down(MouseButton.RIGHT)
 
+    @staticmethod
     def default_discriminator(_object_id: int) -> bool:
         """Pick any object ID."""
         return True
 
-    def __init__(self,
-                 simulator: HabitatSim,
-                 gui_input: GuiInput,
-                 selection_fn: Callable[[GuiInput], bool],
-                 object_id_discriminator: Callable[[int], bool] = default_discriminator,
-                 ):
+    def __init__(
+        self,
+        simulator: HabitatSim,
+        gui_input: GuiInput,
+        selection_fn: Callable[[GuiInput], bool],
+        object_id_discriminator: Callable[[int], bool] = default_discriminator,
+    ):
         """
         :param simulator: Simulator that is raycast upon.
         :param gui_input: GuiInput to track.
@@ -61,7 +68,7 @@ class Selection:
     def selected(self) -> bool:
         """Returns true if something is selected."""
         return self._selected
-    
+
     @property
     def object_id(self) -> Optional[int]:
         """Currently selected object ID."""
@@ -70,12 +77,12 @@ class Selection:
     @property
     def point(self) -> Optional[mn.Vector3]:
         """Point of the currently selected location."""
-        return self._point 
+        return self._point
 
     @property
     def normal(self) -> Optional[mn.Vector3]:
         """Normal at the currently selected location."""
-        return self._normal 
+        return self._normal
 
     def deselect(self) -> None:
         """Clear selection."""
@@ -93,7 +100,7 @@ class Selection:
                 if hit_info is None:
                     self.deselect()
                     return
-                
+
                 object_id: int = hit_info.object_id
 
                 if self._discriminator(object_id):


### PR DESCRIPTION
## Motivation and Context

This adds a new UI to the `rearrange_v2` app with the following features:
* Mouse-based pick and place.
* Mouse-based open/close of articulated object links.
* Color coding of goal object-receptacle pairs.
* Refactoring.

---

## Features

Here are videos showing the overall changes. Note that the instruction text was disabled for visibility, and that highlight circle billboarding is only implemented in Unity.

**Double-click to open individual articulated object links:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/2abf1b16-1182-432c-bcae-90ffe83f37c3

**Double-click to pick objects, and release right click to place it:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/5c08ee09-ae9d-4b5a-9631-0ba9ac69b7d2

**While holding right click, an indicator shows up communicating whether the object can be placed:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/1a891cb5-d43e-421b-af61-f2a19c5e2359

**Experiment objects must be placed on specific receptacles. The pairs are color-coded:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/be07b754-7834-4f65-b890-d161ffb7b1ca

**When an action is possible, the color is green. Otherwise, it is red:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/d4024df8-65fd-46ff-97d2-79cf423a6545

**All of this works in Unity:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/c38b6a62-aad9-4134-a0aa-1a6276069856

---

## How Has This Been Tested

Tested locally and with remote Unity client.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
