### PR TITLE
HITL - Add buttons and modal dialog boxes.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
 from typing import Final, List, Optional, Union
 
 import magnum as mn
@@ -12,6 +13,19 @@ from habitat_hitl.core.types import Message
 from habitat_hitl.core.user_mask import Mask, Users
 
 DEFAULT_NORMAL: Final[List[float]] = [0.0, 1.0, 0.0]
+
+
+# TODO: Move to another file.
+@dataclass
+class UIButton:
+    """
+    Networked UI button. Use RemoteClientState.ui_button_pressed() to retrieve state.
+    """
+
+    def __init__(self, button_id: str, text: str, enabled: bool):
+        self.button_id = button_id
+        self.text = text
+        self.enabled = enabled
 
 
 class ClientMessageManager:
@@ -143,6 +157,34 @@ class ClientMessageManager:
             message["texts"].append(
                 {"text": text, "position": [pos[0], pos[1]]}
             )
+
+    def show_modal_dialogue_box(
+        self,
+        title: str,
+        text: str,
+        buttons: List[UIButton],
+        destination_mask: Mask = Mask.ALL,
+    ):
+        r"""
+        Show a modal dialog box with buttons.
+        There can only be one modal dialog box at a time.
+        """
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+
+            message["dialog"] = {
+                "title": title,
+                "text": text,
+                "buttons": [],
+            }
+            for button in buttons:
+                message["dialog"]["buttons"].append(
+                    {
+                        "id": button.button_id,
+                        "text": button.text,
+                        "enabled": button.enabled,
+                    }
+                )
 
     def change_humanoid_position(
         self, pos: List[float], destination_mask: Mask = Mask.ALL


### PR DESCRIPTION
## Motivation and Context

This change introduces networked UI elements. A button and modal dialog boxes are added.

https://github.com/facebookresearch/habitat-lab/assets/110583667/2c433d07-9234-4102-ba83-33073352ff1b

## How it works

UI elements follow the [immediate mode GUI pattern](https://en.wikipedia.org/wiki/Immediate_mode_GUI). They are both keyframe consumers and message producers.

How buttons work:
1. Server creates a button named `X` and sends it to the client.
2. Client receives it, renders it, and stores whether it was clicked.
3. Client sends back `X`'s state.
4. Server checks whether `X` was clicked.

## Notes

* Dialogue boxes are simply containers of UI elements (right now only supporting buttons).
* A UI wrapper will be created. For the sake of simplifying deltas, this will be done in a later changeset.

Related to:
* https://github.com/0mdc/siro_hitl_unity_client/pull/26

## How Has This Been Tested

Tested in multiplayer HITL application.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
