### PR TITLE
HITL - Fix choppy continuous remote input.

### DIFF
--- a/habitat-hitl/habitat_hitl/_internal/gui_application.py
+++ b/habitat-hitl/habitat_hitl/_internal/gui_application.py
@@ -179,7 +179,12 @@ class GuiApplication(InputHandlerApplication):
 
         for _ in range(num_sim_updates):
             post_sim_update_dict = self._driver.sim_update(sim_dt)
-            self._gui_input.on_frame_end()
+
+            gui_input = self._gui_input
+            gui_input.on_frame_end()
+            gui_input._relative_mouse_position = [0, 0]
+            gui_input._mouse_scroll_offset = 0.0
+
             self._post_sim_update(post_sim_update_dict)
             if "application_exit" in post_sim_update_dict:
                 return

--- a/habitat-hitl/habitat_hitl/_internal/gui_application.py
+++ b/habitat-hitl/habitat_hitl/_internal/gui_application.py
@@ -179,12 +179,7 @@ class GuiApplication(InputHandlerApplication):
 
         for _ in range(num_sim_updates):
             post_sim_update_dict = self._driver.sim_update(sim_dt)
-
-            gui_input = self._gui_input
-            gui_input.on_frame_end()
-            gui_input._relative_mouse_position = [0, 0]
-            gui_input._mouse_scroll_offset = 0.0
-
+            self._gui_input.reset()
             self._post_sim_update(post_sim_update_dict)
             if "application_exit" in post_sim_update_dict:
                 return

--- a/habitat-hitl/habitat_hitl/core/gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/gui_input.py
@@ -99,8 +99,6 @@ class GuiInput:
         self._key_up.clear()
         self._mouse_button_down.clear()
         self._mouse_button_up.clear()
-        self._relative_mouse_position = [0, 0]
-        self._mouse_scroll_offset = 0.0
 
     def copy_from(self, other: GuiInput):
         self._key_down = set(other._key_down)

--- a/habitat-hitl/habitat_hitl/core/gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/gui_input.py
@@ -96,11 +96,10 @@ class GuiInput:
         """
         Reset the input states. To be called at the end of a frame.
 
-        reset_continuous_input: controls whether to reset non-discrete input like scrolling or dragging.
-        For local applications, this must be reset at the end of the frame.
-
-        Remote clients are out of sync with the HITL frame cadence and have their own input cycle.
-        Their continuous inputs must be reset before consolidating a new set of input packets.
+        `reset_continuous_input`: controls whether to reset continuous input like scrolling or dragging.
+        Remote clients send their input at a different frequency than the server framerate.
+        To avoid choppiness, their continuous inputs should be reset before consolidating new remote inputs.
+        This differs from discrete input like clicking, which must be reset every frame to avoid extending click events across multiple frames.
         """
         self._key_down.clear()
         self._key_up.clear()

--- a/habitat-hitl/habitat_hitl/core/gui_input.py
+++ b/habitat-hitl/habitat_hitl/core/gui_input.py
@@ -92,13 +92,24 @@ class GuiInput:
     def mouse_ray(self):
         return self._mouse_ray
 
-    # Key/button up/down is only True on the frame it occurred. Mouse relative position is
-    # relative to its position at the start of frame.
-    def on_frame_end(self):
+    def reset(self, reset_continuous_input: bool = True):
+        """
+        Reset the input states. To be called at the end of a frame.
+
+        reset_continuous_input: controls whether to reset non-discrete input like scrolling or dragging.
+        For local applications, this must be reset at the end of the frame.
+
+        Remote clients are out of sync with the HITL frame cadence and have their own input cycle.
+        Their continuous inputs must be reset before consolidating a new set of input packets.
+        """
         self._key_down.clear()
         self._key_up.clear()
         self._mouse_button_down.clear()
         self._mouse_button_up.clear()
+
+        if reset_continuous_input:
+            self._relative_mouse_position = [0, 0]
+            self._mouse_scroll_offset = 0.0
 
     def copy_from(self, other: GuiInput):
         self._key_down = set(other._key_down)


### PR DESCRIPTION
## Motivation and Context

This improves continuous inputs (scrolling, dragging) coming from remote clients.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f21c8c4c-9258-45f5-8168-e872326f6a19"> | <video src="https://github.com/user-attachments/assets/6acef5d6-3689-4dc1-bb7a-0c8ef31b7569"> |

## Context

Unlike most remote real-time applications, the HITL application is entirely written in the server, in Python. The client simply renders what it's given, and relays back the input. This is a design decision from the standpoint where having the code self-contained within Habitat is more important than optimizing input latency.

## Explanation

In local applications, inputs are updated at the simulator frequency. At the end of each step, we reset the input container (`GuiInput`) and controls behave as expected.

In remote applications, user input arrives at a different frequency and is not guaranteed.
1. Discrete input must be reset every frame. Otherwise, discrete events like `mouse_down` are activated across multiple frames.
2. Continuous input must be reset before a new input packet arrives. Otherwise, the continuous actions like mouse dragging abruptly stop on frames where input is not received.

**Previous State:**

| Frame | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
| - | - | - | - | - | - | - | - | - |
| Incoming |  |  | Scroll(2) |  | No Input |  | Scroll(3) |  |
| Scroll Value | 0 | 0 | 2 | 0 | 0 | 0 | 3 | 0 |

**Proposed State:**

| Frame | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
| - | - | - | - | - | - | - | - | - |
| Incoming |  |  | Scroll(2) |  | No Input |  | Scroll(3) |  |
| Scroll Value | 0 | 0 | 2 | 2 | 0 | 0 | 3 | 3 |

**Caveat:**
While this change improves controls over previous state, continuous inputs overshoot. This can be mitigated with client-side control or dampening.

## How Has This Been Tested

Tested on local and remote HITL application.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
