### PR TITLE
AnyObjectReceptacle

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -530,11 +530,20 @@ class AnyObjectReceptacle(Receptacle):
     ) -> mn.Vector3:
         """
         Sample a uniform random point on the top surface of the global bounding box of the object.
-        If a pre-computed candidate point set was cached, simply sample from those points instead.
+        TODO: If a pre-computed candidate point set was cached, simply sample from those points instead.
 
         :param sample_region_scale: defines a XZ scaling of the sample region around its center. No-op for cached points.
         """
         aabb = self._get_global_bb(sim)
+        if sample_region_scale != 1.0:
+            aabb = mn.Range3D.from_center(
+                aabb.center(),
+                aabb.scaled(
+                    mn.Vector3d(sample_region_scale, 1, sample_region_scale)
+                ).size()
+                / 2.0,
+            )
+
         sample = np.random.uniform(aabb.back_top_left, aabb.front_top_right)
         return sample
 

--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -475,12 +475,14 @@ class AnyObjectReceptacle(Receptacle):
 
         :param precompute_candidate_pointset: Whether or not to pre-compute and cache a discrete point set for sampling instead of using the global bounding box. Uses raycasting with rejection sampling.
         """
+
         super().__init__(name, parent_object_handle, parent_link)
 
     def _get_global_bb(self, sim: habitat_sim.Simulator) -> mn.Range3D:
         """
         Get the global AABB of the Receptacle parent object.
         """
+
         obj = sutils.get_obj_from_handle(sim, self.parent_object_handle)
         global_keypoints = None
         if isinstance(obj, habitat_sim.physics.ManagedRigidObject):
@@ -510,6 +512,7 @@ class AnyObjectReceptacle(Receptacle):
         NOTE: this is an effortful query, not a getter.
         TODO: This needs a sim instance to compute the global bounding box
         """
+
         # TODO: grab the bounds from the global AABB at this state?
         # return mn.Range3D()
         raise NotImplementedError
@@ -523,6 +526,7 @@ class AnyObjectReceptacle(Receptacle):
 
         :param sample_region_scale: defines a XZ scaling of the sample region around its center. For example to constrain object spawning toward the center of a receptacle.
         """
+
         raise NotImplementedError
 
     def sample_uniform_global(
@@ -534,6 +538,7 @@ class AnyObjectReceptacle(Receptacle):
 
         :param sample_region_scale: defines a XZ scaling of the sample region around its center. No-op for cached points.
         """
+
         aabb = self._get_global_bb(sim)
         if sample_region_scale != 1.0:
             aabb = mn.Range3D.from_center(
@@ -557,6 +562,7 @@ class AnyObjectReceptacle(Receptacle):
         :param sim: Simulator must be provided.
         :param color: Optionally provide wireframe color, otherwise magenta.
         """
+
         aabb = self._get_global_bb(sim)
         top_min = aabb.min
         top_min[1] = aabb.top

--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -16,9 +16,11 @@ import corrade as cr
 import magnum as mn
 import numpy as np
 
+import habitat.sims.habitat_simulator.sim_utilities as sutils
 import habitat_sim
 from habitat.core.logging import logger
 from habitat.datasets.rearrange.navmesh_utils import is_accessible
+from habitat.sims.habitat_simulator.debug_visualizer import dblr_draw_bb
 from habitat.tasks.rearrange.utils import get_ao_link_aabb, get_rigid_aabb
 from habitat.utils.geometry_utils import random_triangle_point
 from habitat_sim.utils.common import quat_from_two_vectors as qf2v
@@ -273,13 +275,12 @@ class AABBReceptacle(Receptacle):
         :param sim: Simulator must be provided.
         :param color: Optionally provide wireframe color, otherwise magenta.
         """
-        # draw the box
-        if color is None:
-            color = mn.Color4.magenta()
-        dblr = sim.get_debug_line_render()
-        dblr.push_transform(self.get_global_transform(sim))
-        dblr.draw_box(self.bounds.min, self.bounds.max, color)
-        dblr.pop_transform()
+        dblr_draw_bb(
+            sim.get_debug_line_render(),
+            self.bounds,
+            self.get_global_transform(sim),
+            color,
+        )
 
 
 def assert_triangles(indices: List[int]) -> None:
@@ -451,6 +452,123 @@ class TriangleMeshReceptacle(Receptacle):
                     verts[edge], verts[(edge + 1) % 3], color
                 )
         dblr.pop_transform()
