### PR TITLE
HITL - Add configuration to enable new connections by default.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/networking/interprocess_record.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/interprocess_record.py
@@ -27,7 +27,10 @@ class InterprocessRecord:
         self._connection_record_queue: Queue[ConnectionRecord] = Queue()
         self._disconnection_record_queue: Queue[DisconnectionRecord] = Queue()
         self._kick_signal_queue: Queue[int] = Queue()
-        self._allow_new_connections = Value("b", False)
+
+        self._allow_new_connections = Value(
+            "b", networking_config.enable_connections_by_default
+        )
 
     def enable_new_connections(self, enabled: bool):
         """Signal the networking process whether it should accept new connections."""

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -23,6 +23,9 @@ habitat_hitl:
     # Number of accepted concurrent clients (multiplayer if higher than one). All connections beyond this count will be rejected. Beware that this can be different from the agent count.
     max_client_count: 1
 
+    # Accept incoming connections by default. If disabled, connections must be activated using InterprocessRecord.enable_new_connections().
+    enable_connections_by_default: True
+
     # We'll listen for incoming client connections at this port.
     port: 8888
 


### PR DESCRIPTION
## Motivation and Context

This adds a new configuration to enable new connections by default.

Use cases:
* It is on by default.
* Turn off when creating an application that should not have users connecting immediately after launch.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
