### PR TITLE
rec filter generic subset type parsing with option of "within_set"

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -866,12 +866,12 @@ def get_excluded_recs_from_filter_file(
     rec_filter_filepath: str, filter_types: Optional[List[str]] = None
 ) -> List[str]:
     """
-    Load and digest a Receptacle filter file to generate a list of strings which should be excluded from the active ReceptacleSet.
+    Load and digest a Receptacle filter file to generate a list of Receptacle.unique_names strings which should be excluded from the active ReceptacleSet.
 
-    :param filter_types: Optionally specify a particular set of filter types to scrape. Default is all filters.
+    :param filter_types: Optionally specify a particular set of filter types to scrape. Default is all exclusion filters.
     """
 
-    possible_filter_types = [
+    possible_exclude_filter_types = [
         "manually_filtered",
         "access_filtered",
         "stability_filtered",
@@ -879,12 +879,40 @@ def get_excluded_recs_from_filter_file(
     ]
 
     if filter_types is None:
-        filter_types = possible_filter_types
+        filter_types = possible_exclude_filter_types
     else:
         for filter_type in filter_types:
             assert (
-                filter_type in possible_filter_types
-            ), f"Specified filter type '{filter_type}' is not in supported set: {possible_filter_types}"
+                filter_type in possible_exclude_filter_types
+            ), f"Specified filter type '{filter_type}' is not in supported set: {possible_exclude_filter_types}"
+
+    return get_recs_from_filter_file(rec_filter_filepath, filter_types)
+
+
+def get_recs_from_filter_file(
+    rec_filter_filepath: str, filter_types: List[str]
+) -> List[str]:
+    """
+    Load and digest a Receptacle filter file to generate a list of Receptacle.unique_names which belong to a particular filter subset.
+
+    :param filter_types: Specify a particular subset of filter types to include.
+    """
+
+    # all allowed filter set types include:
+    all_possible_filter_types = [
+        "active",
+        "manually_filtered",
+        "access_filtered",
+        "stability_filtered",
+        "height_filtered",
+        "within_set",
+    ]
+
+    # check that specified query filter types are valid
+    for filter_type in filter_types:
+        assert (
+            filter_type in all_possible_filter_types
+        ), f"Specified filter type '{filter_type}' is not in supported set: {all_possible_filter_types}"
 
     filtered_unique_names = []
     with open(rec_filter_filepath, "r") as f:
@@ -892,7 +920,7 @@ def get_excluded_recs_from_filter_file(
         for filter_type in filter_types:
             for filtered_unique_name in filter_json[filter_type]:
                 filtered_unique_names.append(filtered_unique_name)
-    return filtered_unique_names
+    return list(set(filtered_unique_names))
 
 
 class ReceptacleTracker:


### PR DESCRIPTION
## Motivation and Context

Expand the "rec_filter_file" parsing to allow specification of a custom subset of defined filter types. Also add "within_set" as a supported field in preparation for new metadata distinguishing Receptacles which are accessible in the scene's default state from those which are only accessible after opening an ArticulatedObject.

## How Has This Been Tested

Indirectly through downstream code. TODO: Should be tested better when CI dataset is available. 

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
