### PR TITLE
[CI] - resolve sdist filepath issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,21 +200,6 @@ jobs:
             export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
             . activate habitat;
             ccache --show-stats
-      - run:
-          name: Download test data
-          command: |
-              sudo apt install git-lfs
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat
-              git lfs install
-              conda install -y gitpython git-lfs
-              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm hab3_bench_assets --data-path habitat-sim/data/ --no-replace --no-prune
-      - run:
-          name: Run sim benchmark
-          command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat; cd habitat-sim
-              python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
       - save_cache:
           key: v1-habitat-sim-{{ checksum "./hsim_sha" }}-{{ checksum "./date" }}
           background: true
@@ -263,66 +248,6 @@ jobs:
 
       - store_artifacts:
           path: conda_env_dump.log  # This is the list of modules in conda and pip
-      - run:
-          name: Run api tests
-          no_output_timeout: 120m
-          command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat; cd habitat-lab
-              export PYTHONPATH=.:$PYTHONPATH
-              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
-              python -m pytest test/ --cov-report=xml --cov-report term  --cov=./
-      - codecov/upload
-      - run:
-          name: Run HITL tests
-          no_output_timeout: 60m
-          command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat; cd habitat-lab
-              export PYTHONPATH=.:$PYTHONPATH
-              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
-              python -m habitat_sim.utils.datasets_download --uids hab3-episodes hab3_bench_assets habitat_humanoids hab_spot_arm ycb --data-path data/ --no-replace --no-prune
-              python -m pytest habitat-hitl/test
-      - run:
-          name: Run baseline training tests
-          no_output_timeout: 30m
-          command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat; cd habitat-lab
-              export PYTHONPATH=.:$PYTHONPATH
-              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
-              # This is a flag that enables test_baseline_training to work
-              export TEST_BASELINE_SMALL=1
-              python -m pytest test/test_baseline_training.py -s
-      - run:
-          name: Run Hab2.0 benchmark
-          no_output_timeout: 30m
-          command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat; cd habitat-lab
-              python -m habitat_sim.utils.datasets_download --uids hab2_bench_assets
-              mkdir -p data/ep_datasets/
-              cp data/hab2_bench_assets/bench_scene.json.gz data/ep_datasets/
-              bash scripts/hab2_bench/bench_runner.sh
-              python scripts/hab2_bench/plot_bench.py
-              # Assert the SPS number are up to standard
-              python scripts/hab2_bench/assert_bench.py
-      - run:
-          name: Build api documentation
-          command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat; cd habitat-lab
-              # Download sim inventory for crosslinking (no need to build
-              # the whole sim docs for that)
-              # TODO: take it from github.com/facebookmicrosites/habitat-website
-              #   instead
-              mkdir -p ../habitat-sim/build/docs-public/habitat-sim
-              curl -s https://aihabitat.org/docs/habitat-sim/objects.inv > ../habitat-sim/build/docs-public/habitat-sim/objects.inv
-              cd docs
-              conda install -y -c conda-forge doxygen=1.9.5
-              conda install -y  jinja2 pygments docutils
-              mkdir -p ../build/docs
-              ./build-public.sh
       - run:
           name: Ensure non-editable mode works
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,21 @@ jobs:
             export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
             . activate habitat;
             ccache --show-stats
+      - run:
+          name: Download test data
+          command: |
+              sudo apt install git-lfs
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat
+              git lfs install
+              conda install -y gitpython git-lfs
+              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm hab3_bench_assets --data-path habitat-sim/data/ --no-replace --no-prune
+      - run:
+          name: Run sim benchmark
+          command: |
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat; cd habitat-sim
+              python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
       - save_cache:
           key: v1-habitat-sim-{{ checksum "./hsim_sha" }}-{{ checksum "./date" }}
           background: true
@@ -248,6 +263,66 @@ jobs:
 
       - store_artifacts:
           path: conda_env_dump.log  # This is the list of modules in conda and pip
