### PR TITLE
HITL - Add dedicated kick queue.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/client_helper.py
+++ b/habitat-hitl/habitat_hitl/core/client_helper.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from habitat_hitl.app_states.app_service import AppService
 from habitat_hitl.core.average_helper import AverageHelper
+from habitat_hitl.core.user_mask import Mask
 
 
 class ClientHelper:
@@ -18,6 +19,7 @@ class ClientHelper:
 
     def __init__(self, app_service: AppService):
         self._app_service = app_service
+        self._remote_client_state = app_service.remote_client_state
         self._frame_counter = 0
 
         self._client_frame_latency_avg_helper = AverageHelper(
@@ -73,9 +75,8 @@ class ClientHelper:
                     self._show_idle_kick_warning = True
 
                 if self._idle_frame_counter > max_idle_frames:
-                    self._app_service.client_message_manager.signal_kick_client(
-                        self._client_connection_id
-                    )
+                    # TODO: We only support 1 user at the moment.
+                    self._remote_client_state.kick(Mask.from_index(0))
                     self._idle_frame_counter = None
             else:
                 # reset counter whenever the client isn't idle

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -165,16 +165,6 @@ class ClientMessageManager:
             message = self._messages[user_index]
             message["isAppReady"] = True
 
-    def signal_kick_client(
-        self, connection_id: int, destination_mask: Mask = Mask.ALL
-    ):
-        r"""
-        Signal NetworkManager to kick a client identified by connection_id. See also RemoteClientState.get_new_connection_records()[i]["connectionId"]. Sloppy: this is a message to NetworkManager, not the client.
-        """
-        for user_index in self._users.indices(destination_mask):
-            message = self._messages[user_index]
-            message["kickClient"] = connection_id
-
     def set_server_keyframe_id(
         self, keyframe_id: int, destination_mask: Mask = Mask.ALL
     ):

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -433,3 +433,12 @@ class RemoteClientState:
 
     def clear_history(self) -> None:
         self._recent_client_states.clear()
+
+    def kick(self, user_mask: Mask) -> None:
+        """
+        Immediately kick the users matching the specified user mask.
+        """
+        for user_index in self._users.indices(user_mask):
+            self._interprocess_record.send_kick_signal_to_networking_thread(
+                user_index
+            )


### PR DESCRIPTION
## Motivation and Context

This change adds a dedicated kick command queue to HITL.

The previous system was relying on Server->Client messaging to process kicking. This hacky setup had a couple issues:
* Need to filter-out kick messages when consolidating keyframes.
* Difficulty controlling when kicking happens. For example, sometimes, we want to send messages to the user before kicking.
* Add complexity to the message queue.

## How Has This Been Tested

Tested on downstream multiplayer HITL system and locally.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
