### PR TITLE
robustify `snap_down`: use the joined render and collision bounding boxes for the snap point

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -333,7 +333,15 @@ def bb_ray_prescreen(
     raycast_results = []
     gravity_dir = sim.get_gravity().normalized()
     object_local_to_global = obj.transformation
-    bb_corners = get_bb_corners(obj.root_scene_node.cumulative_bb)
+    col_aabb = obj.collision_shape_aabb
+    render_aabb = obj.aabb
+    # use the full collision and render aabb for best snapping accuracy
+    joined_aabb = mn.Range3D(
+        mn.math.min(col_aabb.min, render_aabb.min),
+        mn.math.max(col_aabb.max, render_aabb.max),
+    )
+    bb_corners = get_bb_corners(joined_aabb)
+
     key_points = [mn.Vector3(0)] + bb_corners  # [COM, c0, c1 ...]
     support_impacts: Dict[int, mn.Vector3] = {}  # indexed by keypoints
     for ix, key_point in enumerate(key_points):


### PR DESCRIPTION
## Motivation and Context

This PR replaces the render AABB used by snap_down to estimate the ideal object height displacement with a joined render and collision aabb. Since the desire is to place the object well visually, but a contact test is used to validate the placement proposal, this seems like the best of both worlds.

## How Has This Been Tested

Locally and CI validation

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
