### PR TITLE
guard against missing filter_type for backward compatability

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/receptacle.py
@@ -1037,8 +1037,13 @@ def get_recs_from_filter_file(
     with open(rec_filter_filepath, "r") as f:
         filter_json = json.load(f)
         for filter_type in filter_types:
-            for filtered_unique_name in filter_json[filter_type]:
-                filtered_unique_names.append(filtered_unique_name)
+            if filter_type in filter_json:
+                for filtered_unique_name in filter_json[filter_type]:
+                    filtered_unique_names.append(filtered_unique_name)
+            else:
+                logger.warning(
+                    f"The filter file '{rec_filter_filepath}' does not contain the requested filter type '{filter_type}'."
+                )
     return list(set(filtered_unique_names))
 
 


### PR DESCRIPTION
## Motivation and Context

When querying Receptacle filter sets, the code should guard against missing filter_type in order to support older dataset versions before that filter_type was used.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
