### PR TITLE
add ignore_object_ids to snap_down API

### DIFF
--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -150,6 +150,14 @@ def test_snap_down(support_margin, obj_margin, stage_support):
                 assert (
                     bb_ray_prescreen_results["surface_snap_point"] is not None
                 )
+
+                # reset the object and try again, ignoring the supports instead
+                cube_obj.translation = mn.Vector3(0, 0.2, 0)
+                snap_success = sutils.snap_down(
+                    sim, cube_obj, ignore_obj_ids=support_obj_ids
+                )
+                assert not snap_success
+
                 if stage_support:
                     # don't need 3 iterations for stage b/c no motion types to test
                     break


### PR DESCRIPTION
## Motivation and Context

This PR adds optional `ignore_object_ids` to the `snap_down` API. This allows particular objects to be ignored in the collision and raycasting checks. 

A good example of utility is using snap_down to determine a placement location for an object on the floor. Ideally, the robot's own body would not be considered in the validation checks when locating a placement position. Those ids could be added to the ignore list.

## How Has This Been Tested

Added a simple CI test.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
