### PR TITLE
DebugVisualizer: equirect, removal/deconstruction, image matrix util, and unit test

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -158,6 +158,8 @@ class DebugVisualizer:
         sim: habitat_sim.Simulator,
         output_path: str = "visual_debug_output/",
         resolution: Tuple[int, int] = (500, 500),
+        clear_color: Optional[mn.Color4] = None,
+        equirect=False,
     ) -> None:
         """
         Initialize the debugger provided a Simulator and the uuid of the debug sensor.
@@ -166,6 +168,7 @@ class DebugVisualizer:
         :param sim: Simulator instance must be provided for attachment.
         :param output_path: Directory path for saving debug images and videos.
         :param resolution: The desired sensor resolution for any new debug agent.
+        :param equirect: Optionally use an Equirectangular (360 cube-map) sensor.
         """
 
         self.sim = sim
@@ -178,6 +181,32 @@ class DebugVisualizer:
         self.sensor: habitat_sim.simulator.Sensor = None
         self.agent: habitat_sim.simulator.Agent = None
         self.agent_id = 0
+        # default black background
+        self.clear_color = (
+            mn.Color4.from_linear_rgb_int(0)
+            if clear_color is None
+            else clear_color
+        )
+        self._equirect = equirect
+
+    @property
+    def equirect(self) -> bool:
+        return self._equirect
+
+    @equirect.setter
+    def equirect(self, equirect: bool) -> None:
+        """
+        Set the equirect mode on or off.
+        If dbv is already initialized to a different mode, re-initialize it.
+        """
+
+        if self._equirect != equirect:
+            # change the value
+            self._equirect = equirect
+            if self.agent is not None:
+                # re-initialize the agent
+                self.remove_dbv_agent()
+                self.create_dbv_agent(self.sensor_resolution)
 
     def create_dbv_agent(
         self, resolution: Tuple[int, int] = (500, 500)
@@ -192,11 +221,16 @@ class DebugVisualizer:
 
         debug_agent_config = habitat_sim.agent.AgentConfiguration()
 
-        debug_sensor_spec = habitat_sim.CameraSensorSpec()
+        debug_sensor_spec = (
+            habitat_sim.CameraSensorSpec()
+            if not self._equirect
+            else habitat_sim.EquirectangularSensorSpec()
+        )
         debug_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
         debug_sensor_spec.position = [0.0, 0.0, 0.0]
         debug_sensor_spec.resolution = [resolution[0], resolution[1]]
         debug_sensor_spec.uuid = self.sensor_uuid
+        debug_sensor_spec.clear_color = self.clear_color
 
         debug_agent_config.sensor_specifications = [debug_sensor_spec]
         self.sim.agents.append(
@@ -214,6 +248,20 @@ class DebugVisualizer:
         self.sensor = self.sim._Simulator__sensors[self.agent_id][
             self.sensor_uuid
         ]
+
+    def remove_dbv_agent(self):
+        """
+        Clean up a previously initialized DBV agent.
+        """
+
+        if self.agent is None:
+            print("No active dbv agent to remove.")
+            return
+        del self.sim._Simulator__sensors[self.agent_id]
+        del self.sim.agents[self.agent_id]
+        self.agent = None
+        self.agent_id = 0
+        self.sensor = None
 
     def look_at(
         self,
@@ -539,7 +587,7 @@ class DebugVisualizer:
             world_transform = mn.Matrix4.identity_init()
         look_at = world_transform.transform_point(bb.center())
         bb_size = bb.size()
-        fov = self.sensor._spec.hfov
+        fov = 90 if self._equirect else self.sensor._spec.hfov
         aspect = (
             float(self.sensor._spec.resolution[1])
             / self.sensor._spec.resolution[0]
@@ -547,7 +595,7 @@ class DebugVisualizer:
         import math
 
         # compute the optimal view distance from the camera specs and object size
-        distance = (np.amax(np.array(bb_size)) * 1.1 / aspect) / math.tan(
+        distance = (np.amax(np.array(bb_size)) / aspect) / math.tan(
             fov / (360 / math.pi)
         )
         if cam_local_pos is None:
@@ -609,7 +657,7 @@ class DebugVisualizer:
         :param output_path: Optional directory path for saving the video. Otherwise use self.output_path.
         :param prefix: Optional prefix for output filename. Filename format: "<output_path><prefix><timestamp>"
         :param fps: Framerate of the video. Defaults to 4FPS expecting disjoint still frames.
-        :param obs_cache: Optioanlly provide an external observation cache datastructure in place of self.debug_obs.
+        :param obs_cache: Optionally provide an external observation cache datastructure in place of self.debug_obs.
         """
 
         if output_path is None:

--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -189,6 +189,12 @@ class DebugVisualizer:
         )
         self._equirect = equirect
 
+    def __del__(self) -> None:
+        """
+        When a DBV is removed, it should clean up its agent/sensor.
+        """
+        self.remove_dbv_agent()
+
     @property
     def equirect(self) -> bool:
         return self._equirect

--- a/test/test_debug_visualizer.py
+++ b/test/test_debug_visualizer.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os.path as osp
+
+import pytest
+
+import habitat_sim
+from habitat.sims.habitat_simulator.debug_visualizer import DebugVisualizer
+from habitat_sim.utils.settings import default_sim_settings, make_cfg
+
+
+@pytest.mark.skipif(
+    not osp.exists("data/replica_cad/"),
+    reason="Requires ReplicaCAD dataset.",
+)
+def test_debug_visualizer():
+    ######################
+    # NOTE: set show_images==True to see the output images from the various dbv features
+    show_images = True
+    ######################
+
+    sim_settings = default_sim_settings.copy()
+    sim_settings[
+        "scene_dataset_config_file"
+    ] = "data/replica_cad/replicaCAD.scene_dataset_config.json"
+    sim_settings["scene"] = "apt_0"
+    hab_cfg = make_cfg(sim_settings)
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # at first sim should have only the initial default rgb sensor and agent
+        assert len(sim._Simulator__sensors) == 1
+        assert len(sim.agents) == 1
+
+        # initialize the dbv
+        dbv = DebugVisualizer(sim)
+
+        # before initializing nothing changes
+        assert len(sim._Simulator__sensors) == 1
+        assert len(sim.agents) == 1
+
+        # create and register the agent/sensor
+        dbv.create_dbv_agent()
+
+        # now we should have two sensors and agents
+        assert len(sim._Simulator__sensors) == 2
+        assert len(sim.agents) == 2
+
+        # collect all the debug visualizer observations for showing later
+        dbv_obs = []
+
+        # test scene peeking
+        dbv_obs.append(dbv.peek("scene"))
+
+        # test removing the agent/sensor
+        dbv.remove_dbv_agent()
+        assert len(sim._Simulator__sensors) == 1
+        assert len(sim.agents) == 1
+
+        # test switching modes
+        dbv.create_dbv_agent()
+        assert len(sim._Simulator__sensors) == 2
+        assert len(sim.agents) == 2
+        assert dbv.agent is not None
+        assert dbv.equirect == False
+        assert type(dbv.sensor._spec) == habitat_sim.CameraSensorSpec
+        dbv.equirect = True
+        assert dbv.equirect == True
+        assert type(dbv.sensor._spec) == habitat_sim.EquirectangularSensorSpec
+        dbv_obs.append(dbv.peek("scene"))
+
+        # optionally show the debug images for local testing
+        if show_images:
+            for im in dbv_obs:
+                im.show()

--- a/test/test_debug_visualizer.py
+++ b/test/test_debug_visualizer.py
@@ -20,7 +20,7 @@ from habitat_sim.utils.settings import default_sim_settings, make_cfg
 def test_debug_visualizer():
     ######################
     # NOTE: set show_images==True to see the output images from the various dbv features
-    show_images = True
+    show_images = False
     ######################
 
     sim_settings = default_sim_settings.copy()


### PR DESCRIPTION
## Motivation and Context

This PR adds a set of features to the DebugVisualizer along with a basic unit test.

- Adds Equirectangular mode: `dbv.equirect=True` or `DebugVisualizer(sim, equirect=True)` to use an equirectangular sensor
- Adds `dbv.remove_dbv_agent()` - clean up after dbv by removing the added agent/sensor. This is now also called on deconstruction.
- Adds `dbv.clear_color` - set the background color of dbv images (must be set before initialization).
- Adds utility function `stitch_image_matrix` - stitches together a set of PIL Images into a single image matrix.

### Example Equirect Image from DBV:
![06_12_2024_131527396778](https://github.com/facebookresearch/habitat-lab/assets/1445143/21cd04fe-5f9d-404e-a3e9-3c65de32387e)

Can be viewed in 3D with applications like https://arachnoid.com/3DViewer/
![image](https://github.com/facebookresearch/habitat-lab/assets/1445143/e7af9e4b-fab8-4fff-885b-f54d66c5908e)

### Example stitched image matrix from a set of region omnidirectional renderings:

![stitched_06_12_2024_081450952141-min](https://github.com/facebookresearch/habitat-lab/assets/1445143/649c5eec-42ed-4d15-a136-15802f923dbc)


## How Has This Been Tested

Locally + CI tests

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
