### PR TITLE
HITL - Make client loading state available to applications.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -57,6 +57,8 @@ class RemoteClientState:
             self._client_state_history.append([])
             self._receive_rate_trackers.append(AverageRateTracker(2.0))
 
+        self._client_loading: List[bool] = [False] * users.max_user_count
+
         # temp map VR button to key
         self._button_map = {
             0: GuiInput.KeyNS.ZERO,
@@ -80,6 +82,10 @@ class RemoteClientState:
     def get_gui_inputs(self) -> List[GuiInput]:
         """Get a list of all GuiInputs indexed by user index."""
         return self._gui_inputs
+
+    def is_user_loading(self, user_index: int) -> bool:
+        """Return true if the specified user's client is in a loading state."""
+        return self._client_loading[user_index]
 
     def bind_gui_input(self, gui_input: GuiInput, user_index: int) -> None:
         """
@@ -281,6 +287,13 @@ class RemoteClientState:
             # todo: think about ambiguous GuiInput states (key-down and key-up events in the same
             # frame and other ways that keyHeld, keyDown, and keyUp can be inconsistent.
             last_client_state = client_states[-1]
+
+            # Loading states.
+            self._client_loading[user_index] = False
+            if "isLoading" in last_client_state:
+                self._client_loading[user_index] = last_client_state[
+                    "isLoading"
+                ]
 
             input_json = (
                 last_client_state["input"]

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -289,11 +289,9 @@ class RemoteClientState:
             last_client_state = client_states[-1]
 
             # Loading states.
-            self._client_loading[user_index] = False
-            if "isLoading" in last_client_state:
-                self._client_loading[user_index] = last_client_state[
-                    "isLoading"
-                ]
+            self._client_loading[user_index] = last_client_state.get(
+                "isLoading", False
+            )
 
             input_json = (
                 last_client_state["input"]


### PR DESCRIPTION
## Motivation and Context

This changeset makes client loading states available to HITL applications.

This is useful to control application state in a multi-user environment where user loading time have to be taken into account.

Relates to:
* https://github.com/0mdc/siro_hitl_unity_client/pull/24

## How Has This Been Tested

Tested on multiplayer HITL application.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
