### PR TITLE
HITL - Add configuration to control episode iterator by episode ID.

### DIFF
--- a/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
+++ b/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
@@ -10,9 +10,12 @@ habitat:
   # various config args to ensure the episode never ends
   environment:
     max_episode_steps: 0
+    # Ensure that the episode iterator can be controlled by specifying episode IDs.
     iterator_options:
-      # For the demo, we want to showcase the episodes in the specified order
+      max_scene_repeat_steps: -1
+      max_scene_repeat_episodes: -1
       shuffle: False
+      group_by_scene: False
   task:
     measurements:
       rearrange_cooperate_reward:


### PR DESCRIPTION
## Motivation and Context

This changes the `rearrange_v2` config to allow to use the episode iterator by specifying episode IDs.

Without those changes, the episode iterator will occasionally select wrong episodes.

Thanks @Ram81 for finding this issue.

## How Has This Been Tested

Tested on a large set of episodes.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
