### PR TITLE
Allow selection of the next episode using an index.

### DIFF
--- a/habitat-hitl/habitat_hitl/environment/episode_helper.py
+++ b/habitat-hitl/habitat_hitl/environment/episode_helper.py
@@ -33,7 +33,18 @@ class EpisodeHelper:
     def current_episode(self) -> Episode:
         return self._habitat_env.current_episode
 
-    def set_next_episode_by_id(self, episode_id) -> None:
+    def set_next_episode_by_index(self, episode_index: int) -> None:
+        """
+        Set the next episode to run by episode index.
+        The new episode will be loading upon resetting the simulator.
+        """
+        self._episode_iterator.set_next_episode_by_index(episode_index)
+
+    def set_next_episode_by_id(self, episode_id: str) -> None:
+        """
+        Set the next episode to run by episode ID.
+        The new episode will be loading upon resetting the simulator.
+        """
         self._episode_iterator.set_next_episode_by_id(episode_id)
 
     def next_episode_exists(self) -> bool:

--- a/habitat-lab/habitat/core/dataset.py
+++ b/habitat-lab/habitat/core/dataset.py
@@ -454,7 +454,22 @@ class EpisodeIterator(Iterator[T]):
         self._prev_scene_id = next_episode.scene_id
         return next_episode
 
-    def set_next_episode_by_id(self, episode_id):
+    def set_next_episode_by_index(self, episode_index: int) -> None:
+        """
+        Set the next episode to run by episode index.
+        The new episode will be loading upon resetting the simulator.
+        """
+        if episode_index < 0 or episode_index >= len(self.episodes):
+            raise ValueError(
+                f"Episode index is out of bounds: {episode_index}."
+            )
+        self._iterator = iter([self.episodes[episode_index]])
+
+    def set_next_episode_by_id(self, episode_id: str) -> None:
+        """
+        Set the next episode to run by episode ID.
+        The new episode will be loading upon resetting the simulator.
+        """
         self._iterator = iter(self.episodes)
         for episode in self.episodes:
             if episode.episode_id == episode_id:


### PR DESCRIPTION
## Motivation and Context

The episode iterator can currently only be controlled by specifying episode IDs.

This change allows for controlling the episode iterator by index.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