+
+
+class AnyObjectReceptacle(Receptacle):
+    """
+    The AnyObjectReceptacle enables any rigid or articulated object or link to be used as a Receptacle without metadata annotation.
+    It uses the top surface of an object's global space bounding box as a heuristic for the sampling area.
+    The sample efficiency is likely to be poor (especially for concave objects like L-shaped sofas), this is mitigated by the option to pre-compute a discrete set of candidate points via raycast upon initialization.
+    Also, this heuristic will not support use of interior surfaces such as cubby and cabinet shelves since volumetric occupancy is not considered.
+
+    Note the caveats above and consider that the ideal application of the AnyObjectReceptacle is to support placement of objects onto other simple objects such as open face crates, bins, baskets, trays, plates, bowls, etc... for which receptacle annotation would be overkill.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parent_object_handle: str = None,
+        parent_link: Optional[int] = None,
+        precompute_candidate_pointset: bool = False,
+    ):
+        """
+        Initialize the object as a Receptacle.
+
+        :param precompute_candidate_pointset: Whether or not to pre-compute and cache a discrete point set for sampling instead of using the global bounding box. Uses raycasting with rejection sampling.
+        """
+        super().__init__(name, parent_object_handle, parent_link)
+        self.precomputed_candidate_pointset = None
+        self.max_precomputed_candidate_point_samples: int = (
+            100  # modify this for fidelity vs. speed tradeoff
+        )
+
+    def candidate_pointset_precomputation(self) -> None:
+        """
+        Use vertical raycasting in the object's current state to collect a set of points which are candidates for object placement with snap.
+        Acceptable candidate points are those for which a downward vertical raycast hits the object surface. Other hits in the scene are ignored.
+        """
+        # TODO: sampling logic
+        # TODO: compute the bounds
+
+    def _get_global_bb(self, sim: habitat_sim.Simulator) -> mn.Range3D:
+        """
+        Get the global AABB of the Receptacle parent object.
+        """
+        obj = sutils.get_obj_from_handle(sim, self.parent_object_handle)
+        global_keypoints = None
+        if isinstance(obj, habitat_sim.physics.ManagedRigidObject):
+            global_keypoints = sutils.get_rigid_object_global_keypoints(obj)
+        elif self.parent_link is not None and self.parent_link >= 0:
+            # link
+            global_keypoints = sutils.get_articulated_link_global_keypoints(
+                obj, self.parent_link
+            )
+        else:
+            # AO
+            global_keypoints = sutils.get_articulated_object_global_keypoints(
+                obj
+            )
+
+        # find min and max
+        global_bb = mn.Range3D(
+            np.min(global_keypoints, axis=0), np.max(global_keypoints, axis=0)
+        )
+
+        return global_bb
+
+    @property
+    def bounds(self) -> mn.Range3D:
+        """
+        AABB of the Receptacle in local space.
+        NOTE: unless cached points are used, this is an effortful query, not a getter.
+        """
+        # TODO: grab the bounds from the global AABB at this state
+        if self.precomputed_candidate_pointset is not None:
+            # TODO: return the cached bounds
+            pass
+        return mn.Range3D()
+
+    def sample_uniform_local(
+        self, sample_region_scale: float = 1.0
+    ) -> mn.Vector3:
+        """
+        Sample a uniform random point within Receptacle in local space.
+        NOTE: This only works if a pointset cache was pre-computed. Otherwise raises an exception.
+
+        :param sample_region_scale: defines a XZ scaling of the sample region around its center. For example to constrain object spawning toward the center of a receptacle.
+        """
+        raise NotImplementedError
+
+    def sample_uniform_global(
+        self, sim: habitat_sim.Simulator, sample_region_scale: float
+    ) -> mn.Vector3:
+        """
+        Sample a uniform random point on the top surface of the global bounding box of the object.
+        If a pre-computed candidate point set was cached, simply sample from those points instead.
+
+        :param sample_region_scale: defines a XZ scaling of the sample region around its center. No-op for cached points.
+        """
+        aabb = self._get_global_bb(sim)
+        sample = np.random.uniform(aabb.back_top_left, aabb.front_top_right)
+        return sample
+
+    def debug_draw(
+        self, sim: habitat_sim.Simulator, color: Optional[mn.Color4] = None
+    ) -> None:
+        """
+        Render the Receptacle with DebugLineRender utility at the current frame.
+        Must be called after each frame is rendered, before querying the image data.
+
+        :param sim: Simulator must be provided.
+        :param color: Optionally provide wireframe color, otherwise magenta.
+        """
+        aabb = self._get_global_bb(sim)
+        top_min = aabb.min
+        top_min[1] = aabb.top
+        top_max = aabb.max
+        top_max[1] = aabb.top
+        top_range = mn.Range3D(top_min, top_max)
+        dblr_draw_bb(sim.get_debug_line_render(), top_range, color=color)
 
 
 def get_all_scenedataset_receptacles(

--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -458,7 +458,7 @@ class AnyObjectReceptacle(Receptacle):
     """
     The AnyObjectReceptacle enables any rigid or articulated object or link to be used as a Receptacle without metadata annotation.
     It uses the top surface of an object's global space bounding box as a heuristic for the sampling area.
