### PR TITLE
HITL - Update rearrange_v2 configs.

### DIFF
--- a/examples/hitl/rearrange_v2/config/experiment/headless_server.yaml
+++ b/examples/hitl/rearrange_v2/config/experiment/headless_server.yaml
@@ -6,7 +6,8 @@ habitat_hitl:
     enable: True
     http_availability_server:
       enable: True
-    client_max_idle_duration: 30.0
+    client_max_idle_duration: 180.0
+    enable_connections_by_default: False
   experimental:
     headless:
       do_headless: True

--- a/examples/hitl/rearrange_v2/config/lang_rearrange_humanoid_only.yaml
+++ b/examples/hitl/rearrange_v2/config/lang_rearrange_humanoid_only.yaml
@@ -9,9 +9,12 @@ habitat:
   # various config args to ensure the episode never ends
   environment:
     max_episode_steps: 0
+    # Ensure that the episode iterator can be controlled by specifying episode IDs.
     iterator_options:
-      # For the demo, we want to showcase the episodes in the specified order
+      max_scene_repeat_steps: -1
+      max_scene_repeat_episodes: -1
       shuffle: False
+      group_by_scene: False
 
 habitat_baselines:
   # todo: document these choices
@@ -32,7 +35,7 @@ habitat_hitl:
     - agent_index: 0
       lin_speed: 10.0
       ang_speed: 300
-  hide_humanoid_in_gui: True
+  hide_humanoid_in_gui: False
   camera:
     first_person_mode: True
   networking:
@@ -40,3 +43,4 @@ habitat_hitl:
       server_camera: False
       server_input: False
     client_max_idle_duration: 180.0
+    enable_connections_by_default: False

--- a/examples/hitl/rearrange_v2/config/lang_rearrange_spot_humanoid.yaml
+++ b/examples/hitl/rearrange_v2/config/lang_rearrange_spot_humanoid.yaml
@@ -9,11 +9,11 @@ habitat:
   # various config args to ensure the episode never ends
   environment:
     max_episode_steps: 0
+    # Ensure that the episode iterator can be controlled by specifying episode IDs.
     iterator_options:
-      # For the demo, we want to showcase the episodes in the specified order
-      shuffle: False
       max_scene_repeat_steps: -1
       max_scene_repeat_episodes: -1
+      shuffle: False
       group_by_scene: False
 
 habitat_baselines:
@@ -45,3 +45,4 @@ habitat_hitl:
       server_camera: False
       server_input: False
     client_max_idle_duration: 180.0
+    enable_connections_by_default: False

--- a/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
+++ b/examples/hitl/rearrange_v2/config/rearrange_v2.yaml
@@ -43,6 +43,6 @@ habitat_hitl:
     - agent_index: 1
       lin_speed: 10.0
       ang_speed: 300
-  hide_humanoid_in_gui: True
+  hide_humanoid_in_gui: False
   camera:
     first_person_mode: True


### PR DESCRIPTION
## Motivation and Context

This updates the rearrange_v2 configs to do the following:
* Disable new connections by default.
    * In this application, new connections are only enabled in the `Lobby` state. See #1964.
* Always show the humanoid in the GUI.
    * In the past, we had to hide the humanoid in first-person. This doesn't scale multiplayer applications.
    * Now, we can set object visibility. See #1959.
* Standardize max idle duration.
* Standardize episode iterator settings.

## How Has This Been Tested

Tested on local and remote HITL applications.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
