### PR TITLE
[CI] re-activate the config test after upstream sim fix

### DIFF
--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -567,9 +567,7 @@ def test_ao_open_close_queries():
         new_default_link = sutils.get_ao_default_link(
             new_fridge, compute_if_not_found=True
         )
-        print(
-            f" new_default_link (== {new_default_link}) should be 0, waiting on sim bug fix."
-        )
+
         # "default_link" should get copied over after instantiation if set in the template programmatically.
         assert new_default_link == 0
 

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -547,6 +547,15 @@ def test_ao_open_close_queries():
         sim.metadata_mediator.ao_template_manager.register_template(
             fridge_template, "new_fridge_template"
         )
+        new_fridge_template_check = (
+            sim.metadata_mediator.ao_template_manager.get_template_by_handle(
+                "new_fridge_template"
+            )
+        )
+        assert (
+            new_fridge_template_check.get_user_config().get("default_link")
+            == 0
+        )
         new_fridge = sim.get_articulated_object_manager().add_articulated_object_by_template_handle(
             "new_fridge_template"
         )
@@ -561,8 +570,8 @@ def test_ao_open_close_queries():
         print(
             f" new_default_link (== {new_default_link}) should be 0, waiting on sim bug fix."
         )
-        # TODO: habitat-sim bug. "default_link" does not get copied over after instantiation if set in the template programmatically.
-        # assert new_default_link == 0
+        # "default_link" should get copied over after instantiation if set in the template programmatically.
+        assert new_default_link == 0
 
         # test setting the default link in instance metadata
         fridge.user_attributes.set("default_link", 0)


### PR DESCRIPTION
## Motivation and Context

This PR re-activates the test for setting user_defined config values programmatically in the object template before instantiating the object.

The previous bug was fixed in https://github.com/facebookresearch/habitat-sim/pull/2359

## How Has This Been Tested

CI and local testing.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
