### PR TITLE
HITL - Add object visbility handling and hide "self" in viewports.

### DIFF
--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -121,6 +121,7 @@ class UserData:
         client_helper: ClientHelper,
     ):
         self.app_service = app_service
+        self.world = world
         self.user_index = user_index
         self.gui_agent_controller = gui_agent_controller
         self.server_sps_tracker = server_sps_tracker
@@ -163,6 +164,24 @@ class UserData:
         self.camera_helper.update(self._get_camera_lookat_pos(), dt=0)
         self.ui.reset()
 
+        # Assign user agent objects to their own layer.
+        agent_index = self.gui_agent_controller._agent_idx
+        agent_object_ids = self.world.get_agent_object_ids(agent_index)
+        for agent_object_id in agent_object_ids:
+            self.app_service.client_message_manager.set_object_visibility_layer(
+                object_id=agent_object_id,
+                layer_id=agent_index,
+                destination_mask=Mask.from_index(self.user_index),
+            )
+
+        # Show all layers except "user_index" in the default viewport.
+        # This hides the user's own agent in the first person view.
+        self.app_service.client_message_manager.set_viewport_properties(
+            viewport_id=-1,
+            visible_layer_ids=Mask.all_except_index(agent_index),
+            destination_mask=Mask.from_index(self.user_index),
+        )
+
     def update(self, dt: float):
         if self.gui_input.get_key_down(GuiInput.KeyNS.H):
             self.show_gui_text = not self.show_gui_text
@@ -197,10 +216,23 @@ class UserData:
         if not self.pip_initialized:
             self.pip_initialized = True
 
+            # Assign pip agent objects to their own layer.
+            pip_agent_index = pip_user_data.gui_agent_controller._agent_idx
+            agent_object_ids = self.world.get_agent_object_ids(pip_agent_index)
+            for agent_object_id in agent_object_ids:
+                self.app_service.client_message_manager.set_object_visibility_layer(
+                    object_id=agent_object_id,
+                    layer_id=pip_agent_index,
+                    destination_mask=Mask.from_index(self.user_index),
+                )
+
             # Define picture-in-picture (PIP) viewport.
+            # Show all layers except "pip_user_index".
+            # This hides the other agent in the picture-in-picture viewport.
             self.app_service.client_message_manager.set_viewport_properties(
                 viewport_id=PIP_VIEWPORT_ID,
                 viewport_rect_xywh=[0.8, 0.02, 0.18, 0.18],
+                visible_layer_ids=Mask.all_except_index(pip_agent_index),
                 destination_mask=Mask.from_index(self.user_index),
             )
 

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -13,6 +13,7 @@ from habitat_hitl.core.types import Message
 from habitat_hitl.core.user_mask import Mask, Users
 
 DEFAULT_NORMAL: Final[List[float]] = [0.0, 1.0, 0.0]
+DEFAULT_VIEWPORT_SIZE: Final[List[float]] = [0.0, 0.0, 1.0, 1.0]
 
 
 # TODO: Move to another file.
@@ -242,10 +243,29 @@ class ClientMessageManager:
             message = self._messages[user_index]
             message["serverKeyframeId"] = keyframe_id
 
+    def set_object_visibility_layer(
+        self,
+        object_id: int,
+        layer_id: int = -1,
+        destination_mask: Mask = Mask.ALL,
+    ):
+        r"""
+        Set the visibility layer of the instance associated with specified habitat-sim objectId.
+        The layer_id '-1' is the default layer and is visible to all viewports.
+        There are 8 additional layers for controlling visibility (0 to 7).
+        """
+        assert layer_id >= -1
+        assert layer_id < 8
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            object_properties = _obtain_object_properties(message, object_id)
+            object_properties["layer"] = layer_id
+
     def set_viewport_properties(
         self,
         viewport_id: int,
-        viewport_rect_xywh: List[float],
+        viewport_rect_xywh: List[float] = DEFAULT_VIEWPORT_SIZE,
+        visible_layer_ids: Mask = Mask.ALL,
         destination_mask: Mask = Mask.ALL,
     ):
         r"""
@@ -255,12 +275,18 @@ class ClientMessageManager:
         viewport_id: Unique identifier of the viewport.
         viewport_rect_xywh: Viewport rect (x position, y position, width, height).
                             In window normalized coordinates, i.e. all values in range [0,1] relative to window size.
+        visible_layer_ids: Visibility layers. Only objects assigned to these layers will be visible to this viewport.
         """
+        layers = Users(8)  # Maximum of 8 layers.
         for user_index in self._users.indices(destination_mask):
             message = self._messages[user_index]
             viewport_properties = _obtain_viewport_properties(
                 message, viewport_id
             )
+            # TODO: Use mask int instead of array
+            viewport_properties["layers"] = []
+            for layer in layers.indices(visible_layer_ids):
+                viewport_properties["layers"].append(layer)
             viewport_properties["rect"] = viewport_rect_xywh
 
     def show_viewport(
@@ -345,6 +371,17 @@ def _create_transform_dict(transform: mn.Matrix4) -> Dict[str, List[float]]:
         "translation": [p[0], p[1], p[2]],
         "rotation": [r.scalar, rv[0], rv[1], rv[2]],
     }
+
+
+def _obtain_object_properties(
+    message: Message, object_id: int
+) -> Dict[str, Any]:
+    """Get or create the properties dict of an object_id."""
+    if "objects" not in message:
+        message["objects"] = {}
+    if object_id not in message["objects"]:
+        message["objects"][object_id] = {}
+    return message["objects"][object_id]
 
 
 def _obtain_viewport_properties(


### PR DESCRIPTION
## Motivation and Context

This object leverages [instance metadata keyframes](https://github.com/facebookresearch/habitat-sim/pull/2377) to hide objects in viewports.

It introduces the concept of "visibility layers".
* Objects are assigned to a visibility layer.
* Viewports are assigned a list of visibility layers.
    * All objects from these layers will be visible.

This also changes `rearrange_v2` such as the user's agent is hidden from the first person view.

## Notes

Depends on:
* Latest `habitat-sim`
* https://github.com/0mdc/siro_hitl_unity_client/pull/28
* https://github.com/0mdc/siro_hitl_unity_client/pull/29
* https://github.com/facebookresearch/habitat-lab/pull/1958

Agents are now transparent to selection, so they won't be interfering with UI flow:
* https://github.com/facebookresearch/habitat-lab/pull/1950

## Examples

**Before:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/7834dd94-b1a8-4147-8c80-b325d37c9118

**After:**

https://github.com/facebookresearch/habitat-lab/assets/110583667/7b0e4c6f-168e-4620-bde3-00c57b6f97e6

## How Has This Been Tested

Tested on multiplayer HITL.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