-    The sample efficiency is likely to be poor (especially for concave objects like L-shaped sofas), this is mitigated by the option to pre-compute a discrete set of candidate points via raycast upon initialization.
+    The sample efficiency is likely to be poor (especially for concave objects like L-shaped sofas), TODO: this could be mitigated by the option to pre-compute a discrete set of candidate points via raycast upon initialization.
     Also, this heuristic will not support use of interior surfaces such as cubby and cabinet shelves since volumetric occupancy is not considered.
 
     Note the caveats above and consider that the ideal application of the AnyObjectReceptacle is to support placement of objects onto other simple objects such as open face crates, bins, baskets, trays, plates, bowls, etc... for which receptacle annotation would be overkill.
@@ -469,7 +469,6 @@ class AnyObjectReceptacle(Receptacle):
         name: str,
         parent_object_handle: str = None,
         parent_link: Optional[int] = None,
-        precompute_candidate_pointset: bool = False,
     ):
         """
         Initialize the object as a Receptacle.
@@ -477,18 +476,6 @@ class AnyObjectReceptacle(Receptacle):
         :param precompute_candidate_pointset: Whether or not to pre-compute and cache a discrete point set for sampling instead of using the global bounding box. Uses raycasting with rejection sampling.
         """
         super().__init__(name, parent_object_handle, parent_link)
-        self.precomputed_candidate_pointset = None
-        self.max_precomputed_candidate_point_samples: int = (
-            100  # modify this for fidelity vs. speed tradeoff
-        )
-
-    def candidate_pointset_precomputation(self) -> None:
-        """
-        Use vertical raycasting in the object's current state to collect a set of points which are candidates for object placement with snap.
-        Acceptable candidate points are those for which a downward vertical raycast hits the object surface. Other hits in the scene are ignored.
-        """
-        # TODO: sampling logic
-        # TODO: compute the bounds
 
     def _get_global_bb(self, sim: habitat_sim.Simulator) -> mn.Range3D:
         """
@@ -520,13 +507,12 @@ class AnyObjectReceptacle(Receptacle):
     def bounds(self) -> mn.Range3D:
         """
         AABB of the Receptacle in local space.
-        NOTE: unless cached points are used, this is an effortful query, not a getter.
+        NOTE: this is an effortful query, not a getter.
+        TODO: This needs a sim instance to compute the global bounding box
         """
-        # TODO: grab the bounds from the global AABB at this state
-        if self.precomputed_candidate_pointset is not None:
-            # TODO: return the cached bounds
-            pass
-        return mn.Range3D()
+        # TODO: grab the bounds from the global AABB at this state?
+        # return mn.Range3D()
+        raise NotImplementedError
 
     def sample_uniform_local(
         self, sample_region_scale: float = 1.0

--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -123,7 +123,13 @@ def dblr_draw_bb(
 ) -> None:
     """
     Draw an optionally transformed bounding box with the DebugLineRender interface.
+
+    :param debug_line_render: The DebugLineRender instance.
+    :param bb: The local bounding box to draw.
+    :param transform: The local to global transformation to apply to the local bb.
+    :param color: Optional color for the lines. Default is magenta.
     """
+
     if color is None:
         color = mn.Color4.magenta()
     if transform is not None:

--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -115,6 +115,24 @@ def draw_object_highlight(
     )
 
 
+def dblr_draw_bb(
+    debug_line_render: habitat_sim.gfx.DebugLineRender,
+    bb: mn.Range3D,
+    transform: mn.Matrix4 = None,
+    color: mn.Color4 = None,
+) -> None:
+    """
+    Draw an optionally transformed bounding box with the DebugLineRender interface.
+    """
+    if color is None:
+        color = mn.Color4.magenta()
+    if transform is not None:
+        debug_line_render.push_transform(transform)
+    debug_line_render.draw_box(bb.min, bb.max, color)
+    if transform is not None:
+        debug_line_render.pop_transform()
+
+
 class DebugVisualizer:
     """
     Support class for simple visual debugging of a Simulator instance.

--- a/test/test_rearrange_task.py
+++ b/test/test_rearrange_task.py
@@ -18,6 +18,7 @@ from omegaconf import DictConfig, OmegaConf
 import habitat
 import habitat.datasets.rearrange.run_episode_generator as rr_gen
 import habitat.datasets.rearrange.samplers.receptacle as hab_receptacle
+import habitat.sims.habitat_simulator.sim_utilities as sutils
 import habitat.tasks.rearrange.rearrange_sim
 import habitat.tasks.rearrange.rearrange_task
 import habitat.utils.env_utils
@@ -462,3 +463,83 @@ def test_receptacle_parsing():
                         assert (
                             in_mesh
                         ), "The point must belong to a triangle of the local mesh to be valid."
