### PR TITLE
add vertical padding to next_to

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -1233,7 +1233,7 @@ def bb_next_to(
     transform_a: mn.Matrix4 = None,
     transform_b: mn.Matrix4 = None,
     hor_l2_threshold: float = 0.3,
-    vertical_padding: float = 0.05,
+    vertical_padding: float = 0.1,
 ) -> bool:
     """
     Check whether or not two bounding boxes should be considered "next to" one another.
@@ -1288,7 +1288,7 @@ def obj_next_to(
     object_id_a: int,
     object_id_b: int,
     hor_l2_threshold: float = 0.5,
-    vertical_padding: float = 0.05,
+    vertical_padding: float = 0.1,
     ao_link_map: Dict[int, int] = None,
 ) -> bool:
     """

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -1232,7 +1232,8 @@ def bb_next_to(
     bb_b: mn.Range3D,
     transform_a: mn.Matrix4 = None,
     transform_b: mn.Matrix4 = None,
-    hor_l2_threshold=0.3,
+    hor_l2_threshold: float = 0.3,
+    vertical_padding: float = 0.05,
 ) -> bool:
     """
     Check whether or not two bounding boxes should be considered "next to" one another.
@@ -1242,6 +1243,7 @@ def bb_next_to(
     :param transform_a: local to global transform for the first object. Default is identity.
     :param transform_b: local to global transform for the second object. Default is identity.
     :param hor_l2_threshold: regularized horizontal L2 distance allowed between the objects' centers.
+    :param vertical_padding: vertical distance padding used when comparing bounding boxes. Higher value is a looser constraint.
     :return: Whether or not the objects are heuristically "next to" one another.
 
     Concretely, consists of two checks:
@@ -1265,10 +1267,9 @@ def bb_next_to(
     highest_height_b = max([p[1] for p in keypoints_b])
 
     # check for non-overlapping bounding boxes
-    if (
-        highest_height_a < lowest_height_b
-        or highest_height_b < lowest_height_a
-    ):
+    if (highest_height_a + vertical_padding) < lowest_height_b or (
+        highest_height_b + vertical_padding
+    ) < lowest_height_a:
         return False
 
     if (
@@ -1286,7 +1287,8 @@ def obj_next_to(
     sim: habitat_sim.Simulator,
     object_id_a: int,
     object_id_b: int,
-    hor_l2_threshold=0.5,
+    hor_l2_threshold: float = 0.5,
+    vertical_padding: float = 0.05,
     ao_link_map: Dict[int, int] = None,
 ) -> bool:
     """
@@ -1297,6 +1299,7 @@ def obj_next_to(
     :param object_id_a: object_id of the first ManagedObject or link.
     :param object_id_b: object_id of the second ManagedObject or link.
     :param hor_l2_threshold: regularized horizontal L2 distance allow between the objects' centers. This should be tailored to the scenario.
+    :param vertical_padding: vertical distance padding added when comparing the object's bounding boxes. Higher value is a looser constraint.
     :param ao_link_map: A pre-computed map from link object ids to their parent ArticulatedObject's object id.
     :return: Whether or not the objects are heuristically "next to" one another.
 
@@ -1321,4 +1324,5 @@ def obj_next_to(
         transform_a,
         transform_b,
         hor_l2_threshold,
+        vertical_padding,
     )

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -870,7 +870,7 @@ def test_on_floor_and_next_to():
                 vertical_padding=0,
             ), f"Objects with ids {obj_a_id} and {obj_b_id} at test pair index {ix} should not be 'next to' one another."
 
-        # NOTE: the drawers are next_to one another with default 5cm vertical padding
+        # NOTE: the drawers are next_to one another with default 10cm vertical padding
         assert sutils.obj_next_to(
             sim,
             140,

--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -847,9 +847,9 @@ def test_on_floor_and_next_to():
         ]
         not_next_to_object_pairs = [
             (36, 38),  # books on different shelves
+            (141, 140),  # two non-neighboring drawers in the chest of drawers
             (11, 14),  # sofa pillows on opposite sides
             (51, 53),  # two objects on different table shelves
-            (141, 140),  # two non-neighboring drawers in the chest of drawers
             (129, 132),  # two non-neighboring cabinet doors
             (17, 20),  # potted plant and coffee table
         ]
@@ -859,6 +859,7 @@ def test_on_floor_and_next_to():
                 obj_a_id,
                 obj_b_id,
                 ao_link_map=ao_link_map,
+                vertical_padding=0,
             ), f"Objects with ids {obj_a_id} and {obj_b_id} at test pair index {ix} should be 'next to' one another."
         for ix, (obj_a_id, obj_b_id) in enumerate(not_next_to_object_pairs):
             assert not sutils.obj_next_to(
@@ -866,4 +867,13 @@ def test_on_floor_and_next_to():
                 obj_a_id,
                 obj_b_id,
                 ao_link_map=ao_link_map,
+                vertical_padding=0,
             ), f"Objects with ids {obj_a_id} and {obj_b_id} at test pair index {ix} should not be 'next to' one another."
+
+        # NOTE: the drawers are next_to one another with default 5cm vertical padding
+        assert sutils.obj_next_to(
+            sim,
+            140,
+            141,
+            ao_link_map=ao_link_map,
+        ), "The drawers should be 'next to' one another with vertical padding."


### PR DESCRIPTION
## Motivation and Context

Thin objects can be semantically next_to one another without actually overlapping bounding boxes. This PR adds a vertical padding option with default value of 10 centimeters.

## How Has This Been Tested

Locally and added a CI test 

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
