### PR TITLE
HITL - Networking improvements.

### DIFF
--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -59,6 +59,7 @@ class AppStatePickThrowVr(AppState):
         self._can_grasp_place_threshold = (
             self._app_service.hitl_config.can_grasp_place_threshold
         )
+        app_service.users.add_user(1)
 
         self._cam_transform: Optional[mn.Matrix4] = None
         self._held_target_obj_idx: Optional[int] = None

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -60,7 +60,7 @@ class AppStatePickThrowVr(AppState):
             self._app_service.hitl_config.can_grasp_place_threshold
         )
         # Activate the remote user.
-        app_service.users.add_user(0)
+        app_service.users.activate_user(0)
 
         self._cam_transform: Optional[mn.Matrix4] = None
         self._held_target_obj_idx: Optional[int] = None

--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -59,7 +59,8 @@ class AppStatePickThrowVr(AppState):
         self._can_grasp_place_threshold = (
             self._app_service.hitl_config.can_grasp_place_threshold
         )
-        app_service.users.add_user(1)
+        # Activate the remote user.
+        app_service.users.add_user(0)
 
         self._cam_transform: Optional[mn.Matrix4] = None
         self._held_target_obj_idx: Optional[int] = None

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -495,7 +495,7 @@ class AppStateRearrangeV2(AppStateBase):
             )
 
         self._user_data: List[UserData] = []
-        for user_index in self._users.indices(Mask.ALL):
+        for user_index in range(self._users.max_user_count):
             agent_data = self._agent_data[
                 self._user_to_agent_index[user_index]
             ]

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -447,7 +447,9 @@ class AppStateRearrangeV2(AppStateBase):
 
         self._users = app_service.users
         self._num_users = self._users.max_user_count
-        self._agents = Users(len(agent_mgr._all_agent_data))
+        self._agents = Users(
+            len(agent_mgr._all_agent_data), activate_users=True
+        )
         self._num_agents = self._agents.max_user_count
 
         self._sps_tracker = AverageRateTracker(2.0)

--- a/examples/hitl/rearrange_v2/state_machine.py
+++ b/examples/hitl/rearrange_v2/state_machine.py
@@ -50,6 +50,7 @@ class StateMachine(AppState):
             )
         self._app_data.connected_users[connection["userIndex"]] = connection
         self._app_state._time_since_last_connection = 0.0
+        self._app_service.users.add_user(user_index)
 
     def _on_client_disconnected(self, disconnection: DisconnectionRecord):
         user_index = disconnection["userIndex"]
@@ -59,6 +60,8 @@ class StateMachine(AppState):
             # raise RuntimeError(f"User index {user_index} already disconnected! Aborting.")
         else:
             del self._app_data.connected_users[user_index]
+
+        self._app_service.users.remove_user(user_index)
 
         # If a user has disconnected, send a cancellation signal to the current state.
         self._app_state.try_cancel()

--- a/examples/hitl/rearrange_v2/state_machine.py
+++ b/examples/hitl/rearrange_v2/state_machine.py
@@ -50,7 +50,7 @@ class StateMachine(AppState):
             )
         self._app_data.connected_users[connection["userIndex"]] = connection
         self._app_state._time_since_last_connection = 0.0
-        self._app_service.users.add_user(user_index)
+        self._app_service.users.activate_user(user_index)
 
     def _on_client_disconnected(self, disconnection: DisconnectionRecord):
         user_index = disconnection["userIndex"]
@@ -61,7 +61,7 @@ class StateMachine(AppState):
         else:
             del self._app_data.connected_users[user_index]
 
-        self._app_service.users.remove_user(user_index)
+        self._app_service.users.deactivate_user(user_index)
 
         # If a user has disconnected, send a cancellation signal to the current state.
         self._app_state.try_cancel()

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -174,7 +174,10 @@ class HitlDriver(AppDriver):
 
         self._episode_helper = EpisodeHelper(self.habitat_env)
 
-        users = Users(max(self._hitl_config.networking.max_client_count, 1))
+        users = Users(
+            max(self._hitl_config.networking.max_client_count, 1),
+            activate_users=self._hitl_config.networking.enable,
+        )
 
         self._client_message_manager = None
         if self.network_server_enabled:

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -174,9 +174,14 @@ class HitlDriver(AppDriver):
 
         self._episode_helper = EpisodeHelper(self.habitat_env)
 
