### PR TITLE
HITL - Rearrange session handling

### DIFF
--- a/examples/hitl/rearrange_v2/app_state_base.py
+++ b/examples/hitl/rearrange_v2/app_state_base.py
@@ -63,3 +63,9 @@ class AppStateBase(AppState):
     def _kick_all_users(self) -> None:
         "Kick all users."
         self._app_service.remote_client_state.kick(Mask.ALL)
+
+    def _is_server_gui_enabled(self) -> bool:
+        "Returns true if the local server GUI is available."
+        return (
+            not self._app_service.hitl_config.experimental.headless.do_headless
+        )

--- a/examples/hitl/rearrange_v2/app_state_end_session.py
+++ b/examples/hitl/rearrange_v2/app_state_end_session.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+from app_data import AppData
+from app_state_base import AppStateBase
+from app_states import create_app_state_reset
+from session import Session
+from util import get_top_down_view
+
+from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.user_mask import Mask
+
+# Duration of the end session message, before users are kicked.
+SESSION_END_DELAY = 5.0
+
+
+class AppStateEndSession(AppStateBase):
+    """
+    * Indicate users that the session is terminated.
+    * Upload collected data.
+    """
+
+    def __init__(
+        self, app_service: AppService, app_data: AppData, session: Session
+    ):
+        super().__init__(app_service, app_data)
+        self._session = session
+        self._elapsed_time = 0.0
+        self._save_keyframes = False
+
+        self._status = "Session ended."
+        if len(session.error) > 0:
+            self._status += f"\nError: {session.error}"
+
+    def get_next_state(self) -> Optional[AppStateBase]:
+        if self._elapsed_time > SESSION_END_DELAY:
+            self._end_session()
+            return create_app_state_reset(
+                self._app_service, self._app_data
+            )
+
+    def sim_update(self, dt: float, post_sim_update_dict):
+        # Top-down view.
+        cam_matrix = get_top_down_view(self._app_service.sim)
+        post_sim_update_dict["cam_transform"] = cam_matrix
+        self._app_service._client_message_manager.update_camera_transform(
+            cam_matrix, destination_mask=Mask.ALL
+        )
+
+        self._status_message(self._status)
+        self._elapsed_time += dt
+
+    def _end_session(self):
+        # TODO: Data collection.
+        pass

--- a/examples/hitl/rearrange_v2/app_state_end_session.py
+++ b/examples/hitl/rearrange_v2/app_state_end_session.py
@@ -40,9 +40,8 @@ class AppStateEndSession(AppStateBase):
     def get_next_state(self) -> Optional[AppStateBase]:
         if self._elapsed_time > SESSION_END_DELAY:
             self._end_session()
-            return create_app_state_reset(
-                self._app_service, self._app_data
-            )
+            return create_app_state_reset(self._app_service, self._app_data)
+        return None
 
     def sim_update(self, dt: float, post_sim_update_dict):
         # Top-down view.

