### PR TITLE
HITL - Disallow placing objects onto held objects.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -300,6 +300,9 @@ class UI:
         # Cannot place further than reach.
         if not self._is_within_reach(point):
             return False
+        # Cannot place on held object.
+        if self._is_someone_holding_object(receptacle_object_id):
+            return False
         return True
 
     def _draw_aabb(

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -300,7 +300,7 @@ class UI:
         # Cannot place further than reach.
         if not self._is_within_reach(point):
             return False
-        # Cannot place on held object.
+        # Cannot place on objects held by agents.
         if self._is_someone_holding_object(receptacle_object_id):
             return False
         return True


### PR DESCRIPTION
## Motivation and Context

This change disallows placing objects onto objects held by other agents.

## How Has This Been Tested

Tested in multiplayer HITL.

## Types of changes

- **\[Bug Fix\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
