### PR TITLE
[Bug Fix] fix out of index error on Stretch arm action when using a joint mask

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
@@ -187,9 +187,9 @@ class KinematicRelationshipManager:
                 continue
 
             obj = sutils.get_obj_from_handle(self.sim, obj_handle)
-            assert (
-                obj is not None
-            ), f"Object with handle '{obj_handle}' could not be found in the scene. Has the Episode been initialized?"
+            if obj is None:
+                # ignore
+                continue
             rec = unique_name_to_rec[rec_unique_name]
             parent_obj = sutils.get_obj_from_handle(
                 self.sim, rec.parent_object_handle

--- a/habitat-lab/habitat/tasks/rearrange/actions/actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/actions.py
@@ -403,7 +403,6 @@ class ArmRelPosKinematicReducedActionStretch(ArticulatedAgentAction):
         for mask in self._arm_joint_mask:
             if mask == 0:
                 tgt_idx += 1
-                src_idx += 1
                 continue
             expanded_delta_pos[tgt_idx] = delta_pos[src_idx]
             tgt_idx += 1

--- a/habitat-lab/habitat/tasks/rearrange/actions/actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/actions.py
@@ -409,9 +409,8 @@ class ArmRelPosKinematicReducedActionStretch(ArticulatedAgentAction):
             src_idx += 1
 
         min_limit, max_limit = self.cur_articulated_agent.arm_joint_limits
-
         set_arm_pos = (
-            expanded_delta_pos + self.cur_articulated_agent.arm_motor_pos
+            expanded_delta_pos + self.cur_articulated_agent.arm_joint_pos
         )
         # Perform roll over to the joints so that the user cannot control
         # the motor 2, 3, 4 for the arm.
@@ -428,6 +427,10 @@ class ArmRelPosKinematicReducedActionStretch(ArticulatedAgentAction):
         set_arm_pos = np.clip(set_arm_pos, min_limit, max_limit)
 
         self.cur_articulated_agent.arm_motor_pos = set_arm_pos
+        self.cur_articulated_agent.arm_joint_pos = set_arm_pos
+        if self.cur_grasp_mgr.snap_idx is not None:
+            # Holding onto an object, also kinematically update the object.
+            self.cur_grasp_mgr.update_object_to_grasp()
 
 
 @registry.register_task_action


### PR DESCRIPTION
## Motivation and Context

- when using a joint mask (for example `[1,0,0,0,1,1,1,1,1,1]`) on Stretch while using the `ArmRelPosKinematicReducedActionStretch` action type, you would expect to specify the action using only the masked joints and not having any values for ignored joints (otherwise, what's the point of the mask?). 
- current code does not support this, causing an out of index error.

## How Has This Been Tested

By running a stretch based agent that uses a joint mask.

## Types of changes

NOTE: in theory this is a breaking change, in case someone was relying on the joint mask not doing anything. If the people who designed the mask are still around, was this the intended behaviour or was the intended behaviour to still include ignored joints in the action space?

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
