### PR TITLE
**\[Development\]** Add new api for getting and setting object states which supports custom serialization

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/object_state_machine.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/object_state_machine.py
@@ -156,6 +156,61 @@ class ObjectStateSpec:
         :param camera_transform: The Matrix4 camera transform.
         """
 
+    def get_state_of_obj(
+        self, obj: Union[ManagedArticulatedObject, ManagedRigidObject]
+    ) -> Any:
+        """
+        Retrieves the state of a given object for this state.
+
+        :param obj: The object to retrieve the state for.
+        :return: The state of the object for this state, or None if the object does not afford this state.
+        :rtype: Any
+        """
+        if not self.is_affordance_of_obj(obj):
+            return None
+
+        if "object_states" in obj.user_attributes.get_subconfig_keys():
+            obj_states_config = obj.user_attributes.get_subconfig(
+                "object_states"
+            )
+            if obj_states_config.has_value(self.name):
+                return self.deserialize_value(obj_states_config.get(self.name))
+        return self.default_value()
+
+    def set_state_of_obj(
+        self,
+        obj: Union[ManagedArticulatedObject, ManagedRigidObject],
+        value: Any,
+    ) -> None:
+        """
+        Sets the state of a given object for this state spec.
+
+        :param obj: The object to set the state for.
+        :param value: The value of the state to set.
+        """
+        user_attr = obj.user_attributes
+        obj_state_config = user_attr.get_subconfig("object_states")
+        obj_state_config.set(self.name, self.serialize_value(value))
+        user_attr.save_subconfig("object_states", obj_state_config)
+
+    def serialize_value(self, value: Any) -> Any:
+        """
+        Serializes the value of the state to be stored in the object states configuration.
+        Should be overridden by subclasses for complex/non-primitive state types.
+        :param value: The value of the state to set.
+        """
+        return value
+
+    def deserialize_value(self, config_value: Any) -> Any:
+        """
+        Deserializes the value of the state loaded from the user_attributes config
+        Should be overridden by subclasses for complex/non-primitive state types.
+
+        :param config_value: The value loaded from the user_attributes config.
+        :return: The deserialize value of the state.
+        """
+        return config_value
+
 
 class BooleanObjectState(ObjectStateSpec):
     """
@@ -213,6 +268,9 @@ class BooleanObjectState(ObjectStateSpec):
         new_state = not cur_state
         set_state_of_obj(obj, self.name, new_state)
         return new_state
+
+    def deserialize_value(self, config_value: Any) -> bool:
+        return bool(config_value)
 
 
 class ObjectIsClean(BooleanObjectState):
@@ -303,6 +361,55 @@ class ObjectStateMachine:
                 for state in states:
                     state.update_state(sim, obj, dt)
 
+    def _get_state_spec_from_name(self, state_name: str) -> ObjectStateSpec:
+        """
+        Retrieves the state specification for a given state name.
+
+        :param state_name: The name of the state.
+        :return: The state specification for the given state name.
+        """
+        for state in self.active_states:
+            if state.name == state_name:
+                return state
+        raise ValueError(f"State {state_name} not found in active states.")
+
+    def get_state_of_obj(
+        self,
+        obj: Union[ManagedArticulatedObject, ManagedRigidObject],
+        state_name: str,
+    ) -> Any:
+        """
+        Retrieves the state of a given object for a specific state name.
+
+        :param obj: The object to retrieve the state for.
+        :param state_name: The name of the state.
+        :return: The state of the object for the given state name, or None if the object does not afford this state.
+        :rtype: Any
+        """
+        object_state_spec = self._get_state_spec_from_name(state_name)
+        if object_state_spec in self.objects_with_states[obj.handle]:
+            return object_state_spec.get_state_of_obj(obj)
+        else:
+            # Return none if the object does not afford this state
+            return None
+
+    def set_state_of_obj(
+        self,
+        obj: Union[ManagedArticulatedObject, ManagedRigidObject],
+        state_name: str,
+        value: Any,
+    ) -> None:
+        """
+        Sets the state of a given object for a specific state name. Does nothing if the object does not afford the state.
+
+        :param obj: The object to set the state for.
+        :param state_name: The name of the state.
+        :param value: The value of the state to set.
+        """
+        object_state_spec = self._get_state_spec_from_name(state_name)
+        if object_state_spec in self.objects_with_states[obj.handle]:
+            object_state_spec.set_state_of_obj(obj, value)
+
     def get_snapshot_dict(
         self, sim: habitat_sim.Simulator
     ) -> Dict[str, Dict[str, Any]]:
@@ -329,7 +436,7 @@ class ObjectStateMachine:
         for object_handle, states in self.objects_with_states.items():
             obj = sutils.get_obj_from_handle(sim, object_handle)
             for state in states:
-                obj_state = get_state_of_obj(obj, state.name)
+                obj_state = self.get_state_of_obj(obj, state.name)
                 snapshot[state.name][object_handle] = (
                     obj_state
                     if obj_state is not None


### PR DESCRIPTION
Adds a new api for getting and setting object states which supports custom serialization

## Motivation and Context

This will allow us to 
1) query the state of a single object while still injecting the default value when necessary. and
2) Support compound/non-primitive state values for object states.
## How Has This Been Tested

Unit testing

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Docs change\]** Addition or changes to the documentation
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Dependency Upgrade\]** Upgrades one or several dependencies in habitat
- **\[Bug Fix\]** (non-breaking change which fixes an issue)
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!
- **\[Experiment\]** A pull request that add new features to the [habitat-baselines](/habitat-baselines/) training codebase. Experiments Pull Requests can be any size, must have smoke/integration tests and be isolated from the rest of the code. Your code additions should not rely on other habitat-baselines code. This is to avoid dependencies between different parts of habitat-baselines. You must also include a README that will document how to use your new feature or trainer. **You** will be the maintainer of this code, if the code becomes stale or is not supported often enough, we will eventually remove it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ x] I have completed my CLA (see **CONTRIBUTING**)
- [x ] I have added tests to cover my changes if required.