--- a/examples/hitl/rearrange_v2/app_state_load_episode.py
+++ b/examples/hitl/rearrange_v2/app_state_load_episode.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+from app_data import AppData
+from app_state_base import AppStateBase
+from app_states import (
+    create_app_state_cancel_session,
+    create_app_state_end_session,
+    create_app_state_start_screen,
+)
+from session import Session
+from util import get_top_down_view
+
+from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.user_mask import Mask
+
+
+class AppStateLoadEpisode(AppStateBase):
+    """
+    Load an episode.
+    A loading screen is shown while the content loads.
+    * If a next episode exists, launch RearrangeV2.
+    * If all episodes are done, end session.
+    * If any user disconnects, cancel the session.
+    """
+
+    def __init__(
+        self, app_service: AppService, app_data: AppData, session: Session
+    ):
+        super().__init__(app_service, app_data)
+        self._session = session
+        self._loading = True
+        self._session_ended = False
+        self._frame_number = 0
+        self._save_keyframes = False
+
+    def get_next_state(self) -> Optional[AppStateBase]:
+        if self._cancel:
+            return create_app_state_cancel_session(
+                self._app_service, self._app_data, self._session, "User disconnected."
+            )
+        if self._session_ended:
+            return create_app_state_end_session(
+                self._app_service, self._app_data, self._session
+            )
+        # When all clients finish loading, show the start screen.
+        if not self._loading:
+            return create_app_state_start_screen(
+                self._app_service, self._app_data, self._session
+            )
+        return None
+
+    def sim_update(self, dt: float, post_sim_update_dict):
+        self._status_message("Loading...")
+
+        # HACK: Skip a frame so that the status message reaches the client before the server blocks.
+        # TODO: Clean this up.
+        if self._frame_number == 1:
+            self._increment_episode()
+        elif self._frame_number > 1:
+            # Top-down view.
+            cam_matrix = get_top_down_view(self._app_service.sim)
+            post_sim_update_dict["cam_transform"] = cam_matrix
+            self._app_service._client_message_manager.update_camera_transform(
+                cam_matrix, destination_mask=Mask.ALL
+            )
+
+            # HACK: Wait before checking whether clients are loading. The server isn't immediately aware of this.
+            # TODO: Use the keyframe ID from 'ClientMessageManager.set_server_keyframe_id()' to find the exact client response frames.
+            if self._frame_number > 20:
+                any_client_loading = False
+                for user_index in range(self._app_data.max_user_count):
+                    if self._app_service.remote_client_state._client_loading[
+                        user_index
+                    ]:
+                        any_client_loading = True
+                        break
+                if not any_client_loading:
+                    self._loading = False
+
+        self._frame_number += 1
+
+    def _increment_episode(self):
+        session = self._session
+        assert session.episode_ids is not None
+        if session.current_episode_index < len(session.episode_ids):
+            self._set_episode(session.current_episode_index)
+            session.current_episode_index += 1
+        else:
+            self._session_ended = True
+
+    def _set_episode(self, episode_index: int):
+        session = self._session
+
+        # Set the ID of the next episode to play in lab.
+        next_episode_id = session.episode_ids[episode_index]
+        print(f"Next episode index: {next_episode_id}.")
+        try:
+            next_episode_index = int(next_episode_id)
+            self._app_service.episode_helper.set_next_episode_by_index(
+                next_episode_index
+            )
+        except Exception as e:
+            print(f"ERROR: Invalid episode index {next_episode_id}. {e}")
+            print(f"Loading episode index 0.")
+            self._app_service.episode_helper.set_next_episode_by_index(
+                0
+            )
+
+        # Once an episode ID has been set, lab needs to be reset to load the episode.
+        self._app_service.end_episode(do_reset=True)
+
+        # Signal the clients that the scene has changed.
+        client_message_manager = self._app_service.client_message_manager
+        if client_message_manager:
+            client_message_manager.signal_scene_change(Mask.ALL)
+
+        # Save a keyframe. This propagates the new content to the clients, initiating client-side loading.
+        # Beware that the client "loading" state won't immediately be visible to the server.
+        self._app_service.sim.gfx_replay_manager.save_keyframe()

--- a/examples/hitl/rearrange_v2/app_state_load_episode.py
+++ b/examples/hitl/rearrange_v2/app_state_load_episode.py
@@ -42,7 +42,10 @@ class AppStateLoadEpisode(AppStateBase):
     def get_next_state(self) -> Optional[AppStateBase]:
         if self._cancel:
             return create_app_state_cancel_session(
-                self._app_service, self._app_data, self._session, "User disconnected."
+                self._app_service,
+                self._app_data,
+                self._session,
+                "User disconnected.",
             )
         if self._session_ended:
             return create_app_state_end_session(
@@ -107,10 +110,8 @@ class AppStateLoadEpisode(AppStateBase):
             )
         except Exception as e:
             print(f"ERROR: Invalid episode index {next_episode_id}. {e}")
-            print(f"Loading episode index 0.")
-            self._app_service.episode_helper.set_next_episode_by_index(
-                0
-            )
+            print("Loading episode index 0.")
+            self._app_service.episode_helper.set_next_episode_by_index(0)
 
         # Once an episode ID has been set, lab needs to be reset to load the episode.
         self._app_service.end_episode(do_reset=True)

