### PR TITLE
HITL - Make agents transparent to selection.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -80,7 +80,10 @@ class UI:
         self._selections: List[Selection] = []
         # Track hovered object.
         self._hover_selection = Selection(
-            self._sim, self._gui_input, Selection.hover_fn
+            self._sim,
+            self._gui_input,
+            Selection.hover_fn,
+            self.selection_discriminator_ignore_agents,
         )
         self._selections.append(self._hover_selection)
         # Track left-clicked object.
@@ -88,6 +91,7 @@ class UI:
             self._sim,
             self._gui_input,
             Selection.left_click_fn,
+            self.selection_discriminator_ignore_agents,
         )
         self._selections.append(self._click_selection)
 
@@ -105,8 +109,13 @@ class UI:
             self._sim,
             self._gui_input,
             place_selection_fn,
+            self.selection_discriminator_ignore_agents,
         )
         self._selections.append(self._place_selection)
+
+    def selection_discriminator_ignore_agents(self, object_id: int) -> bool:
+        """Allow selection through agents."""
+        return object_id not in self._world._agent_object_ids
 
     def reset(self) -> None:
         """

--- a/habitat-hitl/habitat_hitl/core/selection.py
+++ b/habitat-hitl/habitat_hitl/core/selection.py
@@ -97,20 +97,24 @@ class Selection:
                     self.deselect()
                     return
 
-                object_id: int = hit_info.object_id
-
-                if self._discriminator(object_id):
-                    self._selected = True
-                    self._object_id = object_id
-                    self._point = hit_info.point
-                    self._normal = hit_info.normal
-                else:
-                    self.deselect()
+                self._selected = True
+                self._object_id = hit_info.object_id
+                self._point = hit_info.point
+                self._normal = hit_info.normal
+            else:
+                self.deselect()
 
     def _raycast(self, ray: Ray) -> Optional[RayHitInfo]:
         raycast_results = self._sim.cast_ray(ray=ray)
         if not raycast_results.has_hits():
             return None
         # Results are sorted by distance. [0] is the nearest one.
-        hit_info = raycast_results.hits[0]
-        return hit_info
+        hits = raycast_results.hits
+        for hit in hits:
+            object_id: int = hit.object_id
+            if not self._discriminator(object_id):
+                continue
+            else:
+                return hit
+
+        return None

--- a/habitat-hitl/habitat_hitl/core/selection.py
+++ b/habitat-hitl/habitat_hitl/core/selection.py
@@ -48,6 +48,7 @@ class Selection:
         :param gui_input: GuiInput to track.
         :param selection_fn: Function that returns true if gui_input is attempting selection.
         :param object_id_discriminator: Function that determines whether an object ID is selectable.
+                                        Rejected objects are transparent to selection.
                                         By default, all objects are selectable.
         """
         self._sim = simulator
@@ -105,6 +106,10 @@ class Selection:
                 self.deselect()
 
     def _raycast(self, ray: Ray) -> Optional[RayHitInfo]:
+        """
+        Raycast the scene using the specified ray.
+        Objects rejected by the discriminator function are transparent to selection.
+        """
         raycast_results = self._sim.cast_ray(ray=ray)
         if not raycast_results.has_hits():
             return None


### PR DESCRIPTION
## Motivation and Context

In the HITL app, the agents controlled in first-person are hidden in the user's view. The agent may still obstruct the selection UI, e.g. the spot arm is in the way of selection. This causes selection to appear flaky.

This PR changes the following:
* Objects rejected by selection discriminator functions are "transparent" to selection, meaning that the next closest hit info will be queried.
* Agents can now be selected through.

## How Has This Been Tested

* Tested in single/multi user HITL.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
