### PR TITLE
refactor snap_down support_surface setup for AO links

### DIFF
--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -306,17 +306,20 @@ class ObjectSampler:
                     ao_instance = sim.get_articulated_object_manager().get_object_by_handle(
                         receptacle.parent_object_handle
                     )
-                    for (
-                        object_id,
-                        link_ix,
-                    ) in ao_instance.link_object_ids.items():
-                        if receptacle.parent_link == link_ix:
-                            support_object_ids = [
-                                object_id,
-                                ao_instance.object_id,
-                            ]
-                            break
+                    if receptacle.parent_link == -1:
+                        # Receptacle is attached to the body link, so only allow placements there
+                        support_object_ids = [ao_instance.object_id]
+                    else:
+                        # Receptacle is attached to a moveable link, only allow samples on that link
+                        for (
+                            object_id,
+                            link_ix,
+                        ) in ao_instance.link_object_ids.items():
+                            if receptacle.parent_link == link_ix:
+                                support_object_ids = [object_id]
+                                break
                 elif receptacle.parent_object_handle is not None:
+                    # rigid object receptacle
                     support_object_ids = [
                         sim.get_rigid_object_manager()
                         .get_object_by_handle(receptacle.parent_object_handle)

--- a/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
+++ b/habitat-lab/habitat/datasets/rearrange/samplers/object_sampler.py
@@ -306,18 +306,22 @@ class ObjectSampler:
                     ao_instance = sim.get_articulated_object_manager().get_object_by_handle(
                         receptacle.parent_object_handle
                     )
-                    if receptacle.parent_link == -1:
+                    link_ids_to_obj_ids = {
+                        v: k for k, v in ao_instance.link_object_ids.items()
+                    }
+                    if receptacle.parent_link <= 0:
                         # Receptacle is attached to the body link, so only allow placements there
-                        support_object_ids = [ao_instance.object_id]
+                        # NOTE: If collision objects are marked STATIC in the URDF (via collision_group==2) then they will be attached to the -1 link as STATIC rigids, even if defined at the 0 link
+                        support_object_ids = [
+                            ao_instance.object_id,
+                            link_ids_to_obj_ids[0],
+                        ]
                     else:
                         # Receptacle is attached to a moveable link, only allow samples on that link
-                        for (
-                            object_id,
-                            link_ix,
-                        ) in ao_instance.link_object_ids.items():
-                            if receptacle.parent_link == link_ix:
-                                support_object_ids = [object_id]
-                                break
+                        support_object_ids = [
+                            link_ids_to_obj_ids[receptacle.parent_link]
+                        ]
+
                 elif receptacle.parent_object_handle is not None:
                     # rigid object receptacle
                     support_object_ids = [


### PR DESCRIPTION
## Motivation and Context

This PR refactors `support_surface_id` setup for `ObjectSampler's` use of `snap_down` function for `Receptacles` attached to articulated links. Previously, the code would allow snapping to the link or the body. Instead, only snapping to the link should be allowed.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
