### PR TITLE
Skip json conversion of invalid attributes.

### DIFF
--- a/habitat-hitl/habitat_hitl/core/serialize_utils.py
+++ b/habitat-hitl/habitat_hitl/core/serialize_utils.py
@@ -57,11 +57,17 @@ def convert_to_json_friendly(obj):
         return convert_to_json_friendly(list(obj))
     else:
         # If obj is a complex object, convert its attributes to a dictionary
-        attributes = {
-            attr: convert_to_json_friendly(getattr(obj, attr))
-            for attr in dir(obj)
-            if not attr.startswith("__") and not callable(getattr(obj, attr))
-        }
+        attributes = {}
+        for attr in dir(obj):
+            try:
+                if not attr.startswith("__") and not callable(
+                    getattr(obj, attr)
+                ):
+                    attributes[attr] = getattr(obj, attr)
+            except Exception as e:
+                print(
+                    f"Unable to convert attribute to JSON: {attr}. Skipping. {e}"
+                )
         return convert_to_json_friendly(attributes)
 
 


### PR DESCRIPTION
## Motivation and Context

This changeset prevent crashes when serializing invalid objects. This is the case for configs with `MISSING` attributes, which happens when using llm configs.

## How Has This Been Tested

Tested on HITL with LLM configs.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
