### PR TITLE
HITL - Add selection to rearrange_v2 UI.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -755,15 +755,6 @@ class UI:
                     destination_mask=Mask.from_index(self._user_index),
                 )
 
-        # Skip highlight if select object is the same as hovered object.
-        selected_obj_id = self._click_selection.object_id
-        if selected_obj_id is not None:
-            selected_obj = sim_utilities.get_obj_from_id(
-                sim, selected_obj_id, self._world._link_id_to_ao_map
-            )
-            if selected_obj is not None and obj.handle == selected_obj.handle:
-                return
-
     def _draw_selected_object_highlights(self) -> None:
         """Highlight the selected object."""
         object_id = self._click_selection.object_id


### PR DESCRIPTION
## Motivation and Context

This changeset adds a selection system to `rearrange_v2` GUI.

* Add selection feedback.
* Adjust selection behavior.
* Adjust hover behavior and colors.

Builds on top of the following recent changes:
* https://github.com/facebookresearch/habitat-lab/pull/2030
* https://github.com/facebookresearch/habitat-lab/pull/2028

https://github.com/user-attachments/assets/488feba8-3075-47f4-90ee-abfce079774a

## How Has This Been Tested

Tested on remote Unity-based HITL application.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
