### PR TITLE
HITL - Add textboxes.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -28,6 +28,18 @@ class UIButton:
         self.enabled = enabled
 
 
+@dataclass
+class UITextbox:
+    """
+    Networked UI textbox. Use RemoteClientState.get_textbox_content() to retrieve content.
+    """
+
+    def __init__(self, textbox_id: str, text: str, enabled: bool):
+        self.textbox_id = textbox_id
+        self.text = text
+        self.enabled = enabled
+
+
 class ClientMessageManager:
     r"""
     Extends gfx-replay keyframes to include server messages to be interpreted by the clients.
@@ -163,6 +175,7 @@ class ClientMessageManager:
         title: str,
         text: str,
         buttons: List[UIButton],
+        textbox: Optional[UITextbox] = None,
         destination_mask: Mask = Mask.ALL,
     ):
         r"""
@@ -177,6 +190,12 @@ class ClientMessageManager:
                 "text": text,
                 "buttons": [],
             }
+            if textbox is not None:
+                message["dialog"]["textbox"] = {
+                    "id": textbox.textbox_id,
+                    "text": textbox.text,
+                    "enabled": textbox.enabled,
+                }
             for button in buttons:
                 message["dialog"]["buttons"].append(
                     {


### PR DESCRIPTION
## Motivation and Context

This change introduces networked textboxes.

https://github.com/facebookresearch/habitat-lab/assets/110583667/d423bf86-81c7-4c92-b529-c29c2d4ce0fe

## How it works

1. Server creates a textbox named `X` and sends it to the client.
2. Client receives it, renders it, and store its state.
3. Client sends back `X`'s content.
4. Server provides `X`'s content to the applications.

## Notes

Depends on:
* https://github.com/facebookresearch/habitat-lab/pull/1956
* https://github.com/0mdc/siro_hitl_unity_client/pull/27

## How Has This Been Tested

Tested on multiplayer HITL application.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