+
+
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/replicaCAD.scene_dataset_config.json"),
+    reason="This test requires replica cad SceneDataset.",
+)
+@pytest.mark.skipif(
+    not habitat_sim.bindings.built_with_bullet,
+    reason="Bullet physics used for validation.",
+)
+def test_any_object_receptacle():
+    sim_settings = habitat_sim.utils.settings.default_sim_settings.copy()
+    sim_settings["scene"] = "apt_0"
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    cfg = habitat_sim.utils.settings.make_cfg(sim_settings)
+    with habitat_sim.Simulator(cfg) as sim:
+        # get an object which does not have a Receptacle defined
+        stool_object = sutils.get_obj_from_handle(
+            sim, "frl_apartment_stool_02_:0000"
+        )
+        # get an ArticulatedObject and an ArticulatedLink to try
+        counter_ao = sutils.get_obj_from_handle(sim, "kitchen_counter_:0000")
+        drawer_link_id = 6
+        drawer_obj_id = 125
+
+        stool_receptacle = hab_receptacle.AnyObjectReceptacle(
+            "stool_rec", stool_object.handle
+        )
+        counter_receptacle = hab_receptacle.AnyObjectReceptacle(
+            "counter_rec", counter_ao.handle
+        )
+        drawer_receptacle = hab_receptacle.AnyObjectReceptacle(
+            "drawer_rec", counter_ao.handle, parent_link=drawer_link_id
+        )
+
+        down = mn.Vector3(0, -1, 0)
+
+        def validate_rec_with_raycast_samples(rec, parent_obj_id):
+            samples = [rec.sample_uniform_global(sim, 1.0) for _ in range(100)]
+            # NOTE: we bump the ray origin up to account for collision object inflation around the bounding volume.
+            sample_raycast_results = [
+                sim.cast_ray(
+                    habitat_sim.geo.Ray(sample + mn.Vector3(0, 0.2, 0), down)
+                )
+                for sample in samples
+            ]
+            samples_over_obj = len(
+                [
+                    True
+                    for raycast_result in sample_raycast_results
+                    if (
+                        raycast_result.has_hits()
+                        and parent_obj_id
+                        in [hit.object_id for hit in raycast_result.hits]
+                    )
+                ]
+            )
+            assert (
+                samples_over_obj > 75
+            ), "75 percent of samples should be above the object in question for this scene with high statistical likelihood."
+
+        for rec, parent_obj_id in [
+            (stool_receptacle, stool_object.object_id),
+            (counter_receptacle, counter_ao.object_id),
+            (drawer_receptacle, drawer_obj_id),
+        ]:
+            validate_rec_with_raycast_samples(rec, parent_obj_id)
+            # test that samples in a scaled Receptacle region align with the global bounding box center
+            center_sample = rec.sample_uniform_global(sim, 0.01)
+            global_keypoints = sutils.get_global_keypoints_from_object_id(
+                sim, parent_obj_id
+            )
+            sample_to_center = mn.Vector3(global_keypoints[0] - center_sample)
+            assert mn.math.dot(sample_to_center.normalized(), down) >= 0.99
+            # check that the global keypoints all fit inside the rec computed bounding box
+            rec_global_bb = rec._get_global_bb(sim).padded(mn.Vector3(0.001))
+            for keypoint in global_keypoints:
+                assert rec_global_bb.contains(keypoint)


### PR DESCRIPTION
## Motivation and Context

This PR introduces the `AnyObjectReceptacle`. This allows any object in the simulation to be used as a Receptacle by implementing the Receptacle API in a generic way:
- The top surface of the global bounding box of the object in its current state is used as the sampling region for snap_down placements.
- Can support RigidObject, ArticulatedObject, ArticulatedLink
- Can be added to the world at any time
- Can debug draw itself
- supports a required "up" direction (Y+ axis) preventing placement when the object is upside down or sideways

Future Improvements/iterative work:
- TODO: optionally disable "up" direction to support stacking objects in any orientation
- TODO: option to pre-generate a discrete set of candidate points in object local space instead of using the global AABB.
- TODO: `bounds` attribute cannot be computed because Receptacle does not expect access to sim for this.
- TODO: transform caching and dirty check could prevent wasted cycles when the object has not moved between queries.

## How Has This Been Tested

Added a unit test.

Local testing in example app. The video below takes place in a ReplicaCAD scene. Pre-configured AABBReceptacles already exist in the scene. Some objects do not have Receptacles configured. When the user clicks such an object, an AnyObjectReceptacle is added. This can then be used to sample snap_down placements.

Notice that these placements are not very good (especially with dynamic simulation stability). That's why we annotate Receptacles instead of using this approach in general. However, this is better than nothing and should serve for kinematic use cases.


https://github.com/facebookresearch/habitat-lab/assets/1445143/2448ecdc-5495-4934-a7ce-053e576e1078



## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
