### PR TITLE
[BE] - KRM single parent refactor

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
@@ -11,6 +11,7 @@ import magnum as mn
 
 import habitat.sims.habitat_simulator.sim_utilities as sutils
 import habitat_sim
+from habitat.core.logging import logger
 from habitat.datasets.rearrange.samplers.receptacle import Receptacle
 
 
@@ -41,7 +42,7 @@ class RelationshipGraph:
 
         assert parent != child
         if (parent, child) in self.relation_types:
-            print(
+            logger.warn(
                 f"Redundant relationship detected. Changing '{parent}' {self.relation_types[(parent, child)]} '{child}' to '{parent}' {rel_type} '{child}'"
             )
         else:
@@ -49,7 +50,7 @@ class RelationshipGraph:
                 self.obj_to_children[parent] = []
             self.obj_to_children[parent].append(child)
             if child in self.obj_to_parents:
-                print(
+                logger.warn(
                     f"Inconsistent relationship requested: child object '{child}' already parented to '{self.obj_to_parents[child]}'. Changing parent to '{parent}' and removing previous relationship."
                 )
                 self.remove_relation(self.obj_to_parents[child], child)

--- a/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
@@ -48,6 +48,11 @@ class RelationshipGraph:
             if parent not in self.obj_to_children:
                 self.obj_to_children[parent] = []
             self.obj_to_children[parent].append(child)
+            if child in self.obj_to_parents:
+                print(
+                    f"Inconsistent relationship requested: child object '{child}' already parented to '{self.obj_to_parents[child]}'. Changing parent to '{parent}' and removing previous relationship."
+                )
+                self.remove_relation(self.obj_to_parents[child], child)
             self.obj_to_parents[child] = parent
         self.relation_types[(parent, child)] = rel_type
 

--- a/test/test_kinematic_relationship_manager.py
+++ b/test/test_kinematic_relationship_manager.py
@@ -152,3 +152,27 @@ def test_kinematic_relationship_manager():
         krm.relationship_graph.get_human_readable_relationship_forest(
             sim, do_print=False
         )
+
+        # attempt an invalid parenting re-assignment (should trigger message and adjust the tree)
+        test_child = list(krm.relationship_graph.obj_to_parents.keys())[0]
+        test_parent = krm.relationship_graph.obj_to_parents[test_child]
+        assert test_parent in krm.relationship_graph.obj_to_children
+        assert (
+            test_child in krm.relationship_graph.obj_to_children[test_parent]
+        )
+        # now add the previously removed parent as parent of this child
+        new_test_parent = table_objects[0].object_id
+        krm.relationship_graph.add_relation(new_test_parent, test_child, "on")
+        assert (
+            test_child
+            not in krm.relationship_graph.obj_to_children[test_parent]
+        )
+        assert new_test_parent in krm.relationship_graph.obj_to_children
+        assert (
+            test_child
+            in krm.relationship_graph.obj_to_children[new_test_parent]
+        )
+        assert (
+            krm.relationship_graph.obj_to_parents[test_child]
+            == new_test_parent
+        )


### PR DESCRIPTION
## Motivation and Context

Refactors KinematicRelationshipManager to track only a single child->parent relationship for consistency. When a conflicting relationship is created, a warning is logged and the new relationship overrides the previous.

Also refactor print statements to log warnings.

## How Has This Been Tested

Added a unit test.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