+      - run:
+          name: Run api tests
+          no_output_timeout: 120m
+          command: |
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat; cd habitat-lab
+              export PYTHONPATH=.:$PYTHONPATH
+              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
+              python -m pytest test/ --cov-report=xml --cov-report term  --cov=./
+      - codecov/upload
+      - run:
+          name: Run HITL tests
+          no_output_timeout: 60m
+          command: |
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat; cd habitat-lab
+              export PYTHONPATH=.:$PYTHONPATH
+              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
+              python -m habitat_sim.utils.datasets_download --uids hab3-episodes hab3_bench_assets habitat_humanoids hab_spot_arm ycb --data-path data/ --no-replace --no-prune
+              python -m pytest habitat-hitl/test
+      - run:
+          name: Run baseline training tests
+          no_output_timeout: 30m
+          command: |
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat; cd habitat-lab
+              export PYTHONPATH=.:$PYTHONPATH
+              export MULTI_PROC_OFFSET=0 && export MAGNUM_LOG=quiet && export HABITAT_SIM_LOG=quiet
+              # This is a flag that enables test_baseline_training to work
+              export TEST_BASELINE_SMALL=1
+              python -m pytest test/test_baseline_training.py -s
+      - run:
+          name: Run Hab2.0 benchmark
+          no_output_timeout: 30m
+          command: |
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat; cd habitat-lab
+              python -m habitat_sim.utils.datasets_download --uids hab2_bench_assets
+              mkdir -p data/ep_datasets/
+              cp data/hab2_bench_assets/bench_scene.json.gz data/ep_datasets/
+              bash scripts/hab2_bench/bench_runner.sh
+              python scripts/hab2_bench/plot_bench.py
+              # Assert the SPS number are up to standard
+              python scripts/hab2_bench/assert_bench.py
+      - run:
+          name: Build api documentation
+          command: |
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
+              . activate habitat; cd habitat-lab
+              # Download sim inventory for crosslinking (no need to build
+              # the whole sim docs for that)
+              # TODO: take it from github.com/facebookmicrosites/habitat-website
+              #   instead
+              mkdir -p ../habitat-sim/build/docs-public/habitat-sim
+              curl -s https://aihabitat.org/docs/habitat-sim/objects.inv > ../habitat-sim/build/docs-public/habitat-sim/objects.inv
+              cd docs
+              conda install -y -c conda-forge doxygen=1.9.5
+              conda install -y  jinja2 pygments docutils
+              mkdir -p ../build/docs
+              ./build-public.sh
       - run:
           name: Ensure non-editable mode works
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,6 +347,8 @@ jobs:
               pip install --upgrade build
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-lab/
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-baselines/
+              ls habitat-lab/dist/
+              ls habitat-baselines/dist/
       - run:
           name: Ensure sdist and bdist intall work
           command: |
@@ -364,6 +366,8 @@ jobs:
               python -c 'import habitat_baselines; print("habitat_baselines version:", habitat_baselines.__version__)'
               # install from source distribution:
               . activate sdist-install
+              ls habitat-lab/dist/
+              ls habitat-baselines/dist/
               pip install habitat-lab/dist/habitat-lab*.tar.gz
               python -c 'import habitat; print("habitat version:", habitat.__version__)'
               pip install habitat-baselines/dist/habitat-baselines*.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,8 +272,6 @@ jobs:
               pip install --upgrade build
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-lab/
               python -m build -s -w -C--global-option=egg_info -C--global-option=--tag-date habitat-baselines/
-              ls habitat-lab/dist/
-              ls habitat-baselines/dist/
       - run:
           name: Ensure sdist and bdist intall work
           command: |
@@ -291,8 +289,6 @@ jobs:
               python -c 'import habitat_baselines; print("habitat_baselines version:", habitat_baselines.__version__)'
               # install from source distribution:
               . activate sdist-install
-              ls habitat-lab/dist/
-              ls habitat-baselines/dist/
               pip install habitat-lab/dist/habitat_lab*.tar.gz
               python -c 'import habitat; print("habitat version:", habitat.__version__)'
               pip install habitat-baselines/dist/habitat_baselines*.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,9 +293,9 @@ jobs:
               . activate sdist-install
               ls habitat-lab/dist/
               ls habitat-baselines/dist/
-              pip install habitat-lab/dist/habitat-lab*.tar.gz
+              pip install habitat-lab/dist/habitat_lab*.tar.gz
               python -c 'import habitat; print("habitat version:", habitat.__version__)'
-              pip install habitat-baselines/dist/habitat-baselines*.tar.gz
+              pip install habitat-baselines/dist/habitat_baselines*.tar.gz
               python -c 'import habitat_baselines; print("habitat_baselines version:", habitat_baselines.__version__)'
       - store_artifacts:
           path: habitat-lab/data/profile  # This is the benchmark profile


### PR DESCRIPTION
## Motivation and Context

For some reason the previous package paths (e.g. `habitat-lab/dist/habitat-lab*.tar.gz`) are now being written with underscore instead of hyphen (e.g. `habitat-lab/dist/habitat_lab*.tar.gz`). Not sure why this changed, but it was breaking CI verification. 

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
