### PR TITLE
HITL - Immediately end sessions when all users are disconnected.

### DIFF
--- a/examples/hitl/rearrange_v2/app_state_end_session.py
+++ b/examples/hitl/rearrange_v2/app_state_end_session.py
@@ -46,7 +46,8 @@ class AppStateEndSession(AppStateBase):
             self._status += f"\nError: {session.error}"
 
     def get_next_state(self) -> Optional[AppStateBase]:
-        if self._elapsed_time > SESSION_END_DELAY:
+        connected_user_count = len(self._app_data.connected_users)
+        if self._elapsed_time > SESSION_END_DELAY or connected_user_count == 0:
             self._end_session()
             return create_app_state_reset(self._app_service, self._app_data)
         return None


### PR DESCRIPTION
## Motivation and Context

The "end session" state has a short timer to display a message that the session is finished.
This small change immediately ends a session when there's no user, which speeds up testing and server availability.

## How Has This Been Tested

Tested on HITL server.

## Types of changes

- **\[Bug Fix\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
