### PR TITLE
[bugfix] - skip floor in KRM init

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
@@ -182,6 +182,10 @@ class KinematicRelationshipManager:
 
         # construct the parent relations
         for obj_handle, rec_unique_name in obj_to_rec.items():
+            if rec_unique_name == "floor":
+                # NOTE: floor placements are denoted by this explicit name string and do not result in any parenting relationships
+                continue
+
             obj = sutils.get_obj_from_handle(self.sim, obj_handle)
             assert (
                 obj is not None

--- a/test/test_kinematic_relationship_manager.py
+++ b/test/test_kinematic_relationship_manager.py
@@ -62,7 +62,9 @@ def test_kinematic_relationship_manager():
         #     )
 
         # create some known mappings from objects to their supporting receptacles
-        obj_to_rec_relations = {}
+        obj_to_rec_relations = {
+            table_object.handle: "floor"  # explicitly test a floor parent relationship which should be skipped
+        }
         # objects on the center table
         for table_obj in table_objects:
             obj_to_rec_relations[


### PR DESCRIPTION
## Motivation and Context

KRM init from RearrangeEpisode should skip the "floor" receptacle string used to denote placement on the floor rather than in/on a Receptacle. No parenting relationships will result from this placement.

## How Has This Been Tested

Added a test case for CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
