### PR TITLE
HITL - Fix missing receptacle ids in place UI place events.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -285,7 +285,7 @@ class UI:
                 UI.PlaceEventData(
                     object_id=object_id,
                     object_handle=rigid_object.handle,
-                    receptacle_id=self._place_selection.object_id,
+                    receptacle_id=receptacle_object_id,
                 )
             )
 


### PR DESCRIPTION
## Motivation and Context

This change fixes a bug that causes receptacle object IDs to be missing from collected data.

## How Has This Been Tested

Tested on single-learn evaluation.

## Types of changes

- **\[Bug Fix\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
