### PR TITLE
HITL - Synchronize UI with grasp manager.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import magnum as mn
 from world import World
@@ -24,6 +24,11 @@ from habitat_hitl.core.user_mask import Mask
 from habitat_hitl.environment.camera_helper import CameraHelper
 from habitat_hitl.environment.controllers.controller_abc import GuiController
 from habitat_hitl.environment.hablab_utils import get_agent_art_obj_transform
+
+if TYPE_CHECKING:
+    from habitat.tasks.rearrange.rearrange_grasp_manager import (
+        RearrangeGraspManager,
+    )
 
 # Verticality threshold for successful placement.
 MINIMUM_DROP_VERTICALITY: float = 0.9
@@ -123,6 +128,9 @@ class UI:
         self._on_open = Event()
         self._on_close = Event()
 
+        # Disable the snap manager automatic object positioning so that object placement is controlled here.
+        self._get_grasp_manager()._automatically_update_snapped_object = False
+
     @dataclass
     class PickEventData:
         object_id: int
@@ -218,6 +226,11 @@ class UI:
         self._draw_hovered_pickable()
         self._draw_goals()
 
+    def _get_grasp_manager(self) -> "RearrangeGraspManager":
+        agent_mgr = self._sim.agents_mgr
+        agent_data = agent_mgr._all_agent_data[self._gui_controller._agent_idx]
+        return agent_data.grasp_mgr
+
     def _pick_object(self, object_id: int) -> None:
         """Pick the specified object_id. The object must be pickable and held by nobody else."""
         if (
@@ -233,6 +246,13 @@ class UI:
                     self._held_object_id = object_id
                     self._place_selection.deselect()
                     self._world._all_held_object_ids.add(object_id)
+
+                    grasp_mgr = self._get_grasp_manager()
+                    grasp_mgr.snap_to_obj(
+                        snap_obj_id=object_id,
+                        force=True,
+                    )
+
                     self._on_pick.invoke(
                         UI.PickEventData(
                             object_id=object_id,
@@ -281,11 +301,15 @@ class UI:
             self._held_object_id = None
             self._place_selection.deselect()
             self._world._all_held_object_ids.remove(object_id)
+
+            grasp_mgr = self._get_grasp_manager()
+            grasp_mgr.desnap(force=True)
+
             self._on_place.invoke(
                 UI.PlaceEventData(
                     object_id=object_id,
                     object_handle=rigid_object.handle,
-                    receptacle_id=self._place_selection.object_id,
+                    receptacle_id=receptacle_object_id,
                 )
             )
 

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -223,7 +223,7 @@ class UI:
         if (
             not self._is_holding_object()
             and self._is_object_pickable(object_id)
-            and not self._is_someone_holding_object(object_id)
+            and not self._world.is_any_agent_holding_object(object_id)
         ):
             rigid_object = self._world.get_rigid_object(object_id)
             if rigid_object is not None:
@@ -353,10 +353,6 @@ class UI:
         """Returns true if the user is holding an object."""
         return self._held_object_id is not None
 
-    def _is_someone_holding_object(self, object_id: int) -> bool:
-        """Returns true if any user is holding the specified object."""
-        return object_id in self._world._all_held_object_ids
-
     def _is_within_reach(self, target_pos: mn.Vector3) -> bool:
         """Returns true if the target can be reached by the user."""
         return (
@@ -382,7 +378,7 @@ class UI:
         if not self._is_within_reach(point):
             return False
         # Cannot place on objects held by agents.
-        if self._is_someone_holding_object(receptacle_object_id):
+        if self._world.is_any_agent_holding_object(receptacle_object_id):
             return False
         return True
 
@@ -451,7 +447,7 @@ class UI:
         object_id = self._hover_selection.object_id
         if not self._is_object_pickable(
             object_id
-        ) or self._is_someone_holding_object(object_id):
+        ) or self._world.is_any_agent_holding_object(object_id):
             return
 
         managed_object = sim_utilities.get_obj_from_id(

--- a/examples/hitl/rearrange_v2/world.py
+++ b/examples/hitl/rearrange_v2/world.py
@@ -122,3 +122,18 @@ class World:
             agent_object_ids.add(link_object_id)
 
         return agent_object_ids
+
+    def is_any_agent_holding_object(self, object_id: int) -> bool:
+        """
+        Checks whether the specified object is being held by an agent.
+        This function looks up both the HITL world state and grasp managers.
+        """
+        sim = self._sim
+        agents_mgr = sim.agents_mgr
+
+        for agent_index in range(len(agents_mgr.agent_names)):
+            grasp_mgr = agents_mgr._all_agent_data[agent_index].grasp_mgr
+            if grasp_mgr._snapped_obj_id == object_id:
+                return True
+
+        return object_id in self._all_held_object_ids

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_grasp_manager.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_grasp_manager.py
@@ -56,6 +56,10 @@ class RearrangeGraspManager:
         self._managed_articulated_agent = articulated_agent
         self.ee_index = ee_index
 
+        # HACK: This flag sets whether the grasp manager handles moving the grasped object.
+        # Turn off in applications that handle grasping themselves.
+        self._automatically_update_snapped_object = True
+
         self._kinematic_mode = self._sim.habitat_config.kinematic_mode
 
     def reconfigure(self) -> None:
@@ -213,15 +217,16 @@ class RearrangeGraspManager:
         if self._kinematic_mode:
             return
 
-        self._snap_constraints = [
-            self.create_hold_constraint(
-                RigidConstraintType.PointToPoint,
-                mn.Vector3(0.0, 0.0, 0.0),
-                mn.Vector3(*marker.offset_position),
-                marker.ao_parent.object_id,
-                marker.link_id,
-            ),
-        ]
+        if self._automatically_update_snapped_object:
+            self._snap_constraints = [
+                self.create_hold_constraint(
+                    RigidConstraintType.PointToPoint,
+                    mn.Vector3(0.0, 0.0, 0.0),
+                    mn.Vector3(*marker.offset_position),
+                    marker.ao_parent.object_id,
+                    marker.link_id,
+                ),
+            ]
 
     def create_hold_constraint(
         self,
@@ -299,7 +304,10 @@ class RearrangeGraspManager:
         is grasped then nothing will happen.
         """
 
-        if self._snapped_obj_id is None:
+        if (
+            self._snapped_obj_id is None
+            or not self._automatically_update_snapped_object
+        ):
             # Not grasping anything, so do nothing.
             return
 
@@ -367,16 +375,17 @@ class RearrangeGraspManager:
         if rel_pos is None:
             rel_pos = mn.Vector3.zero_init()
 
-        self._snap_constraints = [
-            self.create_hold_constraint(
-                RigidConstraintType.Fixed,
-                # link pivot is the object in link space
-                pivot_in_link=rel_pos,
-                # object pivot is local origin
-                pivot_in_obj=mn.Vector3.zero_init(),
-                obj_id_b=self._snapped_obj_id,
-            ),
-        ]
+        if self._automatically_update_snapped_object:
+            self._snap_constraints = [
+                self.create_hold_constraint(
+                    RigidConstraintType.Fixed,
+                    # link pivot is the object in link space
+                    pivot_in_link=rel_pos,
+                    # object pivot is local origin
+                    pivot_in_obj=mn.Vector3.zero_init(),
+                    obj_id_b=self._snapped_obj_id,
+                ),
+            ]
 
         if should_open_gripper:
             self._managed_articulated_agent.open_gripper()


### PR DESCRIPTION
## Motivation and Context

The `RearrangeGraspManager` is used by agents to pick up objects or identify if an object is grabbed. Therefore, the objects grabbed in `rearrange_v2` are not visible to the agents, while the objects grabbed by agents can be interacted by the UI.

This changeset changes the `rearrange_v2` GUI such as the grabbed objects are synchronized with grasp managers.

**Note:**
A hacky flag is introduced in `RearrangeGraspManager`, `_automatically_update_snapped_object`, which toggles whether objects are automatically displaced. In HITL, we displace the objects ourselves to avoid occluding the view and communicate to the user that an object is grabbed (see #1908 for examples).
Ideally, the "grasped object" data should be separated from the object displacement item. However, this is a significant refactor. Let me know if you have ideas in the thread.

## How Has This Been Tested

Tested on single-learn and multi-player evaluation.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
