### PR TITLE
[CI] close pddl sim after test

### DIFF
--- a/test/test_rearrange_task.py
+++ b/test/test_rearrange_task.py
@@ -131,6 +131,7 @@ def test_pddl_actions():
     poss_actions = pddl.get_possible_actions()
     for action in poss_actions:
         action.apply_if_true(sim_info)
+    pddl._sim_info.sim.close()
 
 
 def test_pddl_action_postconds():
@@ -173,6 +174,7 @@ def test_pddl_action_postconds():
         x.compact_str == "object_at(goal0|0,TARGET_goal0|0)"
         for x in true_preds
     )
+    sim_info.sim.close()
 
 
 TEST_CFG_PATHS = list(


### PR DESCRIPTION
## Motivation and Context

Fixes the current CI failure by explicitly closing the sim object inside the `PDDLDomain` after the test concludes.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
