### PR TITLE
remove auto downloader from RearrangeDataset init

### DIFF
--- a/habitat-hitl/test/test_example_apps.py
+++ b/habitat-hitl/test/test_example_apps.py
@@ -7,7 +7,7 @@
 import multiprocessing
 import runpy
 import sys
-from os import path
+from os import path as osp
 
 import pytest
 
@@ -15,8 +15,8 @@ import pytest
 def run_main(*args):
     sys.argv = list(args)
     target = args[0]
-    if path.isfile(target):
-        sys.path.insert(0, path.dirname(target))
+    if osp.isfile(target):
+        sys.path.insert(0, osp.dirname(target))
     runpy.run_path(target, run_name="__main__")
 
 
@@ -28,6 +28,10 @@ def run_main_as_subprocess(args):
     assert process.exitcode == 0
 
 
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/hssd-hab"),
+    reason="Requires public Habitat-HSSD scene dataset. TODO: should be updated to a new dataset.",
+)
 @pytest.mark.parametrize(
     "args",
     [
@@ -43,6 +47,10 @@ def test_hitl_example_basic_viewer(args):
     run_main_as_subprocess(args)
 
 
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/hssd-hab"),
+    reason="Requires public Habitat-HSSD scene dataset. TODO: should be updated to a new dataset.",
+)
 @pytest.mark.parametrize(
     "args",
     [
@@ -58,6 +66,10 @@ def test_hitl_example_minimal(args):
     run_main_as_subprocess(args)
 
 
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/hssd-hab"),
+    reason="Requires public Habitat-HSSD scene dataset. TODO: should be updated to a new dataset.",
+)
 @pytest.mark.parametrize(
     "args",
     [
@@ -73,6 +85,10 @@ def test_hitl_example_pick_throw_vr(args):
     run_main_as_subprocess(args)
 
 
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/hssd-hab"),
+    reason="Requires public Habitat-HSSD scene dataset. TODO: should be updated to a new dataset.",
+)
 @pytest.mark.parametrize(
     "args",
     [
@@ -89,6 +105,10 @@ def test_hitl_example_rearrange(args):
 
 
 @pytest.mark.skip(reason="Cannot currently be tested.")
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/hssd-hab"),
+    reason="Requires public Habitat-HSSD scene dataset. TODO: should be updated to a new dataset.",
+)
 @pytest.mark.parametrize(
     "args",
     [

--- a/habitat-hitl/test/test_main.py
+++ b/habitat-hitl/test/test_main.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from os import path as osp
+
 import magnum
+import pytest
 from hydra import compose, initialize
 
 from habitat_hitl.app_states.app_state_abc import AppState
@@ -37,6 +40,10 @@ def main(config) -> None:
     hitl_main(config, lambda app_service: AppStateTest(app_service))
 
 
+@pytest.mark.skipif(
+    not osp.exists("data/scene_datasets/hssd-hab"),
+    reason="Requires public Habitat-HSSD scene dataset. TODO: should be updated to a new dataset.",
+)
 def test_hitl_main():
     register_hydra_plugins()
     with initialize(version_base=None, config_path="config"):

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
@@ -10,9 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 import attr
 import numpy as np
 
-import habitat_sim.utils.datasets_download as data_downloader
 from habitat.core.dataset import Episode
-from habitat.core.logging import logger
 from habitat.core.registry import registry
 from habitat.core.utils import DatasetFloatJSONEncoder
 from habitat.datasets.pointnav.pointnav_dataset import PointNavDatasetV1
@@ -58,18 +56,9 @@ class RearrangeDatasetV0(PointNavDatasetV1):
         self.config = config
 
         if config and not self.check_config_paths_exist(config):
-            logger.info(
-                "Rearrange task assets are not downloaded locally, downloading and extracting now..."
+            raise ValueError(
+                f"Requested RearrangeDataset config paths '{config.split}' or '{config.scenes_dir}' are not downloaded locally. Aborting."
             )
-            data_downloader.main(
-                [
-                    "--uids",
-                    "rearrange_task_assets",
-                    "--no-replace",
-                    "--no-prune",
-                ]
-            )
-            logger.info("Downloaded and extracted the data.")
 
         check_and_gen_physics_config()
 

--- a/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
+++ b/habitat-lab/habitat/datasets/rearrange/rearrange_dataset.py
@@ -57,7 +57,7 @@ class RearrangeDatasetV0(PointNavDatasetV1):
 
         if config and not self.check_config_paths_exist(config):
             raise ValueError(
-                f"Requested RearrangeDataset config paths '{config.split}' or '{config.scenes_dir}' are not downloaded locally. Aborting."
+                f"Requested RearrangeDataset config paths '{config.data_path.format(split=config.split)}' or '{config.scenes_dir}' are not downloaded locally. Aborting."
             )
 
         check_and_gen_physics_config()


### PR DESCRIPTION
## Motivation and Context

Removing another auto downloader call in the RearrangeDataset when a config is requested for initialization which references non-existant paths. Instead of trying to fill the path, it should rely on the user to do so and fail clearly.

## How Has This Been Tested

NA

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
