### PR TITLE
HITL - Add mock connection parameter config for testing purposes.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
@@ -29,6 +29,7 @@ from habitat_hitl._internal.networking.keyframe_utils import (
     get_empty_keyframe,
     update_consolidated_keyframe,
 )
+from habitat_hitl.core.hydra_utils import ConfigObject
 from habitat_hitl.core.types import (
     ClientState,
     ConnectionRecord,
@@ -282,6 +283,21 @@ class NetworkManager:
                 )
             print("Client is ready!")
             connection_record["connectionId"] = connection_id
+
+            # Copy test connection parameters from "mock_connection_params_dict".
+            if "mock_connection_params_dict" in self._networking_config:
+                mock_connection_params_dict = (
+                    self._networking_config.mock_connection_params_dict
+                )
+                if mock_connection_params_dict is not None and isinstance(
+                    mock_connection_params_dict, ConfigObject
+                ):
+                    for (
+                        key,
+                        value,
+                    ) in mock_connection_params_dict.__dict__.items():
+                        connection_record[key] = value
+
             self._interprocess_record.send_connection_record_to_main_thread(
                 connection_record
             )

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -37,6 +37,9 @@ habitat_hitl:
     # Optionally kick an idle client after n seconds.
     client_max_idle_duration: ~
 
+    # Override incoming client connection parameters for testing purposes.
+    mock_connection_params_dict: None
+
     client_sync:
       # If enabled, the server main camera transform will be sent to the client. Disable if the client should control its own camera (e.g. VR), or if clients must use different camera transforms (e.g. multiplayer).
       server_camera: True


### PR DESCRIPTION
## Motivation and Context

This adds a config parameter to mock connection parameters.

Typically, these parameters are gathered from:
* The browser address bar on WebGL.
* A json config file on Android. 

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
