### PR TITLE
Update object states in hitl to use CollaborationSim

### DIFF
--- a/examples/hitl/rearrange_v2/config/lang_rearrange_llmspot_guihumanoid.yaml
+++ b/examples/hitl/rearrange_v2/config/lang_rearrange_llmspot_guihumanoid.yaml
@@ -37,10 +37,6 @@ habitat:
     type: "CollaborationDataset-v0"
     data_path: "data/episodes/cycled_tuts.json.gz"
     scenes_dir: "data/fpss"
-    # metadata:
-    #   metadata_folder: "data/fpss/metadata"
-    #   obj_metadata: object_categories_filtered.csv
-      # staticobj_metadata: fpmodels-with-decomposed.csv
   task:
     pddl_domain_def: fp
   simulator:
@@ -64,6 +60,11 @@ paths:
   epi_result_file_path: "${paths.results_dir}/episode_result_log.csv"
   run_result_file_path: "${paths.results_dir}/run_result_log.csv"
   end_result_file_path: "${paths.results_dir}/end_result_log.csv"
+
+metadata:
+  metadata_folder: "data/fpss/metadata"
+  obj_metadata: object_categories_filtered.csv
+  staticobj_metadata: fpmodels-with-decomposed.csv
 
 hydra:
   job:

--- a/examples/hitl/rearrange_v2/config/language_rearrange.yaml
+++ b/examples/hitl/rearrange_v2/config/language_rearrange.yaml
@@ -56,7 +56,7 @@ habitat:
   environment:
     max_episode_steps: 750
   simulator:
-    type: RearrangeSim-v0
+    type: CollaborationSim-v0
     seed: 100
     additional_object_paths:
       - "data/objects/ycb/configs/"

--- a/examples/hitl/rearrange_v2/config/language_rearrange_multi_agent_llm_gui.yaml
+++ b/examples/hitl/rearrange_v2/config/language_rearrange_multi_agent_llm_gui.yaml
@@ -111,7 +111,7 @@ habitat:
   environment:
     max_episode_steps: 750  # this is 20000 in habitat-llm
   simulator:
-    type: RearrangeSim-v0
+    type: CollaborationSim-v0
     seed: 100
 
     # --- habitat-llm block

--- a/habitat-hitl/habitat_hitl/_internal/config_helper.py
+++ b/habitat-hitl/habitat_hitl/_internal/config_helper.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from omegaconf import OmegaConf
+
 import habitat
 from habitat.config.default import get_agent_config
 from habitat.config.default_structured_configs import (
@@ -19,6 +21,14 @@ def update_config(
     debug_third_person_height=None,
 ):
     with habitat.config.read_write(config):  # type: ignore
+        # Move the metadata info to the habitat simulator config
+        if "metadata" in config:
+            config_dict = OmegaConf.create(
+                OmegaConf.to_container(config.habitat, resolve=True)
+            )
+            config_dict.simulator.metadata = config.metadata
+            config.habitat = config_dict
+
         habitat_config = config.habitat
         sim_config = habitat_config.simulator
         task_config = habitat_config.task

--- a/habitat-hitl/habitat_hitl/environment/controllers/llm_controller.py
+++ b/habitat-hitl/habitat_hitl/environment/controllers/llm_controller.py
@@ -208,12 +208,20 @@ class LLMController(SingleAgentBaselinesController):
             elif action["action"] == "PLACE":
                 furniture_name = "unknown furniture"
                 if action["receptacle_id"] is not None:
-                    receptacle_object = get_obj_from_id(self.environment_interface.sim, action["receptacle_id"])
-                    receptacle_handle = receptacle_object.handle if hasattr(receptacle_object, "handle") else None
+                    receptacle_object = get_obj_from_id(
+                        self.environment_interface.sim, action["receptacle_id"]
+                    )
+                    receptacle_handle = (
+                        receptacle_object.handle
+                        if hasattr(receptacle_object, "handle")
+                        else None
+                    )
                     receptacle_node = None
                     if receptacle_handle is not None:
                         try:
-                            receptacle_node = self.environment_interface.world_graph.get_node_from_sim_handle(receptacle_handle)
+                            receptacle_node = self.environment_interface.world_graph.get_node_from_sim_handle(
+                                receptacle_handle
+                            )
                         except ValueError as e:
                             self._log.append(e)
                     if receptacle_node is not None:
@@ -262,6 +270,13 @@ class LLMController(SingleAgentBaselinesController):
         return
 
     def act(self, observations, debug_obs: bool = False, *args, **kwargs):
+        # Example fetching object states in HITL
+        print(
+            "Current object states:\n",
+            self.environment_interface.sim.object_state_machine.get_snapshot_dict(
+                self.environment_interface.sim
+            ),
+        )
         # set the task as done and report it back
         if self._task_done and not self._termination_reported:
             if (


### PR DESCRIPTION
## Motivation and Context

Updates the HITL tool to use instances of CollaborationSim so that the latest object state logic is available in HITL. Depends on (https://github.com/facebookresearch/habitat-llm/pull/279)

## How Has This Been Tested

Manual local testing

## Types of changes
Development

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