+        # Create a user container.
+        # In local mode, there is always 1 active user.
+        # In remote mode, users must be activated/deactivated with the 'Users.add_user()' and 'remove_user()' methods.
         users = Users(
-            max(self._hitl_config.networking.max_client_count, 1),
-            activate_users=self._hitl_config.networking.enable,
+            max_user_count=max(
+                self._hitl_config.networking.max_client_count, 1
+            ),
+            activate_users=not self._hitl_config.networking.enable,
         )
 
         self._client_message_manager = None

--- a/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
+++ b/habitat-hitl/habitat_hitl/_internal/hitl_driver.py
@@ -176,7 +176,7 @@ class HitlDriver(AppDriver):
 
         # Create a user container.
         # In local mode, there is always 1 active user.
-        # In remote mode, users must be activated/deactivated with the 'Users.add_user()' and 'remove_user()' methods.
+        # In remote mode, use 'activate_user()' and 'deactivate_user()' when handling connections.
         users = Users(
             max_user_count=max(
                 self._hitl_config.networking.max_client_count, 1

--- a/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
@@ -240,19 +240,20 @@ class NetworkManager:
             )
 
             if len(inc_keyframes_and_messages) > 0:
-                # Consolidate all inc keyframes into one inc_keyframe
                 tmp_con_keyframe = inc_keyframes_and_messages[0]
+
+                # Discard messages for disconnected users.
+                messages = tmp_con_keyframe.messages
+                for user_index in range(len(messages)):
+                    if user_index not in self._user_slots:
+                        messages[user_index].clear()
+
+                # Consolidate all inc keyframes into one inc_keyframe
                 if len(inc_keyframes_and_messages) > 1:
                     for i in range(1, len(inc_keyframes_and_messages)):
                         self._update_consolidated_keyframes_and_messages(
                             tmp_con_keyframe, inc_keyframes_and_messages[i]
                         )
-                    # Discard messages for disconnected users.
-                    messages = tmp_con_keyframe.messages
-                    for user_index in range(len(messages)):
-                        if user_index not in self._user_slots:
-                            messages[user_index].clear()
-
                     inc_keyframes_and_messages = [tmp_con_keyframe]
 
                 for user_index in self._user_slots.keys():

--- a/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
+++ b/habitat-hitl/habitat_hitl/_internal/networking/networking_process.py
@@ -147,6 +147,10 @@ class NetworkManager:
         while user_index in self._user_slots:
             user_index += 1
         self._user_slots[user_index] = client
+
+        # Remove user-specific messages.
+        self._consolidated_keyframe_and_messages.messages[user_index].clear()
+
         return user_index
 
     def _free_user_slot(self, user_index: int) -> None:
@@ -598,7 +602,7 @@ async def networking_main_async(
         # Abort if exception was raised, or if a termination signal was caught.
         if abort or stop.done():
             if stop.done():
-                print(f"Caught termination signal: {stop.result}.")
+                print(f"Caught termination signal: {stop.result()}.")
             break
         # Resume pending tasks.
         tasks = pending

--- a/habitat-hitl/habitat_hitl/core/gui_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/gui_drawer.py
@@ -37,7 +37,8 @@ class GuiDrawer:
         # One local transform stack per user.
         self._local_transforms: List[List[mn.Matrix4]] = []
         if self._client_message_manager:
-            for _ in client_message_manager._users.indices(Mask.ALL):
+            users = client_message_manager._users
+            for _ in range(users.max_user_count):
                 self._local_transforms.append([])
 
     def get_sim_debug_line_render(self) -> Optional[DebugLineRender]:

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -60,7 +60,7 @@ class RemoteClientState:
         self._gui_inputs: List[GuiInput] = []
         self._client_state_history: List[List[ClientState]] = []
         self._receive_rate_trackers: List[AverageRateTracker] = []
-        for _ in users.indices(Mask.ALL):
+        for _ in range(users.max_user_count):
             self._gui_inputs.append(GuiInput())
             self._client_state_history.append([])
             self._receive_rate_trackers.append(AverageRateTracker(2.0))

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -224,7 +224,7 @@ class RemoteClientState:
         Group a list of client states by user index.
         """
         output: List[List[ClientState]] = []
-        for _ in self._users.indices(Mask.ALL):
+        for _ in range(self._users.max_user_count):
             output.append([])
 
         for client_state in client_states:

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -57,11 +57,15 @@ class Users:
     _max_user_count: int
     _active_user_mask: Mask
 
-    def __init__(self, max_user_count: int) -> None:
+    def __init__(
+        self, max_user_count: int, activate_users: bool = True
+    ) -> None:
         assert max_user_count >= 0
         assert max_user_count <= Mask.MAX_VALUE
         self._max_user_count = max_user_count
-        self._active_user_mask = Mask.NONE
+        self._active_user_mask = (
+            Mask.MAX_VALUE if activate_users else Mask.NONE
+        )
 
     def indices(self, user_mask: Mask) -> Generator[int, Any, None]:
         """

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -53,18 +53,14 @@ class Users:
     Represents a set of users with a max_user_count upper bound.
     """
 
-    _max_user_mask: Mask
     _max_user_count: int
+    _active_user_mask: Mask
 
     def __init__(self, max_user_count: int) -> None:
         assert max_user_count >= 0
         assert max_user_count <= Mask.MAX_VALUE
         self._max_user_count = max_user_count
-
-        max_user_mask = 0
-        for _ in range(max_user_count):
-            max_user_mask = (max_user_mask << 1) + 1
-        self._max_user_mask = Mask(max_user_mask)
+        self._active_user_mask = Mask.NONE
 
     def indices(self, user_mask: Mask) -> Generator[int, Any, None]:
         """
@@ -74,12 +70,19 @@ class Users:
         for user_index in users.indices(Mask.all_except_indices([0,2])):
             ...
         """
-        bitset = user_mask & self._max_user_mask
+        bitset = user_mask & self._active_user_mask
         while bitset != 0:
             user_bit = bitset & -bitset
             user_index = log2(user_bit)
             yield int(user_index)
             bitset ^= user_bit
+
+    def add_user(self, user_index: int) -> None:
+        if user_index < self._max_user_count:
+            self._active_user_mask |= Mask.from_index(user_index)
+
+    def remove_user(self, user_index: int) -> None:
+        self._active_user_mask &= ~Mask.from_index(user_index)
 
     def to_index_list(self, user_mask: Mask) -> List[int]:
         """Returns a list of user indices from the specified Mask."""
@@ -92,3 +95,8 @@ class Users:
     def max_user_count(self) -> int:
         """Returns the size of the user set."""
         return self._max_user_count
+
+    @property
+    def active_user_count(self) -> int:
+        """Returns the number of active users."""
+        return len(list(self.indices(Mask.ALL)))

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -51,6 +51,7 @@ class Mask(IntFlag):
 class Users:
     """
     Represents a set of users with a max_user_count upper bound.
+    By default, all users are "inactive". Add new users using the 'add_user' method.
     """
 
     _max_user_count: int
@@ -78,10 +79,12 @@ class Users:
             bitset ^= user_bit
 
     def add_user(self, user_index: int) -> None:
+        """Activate an user."""
         if user_index < self._max_user_count:
             self._active_user_mask |= Mask.from_index(user_index)
 
     def remove_user(self, user_index: int) -> None:
+        """Deactivate an user."""
         self._active_user_mask &= ~Mask.from_index(user_index)
 
     def to_index_list(self, user_mask: Mask) -> List[int]:

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -63,9 +63,14 @@ class Users:
         assert max_user_count >= 0
         assert max_user_count <= Mask.MAX_VALUE
         self._max_user_count = max_user_count
-        self._active_user_mask = (
-            Mask.MAX_VALUE if activate_users else Mask.NONE
-        )
+
+        if activate_users:
+            user_mask = 0
+            for _ in range(max_user_count):
+                user_mask = (user_mask << 1) + 1
+            self._active_user_mask = Mask(user_mask)
+        else:
+            self._active_user_mask = Mask.NONE
 
     def indices(self, user_mask: Mask) -> Generator[int, Any, None]:
         """

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -58,7 +58,7 @@ class Users:
     _active_user_mask: Mask
 
     def __init__(
-        self, max_user_count: int, activate_users: bool = True
+        self, max_user_count: int, activate_users: bool = False
     ) -> None:
         assert max_user_count >= 0
         assert max_user_count <= Mask.MAX_VALUE

--- a/habitat-hitl/habitat_hitl/core/user_mask.py
+++ b/habitat-hitl/habitat_hitl/core/user_mask.py
@@ -87,12 +87,12 @@ class Users:
             yield int(user_index)
             bitset ^= user_bit
 
-    def add_user(self, user_index: int) -> None:
+    def activate_user(self, user_index: int) -> None:
         """Activate an user."""
         if user_index < self._max_user_count:
             self._active_user_mask |= Mask.from_index(user_index)
 
-    def remove_user(self, user_index: int) -> None:
+    def deactivate_user(self, user_index: int) -> None:
         """Deactivate an user."""
         self._active_user_mask &= ~Mask.from_index(user_index)
 

--- a/habitat-hitl/test/test_user_mask.py
+++ b/habitat-hitl/test/test_user_mask.py
@@ -11,7 +11,9 @@ from habitat_hitl.core.user_mask import Mask, Users
 def test_hitl_user_mask():
     # Test without any user.
     zero_users = Users(0)
+    zero_users.add_user(1)
     assert zero_users.max_user_count == 0
+    assert zero_users.active_user_count == 0
     assert len(zero_users.to_index_list(Mask.ALL)) == 0
     assert len(zero_users.to_index_list(Mask.NONE)) == 0
     user_indices = zero_users.to_index_list(
@@ -21,10 +23,21 @@ def test_hitl_user_mask():
     assert 1 not in user_indices
     user_indices = zero_users.to_index_list(Mask.all_except_index(0))
     assert 0 not in user_indices
+    zero_users.remove_user(1)
+    assert zero_users.active_user_count == 0
 
-    # Test without 4 users.
+    # Test with 4 users.
     four_users = Users(4)
     assert four_users.max_user_count == 4
+    assert four_users.active_user_count == 0
+    for user_index in range(4):
+        four_users.add_user(user_index)
+        assert four_users.active_user_count == user_index + 1
+    assert four_users.active_user_count == 4
+    four_users.add_user(5)
+    assert four_users.active_user_count == 4
+    four_users.remove_user(5)
+    assert four_users.active_user_count == 4
     assert len(four_users.to_index_list(Mask.ALL)) == 4
     assert len(four_users.to_index_list(Mask.NONE)) == 0
     user_indices = four_users.to_index_list(
@@ -39,37 +52,31 @@ def test_hitl_user_mask():
     assert 2 in user_indices
     assert 3 in user_indices
     assert 4 not in user_indices
+    for user_index in range(4):
+        four_users.remove_user(user_index)
+        assert (
+            four_users.active_user_count
+            == four_users.max_user_count - user_index - 1
+        )
+    assert four_users.active_user_count == 0
 
-    # Test without 6 users.
-    six_users = Users(6)
-    assert six_users.max_user_count == 6
-    assert len(six_users.to_index_list(Mask.ALL)) == 6
-    assert len(six_users.to_index_list(Mask.NONE)) == 0
-    user_indices = six_users.to_index_list(Mask.all_except_indices([0, 2]))
-    assert 0 not in user_indices
-    assert 1 in user_indices
-    assert 2 not in user_indices
-    assert 3 in user_indices
-    assert 4 in user_indices
-    assert 5 in user_indices
-    assert 6 not in user_indices
-
-    # Test without 2 users.
-    two_users = Users(2)
-    assert two_users.max_user_count == 2
-    assert len(two_users.to_index_list(Mask.ALL)) == 2
-    assert len(two_users.to_index_list(Mask.NONE)) == 0
-    user_indices = two_users.to_index_list(Mask.from_indices([1, 2]))
-    assert 0 not in user_indices
-    assert 1 in user_indices
-    assert 2 not in user_indices
-
-    # Test without max users (32).
+    # Test with max users (32).
     max_users = Users(32)
     assert max_users.max_user_count == 32
+    assert max_users.active_user_count == 0
+    for user_index in range(32):
+        max_users.add_user(user_index)
+        assert max_users.active_user_count == user_index + 1
     assert len(max_users.to_index_list(Mask.ALL)) == 32
     assert len(max_users.to_index_list(Mask.NONE)) == 0
     assert (
         len(max_users.to_index_list(Mask.all_except_indices([17, 22]))) == 30
     )
     assert len(max_users.to_index_list(Mask.from_indices([3, 15]))) == 2
+    for user_index in range(32):
+        max_users.remove_user(user_index)
+        assert (
+            max_users.active_user_count
+            == max_users.max_user_count - user_index - 1
+        )
+    assert max_users.active_user_count == 0

--- a/habitat-hitl/test/test_user_mask.py
+++ b/habitat-hitl/test/test_user_mask.py
@@ -10,7 +10,7 @@ from habitat_hitl.core.user_mask import Mask, Users
 
 def test_hitl_user_mask_0_user():
     zero_users = Users(0)
-    zero_users.add_user(1)
+    zero_users.activate_user(1)
     assert zero_users.max_user_count == 0
     assert zero_users.active_user_count == 0
     assert len(zero_users.to_index_list(Mask.ALL)) == 0
@@ -22,7 +22,7 @@ def test_hitl_user_mask_0_user():
     assert 1 not in user_indices
     user_indices = zero_users.to_index_list(Mask.all_except_index(0))
     assert 0 not in user_indices
-    zero_users.remove_user(1)
+    zero_users.deactivate_user(1)
     assert zero_users.active_user_count == 0
 
 
@@ -31,12 +31,12 @@ def test_hitl_user_mask_4_users():
     assert four_users.max_user_count == 4
     assert four_users.active_user_count == 0
     for user_index in range(4):
-        four_users.add_user(user_index)
+        four_users.activate_user(user_index)
         assert four_users.active_user_count == user_index + 1
     assert four_users.active_user_count == 4
-    four_users.add_user(5)
+    four_users.activate_user(5)
     assert four_users.active_user_count == 4
-    four_users.remove_user(5)
+    four_users.deactivate_user(5)
     assert four_users.active_user_count == 4
     assert len(four_users.to_index_list(Mask.ALL)) == 4
     assert len(four_users.to_index_list(Mask.NONE)) == 0
@@ -53,7 +53,7 @@ def test_hitl_user_mask_4_users():
     assert 3 in user_indices
     assert 4 not in user_indices
     for user_index in range(4):
-        four_users.remove_user(user_index)
+        four_users.deactivate_user(user_index)
         assert (
             four_users.active_user_count
             == four_users.max_user_count - user_index - 1
@@ -66,7 +66,7 @@ def test_hitl_user_mask_32_users():
     assert max_users.max_user_count == 32
     assert max_users.active_user_count == 0
     for user_index in range(32):
-        max_users.add_user(user_index)
+        max_users.activate_user(user_index)
         assert max_users.active_user_count == user_index + 1
     assert len(max_users.to_index_list(Mask.ALL)) == 32
     assert len(max_users.to_index_list(Mask.NONE)) == 0
@@ -75,7 +75,7 @@ def test_hitl_user_mask_32_users():
     )
     assert len(max_users.to_index_list(Mask.from_indices([3, 15]))) == 2
     for user_index in range(32):
-        max_users.remove_user(user_index)
+        max_users.deactivate_user(user_index)
         assert (
             max_users.active_user_count
             == max_users.max_user_count - user_index - 1
@@ -89,7 +89,7 @@ def test_hitl_user_mask_activate_users():
     assert four_users.active_user_count == 4
     assert len(four_users.to_index_list(Mask.ALL)) == 4
     assert len(four_users.to_index_list(Mask.NONE)) == 0
-    four_users.remove_user(3)
+    four_users.deactivate_user(3)
     assert four_users.max_user_count == 4
     assert four_users.active_user_count == 3
     assert len(four_users.to_index_list(Mask.ALL)) == 3

--- a/habitat-hitl/test/test_user_mask.py
+++ b/habitat-hitl/test/test_user_mask.py
@@ -8,8 +8,7 @@
 from habitat_hitl.core.user_mask import Mask, Users
 
 
-def test_hitl_user_mask():
-    # Test without any user.
+def test_hitl_user_mask_0_user():
     zero_users = Users(0)
     zero_users.add_user(1)
     assert zero_users.max_user_count == 0
@@ -26,7 +25,8 @@ def test_hitl_user_mask():
     zero_users.remove_user(1)
     assert zero_users.active_user_count == 0
 
-    # Test with 4 users.
+
+def test_hitl_user_mask_4_users():
     four_users = Users(4)
     assert four_users.max_user_count == 4
     assert four_users.active_user_count == 0
@@ -60,7 +60,8 @@ def test_hitl_user_mask():
         )
     assert four_users.active_user_count == 0
 
-    # Test with max users (32).
+
+def test_hitl_user_mask_32_users():
     max_users = Users(32)
     assert max_users.max_user_count == 32
     assert max_users.active_user_count == 0
@@ -80,3 +81,16 @@ def test_hitl_user_mask():
             == max_users.max_user_count - user_index - 1
         )
     assert max_users.active_user_count == 0
+
+
+def test_hitl_user_mask_activate_users():
+    four_users = Users(4, activate_users=True)
+    assert four_users.max_user_count == 4
+    assert four_users.active_user_count == 4
+    assert len(four_users.to_index_list(Mask.ALL)) == 4
+    assert len(four_users.to_index_list(Mask.NONE)) == 0
+    four_users.remove_user(3)
+    assert four_users.max_user_count == 4
+    assert four_users.active_user_count == 3
+    assert len(four_users.to_index_list(Mask.ALL)) == 3
+    assert len(four_users.to_index_list(Mask.NONE)) == 0


### PR DESCRIPTION
## Motivation and Context

This changeset improves on network per-user messages:
* Allow activating or deactivating users from the `Users` container.
* Avoid sending user messages to inactive users.
* Clear user messages consolidated for the previous user when a new user joins.
* Avoid consolidating messages for inactive users.

## How Has This Been Tested

Unit test + HITL server.

## Types of changes

- **\[Bug Fix\]**
- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
