### PR TITLE
HITL - Add region annotations.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -408,6 +408,7 @@ class UI:
         return True
 
     def _update_hovered_object_ui(self):
+        """Draw a UI when hovering an object with the cursor."""
         object_id = self._hover_selection.object_id
 
         primary_region_name: Optional[str] = None

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -221,6 +221,7 @@ class UI:
         Draw the UI.
         """
         self._update_held_object_placement()
+        self._update_hovered_object_ui()
         self._draw_place_selection()
         self._draw_hovered_interactable()
         self._draw_hovered_pickable()
@@ -405,6 +406,27 @@ class UI:
         if self._world.is_any_agent_holding_object(receptacle_object_id):
             return False
         return True
+
+    def _update_hovered_object_ui(self):
+        object_id = self._hover_selection.object_id
+
+        primary_region_name: Optional[str] = None
+
+        if object_id is not None:
+            world = self._world
+            sim = self._sim
+            obj = sim_utilities.get_obj_from_id(
+                sim, object_id, world._link_id_to_ao_map
+            )
+            if obj is not None:
+                primary_region = world.get_primary_object_region(obj)
+                if primary_region is not None:
+                    primary_region_name = primary_region.category.name()
+
+        if primary_region_name is not None:
+            # TODO: Draw UI
+            # print(primary_region_name)
+            pass
 
     def _draw_aabb(
         self, aabb: mn.Range3D, transform: mn.Matrix4, color: mn.Color3

--- a/examples/hitl/rearrange_v2/world.py
+++ b/examples/hitl/rearrange_v2/world.py
@@ -141,7 +141,7 @@ class World:
         self,
         obj: Union[ManagedBulletArticulatedObject, ManagedBulletRigidObject],
     ) -> Optional[SemanticRegion]:
-        """Get the name of the region that contains most of an object."""
+        """Get the semantic region that contains most of an object."""
         object_regions = sim_utilities.get_object_regions(
             sim=self._sim, object_a=obj, ao_link_map=self._link_id_to_ao_map
         )


### PR DESCRIPTION
## Motivation and Context

This changeset adds the following:
* API to query the region that contains most of an object.
* Placeholder mouse hover GUI.

https://github.com/user-attachments/assets/8a03b4c3-60fa-4040-af27-06937c16938f

## How Has This Been Tested

Tested on HSSD in HITL applications.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
