### PR TITLE
allow STATIC AOs in kinematic_mode

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -667,7 +667,14 @@ class RearrangeSim(HabitatSim):
             for aoi_handle in ao_mgr.get_object_handles():
                 ao = ao_mgr.get_object_by_handle(aoi_handle)
                 if self._kinematic_mode:
-                    ao.motion_type = habitat_sim.physics.MotionType.KINEMATIC
+                    if (
+                        ao.motion_type
+                        == habitat_sim.physics.MotionType.DYNAMIC
+                    ):
+                        # NOTE: allow STATIC objects in kinematic mode
+                        ao.motion_type = (
+                            habitat_sim.physics.MotionType.KINEMATIC
+                        )
                     # remove any existing motors when converting to kinematic AO
                     for motor_id in ao.existing_joint_motor_ids:
                         ao.remove_joint_motor(motor_id)


### PR DESCRIPTION
## Motivation and Context

Using `STATIC` furniture is a common optimization for kinematic simulation. The RearrangeSim should support this. By setting all AOs to `KINEMATIC`, the AO furniture is not being added to the navmesh causing issues.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
