### PR TITLE
Refactor to support expanded Simulator reset in RearrangeTask

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/articulated_agent_manager.py
+++ b/habitat-lab/habitat/tasks/rearrange/articulated_agent_manager.py
@@ -170,6 +170,7 @@ class ArticulatedAgentManager:
             agent_data.articulated_agent.params.arm_init_params = (
                 target_arm_init_params
             )
+            # note this does not reset the base position and rotation
             agent_data.articulated_agent.reset()
 
             # Consume a fixed position from SIMULATOR.agent_0 if configured

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -280,6 +280,14 @@ class RearrangeSim(HabitatSim):
         SimulatorBackend.reset(self)
         for i in range(len(self.agents)):
             self.reset_agent(i)
+        # Load specified articulated object states from episode config
+        self._set_ao_states_from_ep(self.ep_info)
+        # reset objects to episode initial state
+        self._add_objs(
+            self.ep_info,
+            should_add_objects=False,  # objects should already by loaded
+            new_scene=False,
+        )  # the scene shouldn't change between resets
         # auto-sleep rigid objects as optimization
         if self._auto_sleep:
             self._sleep_all_objects()

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -280,6 +280,9 @@ class RearrangeSim(HabitatSim):
         SimulatorBackend.reset(self)
         for i in range(len(self.agents)):
             self.reset_agent(i)
+        # auto-sleep rigid objects as optimization
+        if self._auto_sleep:
+            self._sleep_all_objects()
         return None
 
     @add_perf_timing_func()

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -243,8 +243,11 @@ class RearrangeTask(NavigationTask):
             self._is_episode_active = True
 
             if self._should_place_articulated_agent:
+                # here we are randomizing the base pos and rotation if necessary
                 for agent_idx in range(self._sim.num_articulated_agents):
                     self._set_articulated_agent_start(agent_idx)
+            # here we are setting initial joint states and such from configs, if a configured fixed base start state was provided, it is set
+            self._sim.agents_mgr.post_obj_load_reconfigure()
 
         self.prev_measures = self.measurements.get_metrics()
         self._targ_idx = 0


### PR DESCRIPTION
## Motivation and Context

This PR aims to refactor RearrangeTask to support the expanded reset functionality from https://github.com/facebookresearch/habitat-sim/pull/2451
Primary change: apply auto-sleep and handle articulated_agent base setting after expanded state reset

Context: previously the Simulator.reset() only set time to 0, so RearrangeTask code was able to leave the robot in place between reset and objects would stay sleeping (e.g. for benchmarking or idle scenarios). Now the objects are set to origin or scene_instance initial state and the reset logic must also handle initial state resetting and re-sleeping (since objects wake when moved).

## How Has This Been Tested

Previously the hab2_benchmark test was failing due to regression because the robot was resetting to the origin inside a furniture and objects were awoken on initial reset.

I expect to see the CI pass to validate the change.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