--- a/examples/hitl/rearrange_v2/app_state_lobby.py
+++ b/examples/hitl/rearrange_v2/app_state_lobby.py
@@ -8,7 +8,7 @@ from typing import Final, Optional
 
 from app_data import AppData
 from app_state_base import AppStateBase
-from app_states import create_app_state_rearrange
+from app_states import create_app_state_start_session
 
 from habitat_hitl.app_states.app_service import AppService
 
@@ -51,7 +51,7 @@ class AppStateLobby(AppStateBase):
             == self._app_data.max_user_count
             and self._time_since_last_connection > START_SESSION_DELAY
         ):
-            return create_app_state_rearrange(
+            return create_app_state_start_session(
                 self._app_service, self._app_data
             )
         return None

--- a/examples/hitl/rearrange_v2/app_state_start_screen.py
+++ b/examples/hitl/rearrange_v2/app_state_start_screen.py
@@ -8,7 +8,10 @@ from typing import List, Optional
 
 from app_data import AppData
 from app_state_base import AppStateBase
-from app_states import create_app_state_cancel_session, create_app_state_end_session, create_app_state_rearrange
+from app_states import (
+    create_app_state_cancel_session,
+    create_app_state_rearrange,
+)
 from session import Session
 from util import get_top_down_view
 
@@ -43,9 +46,7 @@ class AppStateStartScreen(AppStateBase):
 
     def get_next_state(self) -> Optional[AppStateBase]:
         if self._cancel:
-            error = (
-                "Timeout" if self._timeout else "User disconnected"
-            )
+            error = "Timeout" if self._timeout else "User disconnected"
             return create_app_state_cancel_session(
                 self._app_service, self._app_data, self._session, error
             )

--- a/examples/hitl/rearrange_v2/app_state_start_screen.py
+++ b/examples/hitl/rearrange_v2/app_state_start_screen.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+from app_data import AppData
+from app_state_base import AppStateBase
+from app_states import create_app_state_cancel_session, create_app_state_end_session, create_app_state_rearrange
+from session import Session
+from util import get_top_down_view
+
+from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.client_message_manager import UIButton
+from habitat_hitl.core.key_mapping import KeyCode
+from habitat_hitl.core.text_drawer import TextOnScreenAlignment
+from habitat_hitl.core.user_mask import Mask
+
+START_BUTTON_ID = "start"
+START_SCREEN_TIMEOUT = 180.0
+SKIP_START_SCREEN = False
+
+
+class AppStateStartScreen(AppStateBase):
+    """
+    Start screen with a "Start" button that all users must press before starting the session.
+    Cancellable.
+    """
+
+    def __init__(
+        self, app_service: AppService, app_data: AppData, session: Session
+    ):
+        super().__init__(app_service, app_data)
+        self._session = session
+        self._ready_to_start: List[bool] = [
+            False
+        ] * self._app_data.max_user_count
+        self._elapsed_time: float = 0.0
+        self._timeout = False  # TODO: Error management
+        self._save_keyframes = True
+
+    def get_next_state(self) -> Optional[AppStateBase]:
+        if self._cancel:
+            error = (
+                "Timeout" if self._timeout else "User disconnected"
+            )
+            return create_app_state_cancel_session(
+                self._app_service, self._app_data, self._session, error
+            )
+
+        # If all users pressed the "Start" button, begin the session.
+        ready_to_start = True
+        for user_ready in self._ready_to_start:
+            ready_to_start &= user_ready
+        if ready_to_start or SKIP_START_SCREEN:
+            return create_app_state_rearrange(
+                self._app_service, self._app_data, self._session
+            )
+
+        return None
+
+    def sim_update(self, dt: float, post_sim_update_dict):
+        # Top-down view.
+        cam_matrix = get_top_down_view(self._app_service.sim)
+        post_sim_update_dict["cam_transform"] = cam_matrix
+        self._app_service._client_message_manager.update_camera_transform(
+            cam_matrix, destination_mask=Mask.ALL
+        )
+
+        # Time limit to start the experiment.
+        self._elapsed_time += dt
+        remaining_time = START_SCREEN_TIMEOUT - self._elapsed_time
+        if remaining_time <= 0:
+            self._cancel = True
+            self._timeout = True
+            return
+        remaining_time_int = int(remaining_time)
+        title = f"New Session (Expires in: {remaining_time_int}s)"
+
+        # Show dialogue box with "Start" button.
+        for user_index in range(self._app_data.max_user_count):
+            button_pressed = (
+                self._app_service.remote_client_state.ui_button_pressed(
+                    user_index, START_BUTTON_ID
+                )
+            )
+            self._ready_to_start[user_index] |= button_pressed
+
+            if not self._ready_to_start[user_index]:
+                self._app_service.client_message_manager.show_modal_dialogue_box(
+                    title,
+                    "Press 'Start' to begin the experiment.",
+                    [UIButton(START_BUTTON_ID, "Start", True)],
+                    destination_mask=Mask.from_index(user_index),
+                )
+            else:
+                self._app_service.client_message_manager.show_modal_dialogue_box(
+                    title,
+                    "Waiting for other participants...",
+                    [UIButton(START_BUTTON_ID, "Start", False)],
+                    destination_mask=Mask.from_index(user_index),
+                )
+
+        # Server-only: Press numeric keys to start episode on behalf of users.
+        if not self._app_service.hitl_config.experimental.headless.do_headless:
+            server_message = "Press numeric keys to start on behalf of users."
+            first_key = int(KeyCode.ONE)
+            for user_index in range(len(self._ready_to_start)):
+                if self._app_service.gui_input.get_key_down(
+                    KeyCode(first_key + user_index)
+                ):
+                    self._ready_to_start[user_index] = True
+                user_ready = self._ready_to_start[user_index]
+                server_message += f"\n[{user_index + 1}]: User {user_index}: {'Ready' if user_ready else 'Not ready'}."
+
+            self._app_service.text_drawer.add_text(
+                server_message,
+                TextOnScreenAlignment.TOP_LEFT,
+                text_delta_x=0,
+                text_delta_y=-50,
+                destination_mask=Mask.NONE,
+            )

--- a/examples/hitl/rearrange_v2/app_state_start_session.py
+++ b/examples/hitl/rearrange_v2/app_state_start_session.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+from app_data import AppData
+from app_state_base import AppStateBase
+from app_states import (
+    create_app_state_cancel_session,
+    create_app_state_load_episode,
+)
+from session import Session
+
+from habitat_hitl.app_states.app_service import AppService
+
+
+class AppStateStartSession(AppStateBase):
+    def __init__(self, app_service: AppService, app_data: AppData):
+        super().__init__(app_service, app_data)
+        self._new_session: Optional[Session] = None
+        self._save_keyframes = False
+
+    def get_next_state(self) -> Optional[AppStateBase]:
+        episode_ids = self._try_get_episodes()
+        if episode_ids is not None:
+            # Start the session.
+            self._new_session = Session(
+                self._app_service.config,
+                list(episode_ids),
+                dict(self._app_data.connected_users),
+            )
+
+            if self._cancel:
+                return create_app_state_cancel_session(
+                    self._app_service, self._app_data, self._new_session, "User disconnected"
+                )
+            else:
+                return create_app_state_load_episode(
+                    self._app_service, self._app_data, self._new_session
+                )
+        else:
+            # Create partial session record.
+            self._new_session = Session(
+                self._app_service.config,
+                [],
+                dict(self._app_data.connected_users),
+            )
+            return create_app_state_cancel_session(
+                self._app_service, self._app_data, self._new_session, "Invalid session"
+            )
+
+    def _try_get_episodes(self) -> Optional[List[str]]:
+        """
+        Attempt to get episodes from client connection parameters.
+        Format: {lower_bound_inclusive}-{upper_bound_exclusive} (e.g. "100-110").
+        """
+        data = self._app_data
+
+        # Sanity checking.
+        if len(data.connected_users) == 0:
+            print("No user connected. Cancelling session.")
+            return None
+        connection_record = episodes_str = list(data.connected_users.values())[
+            0
+        ]
+
+        # Validate that episodes are selected.
+        if "episodes" not in connection_record:
+            print("Users did not request episodes. Cancelling session.")
+            return None
+        episodes_str = connection_record["episodes"]
+
+        # Validate that all users are requesting the same episodes.
+        for connection_record in data.connected_users.values():
+            if connection_record["episodes"] != episodes_str:
+                print(
+                    "Users are requesting different episodes! Cancelling session."
+                )
+                return None
+
+        # Validate that the episode set is not empty.
+        if episodes_str is None or len(episodes_str) == 0:
+            print("Users did not request episodes. Cancelling session.")
+            return None
+
+        # Format: {lower_bound}-{upper_bound} E.g. 100-110
+        # Upper bound is exclusive.
+        episode_range_str = episodes_str.split("-")
+        if len(episode_range_str) != 2:
+            print("Invalid episode range. Cancelling session.")
+            return None
+
+        # Validate that episodes are numeric.
+        start_episode_id = (
+            int(episode_range_str[0])
+            if episode_range_str[0].isdecimal()
+            else None
+        )
+        last_episode_id = (
+            int(episode_range_str[1])
+            if episode_range_str[0].isdecimal()
+            else None
+        )
+        if (
+            start_episode_id is None
+            or last_episode_id is None
+            or start_episode_id < 0
+        ):
+            print("Invalid episode names. Cancelling session.")
+            return None
+
+        total_episode_count = len(
+            self._app_service.episode_helper._episode_iterator.episodes
+        )
+
+        # Validate episode range.
+        if start_episode_id >= total_episode_count:
+            print("Invalid episode names. Cancelling session.")
+            return None
+
+        if last_episode_id >= total_episode_count:
+            last_episode_id = total_episode_count
+
+        # If in decreasing order, swap.
+        if start_episode_id > last_episode_id:
+            temp = last_episode_id
+            last_episode_id = start_episode_id
+            start_episode_id = temp
+        
+        episode_ids: List[int] = []
+        for episode_id in range(start_episode_id, last_episode_id):
+            episode_ids.append(episode_id)
+
+        return episode_ids

--- a/examples/hitl/rearrange_v2/app_state_start_session.py
+++ b/examples/hitl/rearrange_v2/app_state_start_session.py
@@ -35,7 +35,10 @@ class AppStateStartSession(AppStateBase):
 
             if self._cancel:
                 return create_app_state_cancel_session(
-                    self._app_service, self._app_data, self._new_session, "User disconnected"
+                    self._app_service,
+                    self._app_data,
+                    self._new_session,
+                    "User disconnected",
                 )
             else:
                 return create_app_state_load_episode(
@@ -49,7 +52,10 @@ class AppStateStartSession(AppStateBase):
                 dict(self._app_data.connected_users),
             )
             return create_app_state_cancel_session(
-                self._app_service, self._app_data, self._new_session, "Invalid session"
+                self._app_service,
+                self._app_data,
+                self._new_session,
+                "Invalid session",
             )
 
     def _try_get_episodes(self) -> Optional[List[str]]:
@@ -129,9 +135,9 @@ class AppStateStartSession(AppStateBase):
             temp = last_episode_id
             last_episode_id = start_episode_id
             start_episode_id = temp
-        
-        episode_ids: List[int] = []
+
+        episode_ids: List[str] = []
         for episode_id in range(start_episode_id, last_episode_id):
-            episode_ids.append(episode_id)
+            episode_ids.append(str(episode_id))
 
         return episode_ids

--- a/examples/hitl/rearrange_v2/app_states.py
+++ b/examples/hitl/rearrange_v2/app_states.py
@@ -30,6 +30,7 @@ def create_app_state_lobby(
 
     return AppStateLobby(app_service, app_data)
 
+
 def create_app_state_start_session(
     app_service: AppService, app_data: AppData
 ) -> AppStateBase:
@@ -68,6 +69,7 @@ def create_app_state_end_session(
     from app_state_end_session import AppStateEndSession
 
     return AppStateEndSession(app_service, app_data, session)
+
 
 def create_app_state_cancel_session(
     app_service: AppService, app_data: AppData, session: Session, error: str

--- a/examples/hitl/rearrange_v2/app_states.py
+++ b/examples/hitl/rearrange_v2/app_states.py
@@ -10,6 +10,7 @@ Boilerplate code for creating states without circular dependencies.
 
 from app_data import AppData
 from app_state_base import AppStateBase
+from session import Session
 
 from habitat_hitl.app_states.app_service import AppService
 
@@ -29,10 +30,49 @@ def create_app_state_lobby(
 
     return AppStateLobby(app_service, app_data)
 
+def create_app_state_start_session(
+    app_service: AppService, app_data: AppData
+) -> AppStateBase:
+    from app_state_start_session import AppStateStartSession
+
+    return AppStateStartSession(app_service, app_data)
+
+
+def create_app_state_load_episode(
+    app_service: AppService, app_data: AppData, session: Session
+) -> AppStateBase:
+    from app_state_load_episode import AppStateLoadEpisode
+
+    return AppStateLoadEpisode(app_service, app_data, session)
+
+
+def create_app_state_start_screen(
+    app_service: AppService, app_data: AppData, session: Session
+) -> AppStateBase:
+    from app_state_start_screen import AppStateStartScreen
+
+    return AppStateStartScreen(app_service, app_data, session)
+
 
 def create_app_state_rearrange(
-    app_service: AppService, app_data: AppData
+    app_service: AppService, app_data: AppData, session: Session
 ) -> AppStateBase:
     from rearrange_v2 import AppStateRearrangeV2
 
-    return AppStateRearrangeV2(app_service, app_data)
+    return AppStateRearrangeV2(app_service, app_data, session)
+
+
+def create_app_state_end_session(
+    app_service: AppService, app_data: AppData, session: Session
+) -> AppStateBase:
+    from app_state_end_session import AppStateEndSession
+
+    return AppStateEndSession(app_service, app_data, session)
+
+def create_app_state_cancel_session(
+    app_service: AppService, app_data: AppData, session: Session, error: str
+) -> AppStateBase:
+    from app_state_end_session import AppStateEndSession
+
+    session.error = error
+    return AppStateEndSession(app_service, app_data, session)

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -443,7 +443,7 @@ class AppStateRearrangeV2(AppStateBase):
             )
 
     def sim_update(self, dt: float, post_sim_update_dict):
-        if not self._app_service.hitl_config.experimental.headless.do_headless:
+        if self._is_server_gui_enabled():
             # Server GUI exit.
             if (
                 not self._app_service.hitl_config.networking.enable

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -13,7 +13,10 @@ import magnum as mn
 import numpy as np
 from app_data import AppData
 from app_state_base import AppStateBase
-from app_states import create_app_state_cancel_session, create_app_state_load_episode
+from app_states import (
+    create_app_state_cancel_session,
+    create_app_state_load_episode,
+)
 from session import Session
 from ui import UI
 from util import UP
@@ -258,7 +261,9 @@ class AppStateRearrangeV2(AppStateBase):
     Multiplayer rearrangement HITL application.
     """
 
-    def __init__(self, app_service: AppService, app_data: AppData, session: Session):
+    def __init__(
+        self, app_service: AppService, app_data: AppData, session: Session
+    ):
         super().__init__(app_service, app_data)
         self._save_keyframes = False  # Done on env step (rearrange_sim).
         self._app_service = app_service
@@ -299,12 +304,12 @@ class AppStateRearrangeV2(AppStateBase):
                 self._app_service,
                 self._app_data,
                 self._session,
-                "User disconnected")
+                "User disconnected",
+            )
         elif self._is_episode_finished():
             return create_app_state_load_episode(
-                self._app_service,
-                self._app_data,
-                self._session)
+                self._app_service, self._app_data, self._session
+            )
         else:
             return None
 

--- a/examples/hitl/rearrange_v2/session.py
+++ b/examples/hitl/rearrange_v2/session.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List
+from habitat_hitl.core.types import ConnectionRecord
+
+
+class Session:
+    """
+    Data for a single RearrangeV2 session.
+    A session is defined as a sequence of episodes done by a fixed set of users.
+    """
+
+    def __init__(
+        self,
+        config: Any,
+        episode_ids: List[str],
+        connection_records: Dict[int, ConnectionRecord],
+    ):
+        self.success = False
+        self.episode_ids = episode_ids
+        self.current_episode_index = 0
+        self.connection_records = connection_records
+        self.error = ""  # Use this to display error that causes termination
+
+        # Use the port as a discriminator for when there are multiple concurrent servers.
+        output_folder_suffix = str(config.habitat_hitl.networking.port)
+        self.output_folder = f"output_{output_folder_suffix}"

--- a/examples/hitl/rearrange_v2/session.py
+++ b/examples/hitl/rearrange_v2/session.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any, Dict, List
+
 from habitat_hitl.core.types import ConnectionRecord
 
 

--- a/examples/hitl/rearrange_v2/util.py
+++ b/examples/hitl/rearrange_v2/util.py
@@ -5,8 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 from time import time
+from typing import Optional
 
 import magnum as mn
+
+# TODO: Move outside of tutorial.
+from habitat_hitl.environment.hitl_tutorial import (
+    _lookat_bounding_box_top_down,
+)
 
 UP = mn.Vector3(0, 1, 0)
 FWD = mn.Vector3(0, 0, 1)
@@ -15,6 +21,16 @@ FWD = mn.Vector3(0, 0, 1)
 def timestamp() -> str:
     "Generate a Unix timestamp at the current time."
     return str(int(time()))
+
+
+def get_top_down_view(sim) -> mn.Matrix4:
+    """
+    Get a top-down view of the current scene.
+    """
+    scene_root_node = sim.get_active_scene_graph().get_root_node()
+    scene_target_bb: mn.Range3D = scene_root_node.cumulative_bb
+    look_at = _lookat_bounding_box_top_down(200, scene_target_bb, FWD)
+    return mn.Matrix4.look_at(look_at[0], look_at[1], UP)
 
 
 def get_empty_view(sim) -> mn.Matrix4:

--- a/examples/hitl/rearrange_v2/util.py
+++ b/examples/hitl/rearrange_v2/util.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from time import time
-from typing import Optional
 
 import magnum as mn
 


### PR DESCRIPTION
## Motivation and Context

This changeset adds session handling in `rearrange_v2`.

A session is defined as a sequence of episodes to be done by a fixed set of users.
The session is the unit of work that is collected during a HITL experiment.

Additions:
* Session management.
* Episode loading from connection parameters.
* Load screen.
* Start screen.
* End session screen.

https://github.com/facebookresearch/habitat-lab/assets/110583667/091ddb91-f704-4e86-a4cc-cd5c1ee76ef8

## How it works

The [state machine](https://github.com/facebookresearch/habitat-lab/pull/1964) is extended as such:

`Reset` (initial state):
* Kicks all users.
* Previous session is deleted.
* Changes to `Lobby` when all users are disconnected.

`Lobby`:
* Blank screen.
* New connections are only allowed during this state.
* Changes to `Start Session` when `max_user_count` are connected.

`Start Session`:
* Parses the `episodes` field from the users connection parameters.
    * This comes from the URL parameters in WebGL, or a config file on Android.
* The `Session` object is created.
* Switches to `Load Episode` when successful. Cancels session otherwise.

`Load Episode`:
* Increment the session episode index.
* If the next episode exists:
    * Load it.
    * Show a loading screen
    * Switch to `Start Screen`
* If the last episode is completed, change to `End Session`.
* If any user disconnects, cancel the session.

`Start Screen`:
* Show a top-down view of the scene with a "Start" button.
* Change to `RearrangeV2` when all users pressed the button.
* If any user disconnects or the state times out, cancel the session.

`RearrangeV2`:
* HITL application.
* Change to `Load Episode` when all users signaled the episode as completed.
* If any user disconnects or is AFK, cancel the session.

`End Session`:
* Show a "Session ended" screen.
* _[Upcoming PR]_ Upload the session data to S3.
* Switch to `Reset` when upload is finished.

## How Has This Been Tested

Tested in multiplayer HITL application.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
