### PR TITLE
HITL - Session Data Improvements

### DIFF
--- a/examples/hitl/rearrange_v2/app_state_end_session.py
+++ b/examples/hitl/rearrange_v2/app_state_end_session.py
@@ -13,8 +13,8 @@ from app_state_base import AppStateBase
 from app_states import create_app_state_reset
 from s3_upload import (
     generate_unique_session_id,
-    make_s3_filename,
     upload_file_to_s3,
+    validate_experiment_name,
 )
 from session import Session
 from util import get_top_down_view
@@ -71,27 +71,32 @@ class AppStateEndSession(AppStateBase):
 
         # Finalize session.
         if self._session.error == "":
-            session.success = True
+            session.finished = True
         session.session_recorder.end_session(self._session.error)
 
         # Get data collection parameters.
-        try:
-            config = self._app_service.config
-            data_collection_config = config.rearrange_v2.data_collection
-            s3_path = data_collection_config.s3_path
-            s3_subdir = "complete" if session.success else "incomplete"
-            s3_path = os.path.join(s3_path, s3_subdir)
+        config = self._app_service.config
 
-            # Use the port as a discriminator for when there are multiple concurrent servers.
-            output_folder_suffix = str(config.habitat_hitl.networking.port)
-            output_folder = f"output_{output_folder_suffix}"
+        # Set the base S3 path as the experiment name.
+        s3_path: str = "default"
+        if len(session.connection_records) > 0:
+            experiment_name: Optional[str] = session.connection_records[0].get(
+                "experiment", None
+            )
+            if validate_experiment_name(experiment_name):
+                s3_path = experiment_name
+            else:
+                print(f"Invalid experiment name: '{experiment_name}'")
 
-            output_file_name = data_collection_config.output_file_name
-            output_file = f"{output_file_name}.json.gz"
+        # Generate unique session ID
+        session_id = generate_unique_session_id(
+            session.episode_indices, session.connection_records
+        )
+        s3_path = os.path.join(s3_path, session_id)
 
-        except Exception as e:
-            print(f"Invalid data collection config. Skipping S3 upload. {e}")
-            return
+        # Use the port as a discriminator for when there are multiple concurrent servers.
+        output_folder_suffix = str(config.habitat_hitl.networking.port)
+        output_folder = f"output_{output_folder_suffix}"
 
         # Delete previous output directory
         if os.path.exists(output_folder):
@@ -99,13 +104,24 @@ class AppStateEndSession(AppStateBase):
 
         # Create new output directory
         os.makedirs(output_folder)
-        json_path = os.path.join(output_folder, output_file)
-        save_as_json_gzip(session.session_recorder, json_path)
 
-        # Generate unique session ID
-        session_id = generate_unique_session_id(
-            session.episode_indices, session.connection_records
+        # Create a session metadata file.
+        session_json_path = os.path.join(output_folder, "session.json.gz")
+        save_as_json_gzip(
+            session.session_recorder.get_session_output(), session_json_path
         )
+
+        # Create one file per episode.
+        episode_outputs = session.session_recorder.get_episode_outputs()
+        for episode_output in episode_outputs:
+            episode_json_path = os.path.join(
+                output_folder,
+                f"{episode_output.episode.episode_index}.json.gz",
+            )
+            save_as_json_gzip(
+                episode_output,
+                episode_json_path,
+            )
 
         # Upload output directory
         orig_file_names = [
@@ -115,5 +131,8 @@ class AppStateEndSession(AppStateBase):
         ]
         for orig_file_name in orig_file_names:
             local_file_path = os.path.join(output_folder, orig_file_name)
-            s3_file_name = make_s3_filename(session_id, orig_file_name)
+            s3_file_name = orig_file_name
+            print(
+                f"Uploading '{local_file_path}' to '{s3_path}' as '{s3_file_name}'."
+            )
             upload_file_to_s3(local_file_path, s3_file_name, s3_path)

--- a/examples/hitl/rearrange_v2/app_state_load_episode.py
+++ b/examples/hitl/rearrange_v2/app_state_load_episode.py
@@ -90,9 +90,9 @@ class AppStateLoadEpisode(AppStateBase):
     def _increment_episode(self):
         session = self._session
         assert session.episode_indices is not None
-        if session.current_episode_index < len(session.episode_indices):
-            self._set_episode(session.current_episode_index)
-            session.current_episode_index += 1
+        if session.next_session_episode < len(session.episode_indices):
+            self._set_episode(session.next_session_episode)
+            session.next_session_episode += 1
         else:
             self._session_ended = True
 
@@ -102,6 +102,7 @@ class AppStateLoadEpisode(AppStateBase):
 
         # Set the ID of the next episode to play in lab.
         next_episode_index = session.episode_indices[episode_index]
+        session.current_episode_index = next_episode_index
         print(f"Next episode index: {next_episode_index}.")
         try:
             app_service.episode_helper.set_next_episode_by_index(

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -547,11 +547,14 @@ class AppStateRearrangeV2(AppStateBase):
             ].gui_agent_controller._agent_idx
 
         episode = self._app_service.episode_helper.current_episode
+
         self._session.session_recorder.start_episode(
-            episode.episode_id,
-            episode.scene_id,
-            episode.scene_dataset_config,
-            user_index_to_agent_index_map,
+            episode_index=self._session.current_episode_index,
+            episode_id=episode.episode_id,
+            scene_id=episode.scene_id,
+            dataset=episode.scene_dataset_config,
+            user_index_to_agent_index_map=user_index_to_agent_index_map,
+            episode_info=episode.info,
         )
 
     def on_exit(self):
@@ -759,6 +762,8 @@ class AppStateRearrangeV2(AppStateBase):
                 self._metrics.get_task_percent_complete(),
             )
             self._session.session_recorder.record_frame(frame_data)
+        else:
+            self._session.session_recorder.record_frame({})
 
     def _is_any_agent_policy_driven(self) -> bool:
         """

--- a/examples/hitl/rearrange_v2/s3_upload.py
+++ b/examples/hitl/rearrange_v2/s3_upload.py
@@ -6,7 +6,7 @@
 
 
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from util import timestamp
 
@@ -109,3 +109,17 @@ def make_s3_filename(session_id: str, orig_file_name: str) -> str:
             s3_filename += "!"
 
     return s3_filename
+
+
+def validate_experiment_name(experiment_name: Optional[str]) -> bool:
+    if experiment_name is None:
+        return False
+
+    if len(experiment_name) > 128:
+        return False
+
+    authorized_chars = ["_", "-", "."]
+    return all(
+        not (not c.isalnum() and c not in authorized_chars)
+        for c in experiment_name
+    )

--- a/examples/hitl/rearrange_v2/s3_upload.py
+++ b/examples/hitl/rearrange_v2/s3_upload.py
@@ -112,6 +112,9 @@ def make_s3_filename(session_id: str, orig_file_name: str) -> str:
 
 
 def validate_experiment_name(experiment_name: Optional[str]) -> bool:
+    """
+    Check whether the given experiment name is valid.
+    """
     if experiment_name is None:
         return False
 

--- a/examples/hitl/rearrange_v2/session.py
+++ b/examples/hitl/rearrange_v2/session.py
@@ -23,9 +23,10 @@ class Session:
         episode_indices: List[int],
         connection_records: Dict[int, ConnectionRecord],
     ):
-        self.success = False
+        self.finished = False
         self.episode_indices = episode_indices
         self.current_episode_index = 0
+        self.next_session_episode = 0
         self.connection_records = connection_records
 
         self.session_recorder = SessionRecorder(

--- a/examples/hitl/rearrange_v2/session.py
+++ b/examples/hitl/rearrange_v2/session.py
@@ -13,7 +13,7 @@ from habitat_hitl.core.types import ConnectionRecord
 
 class Session:
     """
-    Data for a single RearrangeV2 session.
+    Data for a single HITL session.
     A session is defined as a sequence of episodes done by a fixed set of users.
     """
 
@@ -24,13 +24,32 @@ class Session:
         connection_records: Dict[int, ConnectionRecord],
     ):
         self.finished = False
+        """Whether the session is finished."""
+
         self.episode_indices = episode_indices
+        """List of episode indices within the session."""
+
         self.current_episode_index = 0
+        """
+        Current episode index within the episode set.
+
+        If there are `1000` episodes, `current_episode_index` would be a value between `0` and `999` inclusively.
+        """
+
         self.next_session_episode = 0
+        """
+        Next index of the `episode_indices` list (element index, not episode index).
+
+        If `episode_indices` contains the values `10`, `20` and `30`, `next_session_episode` would be either `0`, `1`, `2` or `3`.
+        """
+
         self.connection_records = connection_records
+        """Connection records of each user."""
 
         self.session_recorder = SessionRecorder(
             config, connection_records, episode_indices
         )
+        """Utility for recording the session."""
 
-        self.error = ""  # Use this to display error that causes termination
+        self.error = ""
+        """Field that contains the display error that caused session termination."""

--- a/examples/hitl/rearrange_v2/session_recorder.py
+++ b/examples/hitl/rearrange_v2/session_recorder.py
@@ -4,11 +4,62 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from util import timestamp
 
 from habitat_hitl.core.types import ConnectionRecord
+
+
+@dataclass
+class SessionRecord:
+    episode_indices: List[int]
+    session_error: str
+    start_timestamp: int
+    end_timestamp: int
+    config: Dict[str, Any]
+    frame_count: int
+    connection_records: Dict[int, ConnectionRecord]
+
+
+@dataclass
+class UserRecord:
+    user_index: int
+    connection_record: ConnectionRecord
+
+
+@dataclass
+class EpisodeRecord:
+    episode_index: int
+    episode_id: str
+    scene_id: str
+    dataset: str
+    user_index_to_agent_index_map: Dict[int, int]
+    episode_info: Dict[str, Any]
+    start_timestamp: int
+    end_timestamp: int
+    finished: bool
+    task_percent_complete: float
+    task_explanation: Optional[str]
+    frame_count: int
+
+
+@dataclass
+class SessionOutput:
+    session: SessionRecord
+    users: List[UserRecord]
+    episodes: List[EpisodeRecord]
+
+
+@dataclass
+class EpisodeOutput:
+    session: SessionRecord
+    users: List[UserRecord]
+    episode: EpisodeRecord
+    frames: List[Dict[str, Any]]
 
 
 class SessionRecorder:
@@ -18,52 +69,57 @@ class SessionRecorder:
         connection_records: Dict[int, ConnectionRecord],
         episode_indices: List[int],
     ):
-        self.data = {
-            "episode_indices": episode_indices,
-            "completed": False,
-            "error": "",
-            "start_timestamp": timestamp(),
-            "end_timestamp": timestamp(),
-            "config": config,
-            "frame_count": 0,
-            "users": [],
-            "episodes": [],
-        }
-
-        for user_index in range(len(connection_records)):
-            self.data["users"].append(
-                {
-                    "user_index": user_index,
-                    "connection_record": connection_records[user_index],
-                }
+        time = timestamp()
+        self.session_record = SessionRecord(
+            episode_indices=episode_indices,
+            session_error="",
+            start_timestamp=time,
+            end_timestamp=time,
+            config=config,
+            frame_count=0,
+            connection_records=connection_records,
+        )
+        self.episode_records: List[EpisodeRecord] = []
+        self.frames: List[List[Dict[str, Any]]] = []
+        self.user_records: List[UserRecord] = []
+        for user_index, connection_record in connection_records.items():
+            self.user_records.append(
+                UserRecord(
+                    user_index=user_index, connection_record=connection_record
+                )
             )
 
     def end_session(self, error: str):
-        self.data["end_timestamp"] = timestamp()
-        self.data["completed"] = True
-        self.data["error"] = error
+        self.session_record.end_timestamp = timestamp()
+        self.session_record.session_error = error
 
     def start_episode(
         self,
+        episode_index: int,
         episode_id: str,
         scene_id: str,
         dataset: str,
         user_index_to_agent_index_map: Dict[int, int],
+        episode_info: Dict[str, Any],
     ):
-        self.data["episodes"].append(
-            {
-                "episode_id": episode_id,
-                "scene_id": scene_id,
-                "start_timestamp": timestamp(),
-                "end_timestamp": timestamp(),
-                "completed": False,
-                "success": False,
-                "frame_count": 0,
-                "dataset": dataset,
-                "user_index_to_agent_index_map": user_index_to_agent_index_map,
-                "frames": [],
-            }
+        time = timestamp()
+        self.episode_records.append(
+            EpisodeRecord(
+                episode_index=episode_index,
+                episode_id=episode_id,
+                scene_id=scene_id,
+                dataset=dataset,
+                user_index_to_agent_index_map=user_index_to_agent_index_map,
+                episode_info=episode_info,
+                start_timestamp=time,
+                end_timestamp=time,
+                finished=False,
+                task_percent_complete=0.0,
+                frame_count=0,
+                task_explanation=None,
+            )
         )
+        self.frames.append([])
 
     def end_episode(
         self,
@@ -71,20 +127,48 @@ class SessionRecorder:
         task_percent_complete: float,
         task_explanation: Optional[str],
     ):
-        self.data["episodes"][-1]["end_timestamp"] = timestamp()
-        self.data["episodes"][-1]["finished"] = episode_finished
-        self.data["episodes"][-1][
-            "task_percent_complete"
-        ] = task_percent_complete
-        self.data["episodes"][-1]["task_explanation"] = task_explanation
+        assert len(self.episode_records) > 0
+        episode = self.episode_records[-1]
+
+        time = timestamp()
+        self.session_record.end_timestamp = time
+        episode.end_timestamp = time
+        episode.finished = episode_finished
+        episode.task_percent_complete = task_percent_complete
+        episode.task_explanation = task_explanation
 
     def record_frame(
         self,
         frame_data: Dict[str, Any],
     ):
-        self.data["end_timestamp"] = timestamp()
-        self.data["frame_count"] += 1
+        assert len(self.episode_records) > 0
+        episode_index = len(self.episode_records) - 1
+        episode = self.episode_records[episode_index]
 
-        self.data["episodes"][-1]["end_timestamp"] = timestamp()
-        self.data["episodes"][-1]["frame_count"] += 1
-        self.data["episodes"][-1]["frames"].append(frame_data)
+        time = timestamp()
+        self.session_record.end_timestamp = time
+        self.session_record.frame_count += 1
+        episode.end_timestamp = time
+        episode.frame_count += 1
+
+        self.frames[episode_index].append(frame_data)
+
+    def get_session_output(self) -> SessionOutput:
+        return SessionOutput(
+            self.session_record,
+            self.user_records,
+            self.episode_records,
+        )
+
+    def get_episode_outputs(self) -> List[EpisodeOutput]:
+        output: List[EpisodeOutput] = []
+        for i in range(len(self.episode_records)):
+            output.append(
+                EpisodeOutput(
+                    self.session_record,
+                    self.user_records,
+                    self.episode_records[i],
+                    self.frames[i],
+                )
+            )
+        return output

--- a/examples/hitl/rearrange_v2/session_recorder.py
+++ b/examples/hitl/rearrange_v2/session_recorder.py
@@ -16,6 +16,11 @@ from habitat_hitl.core.types import ConnectionRecord
 
 @dataclass
 class SessionRecord:
+    """
+    Data entry for a session.
+    The session spans from the time the first user is connected to the time the last episode is completed.
+    """
+
     episode_indices: List[int]
     session_error: str
     start_timestamp: int
@@ -27,12 +32,20 @@ class SessionRecord:
 
 @dataclass
 class UserRecord:
+    """
+    Data entry for a user.
+    """
+
     user_index: int
     connection_record: ConnectionRecord
 
 
 @dataclass
 class EpisodeRecord:
+    """
+    Data entry for an episode.
+    """
+
     episode_index: int
     episode_id: str
     scene_id: str
@@ -49,6 +62,10 @@ class EpisodeRecord:
 
 @dataclass
 class SessionOutput:
+    """
+    Content of the `session.json.gz` file.
+    """
+
     session: SessionRecord
     users: List[UserRecord]
     episodes: List[EpisodeRecord]
@@ -56,6 +73,10 @@ class SessionOutput:
 
 @dataclass
 class EpisodeOutput:
+    """
+    Content of the `{episode_id}.json.gz` file.
+    """
+
     session: SessionRecord
     users: List[UserRecord]
     episode: EpisodeRecord
@@ -63,6 +84,10 @@ class EpisodeOutput:
 
 
 class SessionRecorder:
+    """
+    Utility class for recording HITL data.
+    """
+
     def __init__(
         self,
         config: Dict[str, Any],
@@ -90,6 +115,10 @@ class SessionRecorder:
             )
 
     def end_session(self, error: str):
+        """
+        Signal that the session has ended.
+        Call 'get_session_output' and 'get_episode_outputs' to get the collected resulting data.
+        """
         self.session_record.end_timestamp = timestamp()
         self.session_record.session_error = error
 
@@ -102,6 +131,9 @@ class SessionRecorder:
         user_index_to_agent_index_map: Dict[int, int],
         episode_info: Dict[str, Any],
     ):
+        """
+        Signal that an episode has started.
+        """
         time = timestamp()
         self.episode_records.append(
             EpisodeRecord(
@@ -127,6 +159,9 @@ class SessionRecorder:
         task_percent_complete: float,
         task_explanation: Optional[str],
     ):
+        """
+        Signal that an episode has ended.
+        """
         assert len(self.episode_records) > 0
         episode = self.episode_records[-1]
 
@@ -141,6 +176,9 @@ class SessionRecorder:
         self,
         frame_data: Dict[str, Any],
     ):
+        """
+        Signal that a frame has occurred.
+        """
         assert len(self.episode_records) > 0
         episode_index = len(self.episode_records) - 1
         episode = self.episode_records[episode_index]
@@ -154,6 +192,9 @@ class SessionRecorder:
         self.frames[episode_index].append(frame_data)
 
     def get_session_output(self) -> SessionOutput:
+        """
+        Get the metadata of the session.
+        """
         return SessionOutput(
             self.session_record,
             self.user_records,
@@ -161,6 +202,9 @@ class SessionRecorder:
         )
 
     def get_episode_outputs(self) -> List[EpisodeOutput]:
+        """
+        Get the recorded HITL data.
+        """
         output: List[EpisodeOutput] = []
         for i in range(len(self.episode_records)):
             output.append(

--- a/habitat-hitl/test/rearrange_v2/test_s3_upload.py
+++ b/habitat-hitl/test/rearrange_v2/test_s3_upload.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 from examples.hitl.rearrange_v2.s3_upload import (
     generate_unique_session_id,
     make_s3_filename,
+    validate_experiment_name,
 )
 from examples.hitl.rearrange_v2.util import timestamp
 from habitat_hitl.core.types import ConnectionRecord
@@ -68,3 +69,22 @@ def test_make_s3_filename():
     s3_filename = make_s3_filename("ab", long_name)
     assert len(s3_filename) == 128
     assert s3_filename[-4:] == ".txt"
+
+
+def test_validate_experiment_name():
+    assert validate_experiment_name(None) == False
+    assert validate_experiment_name("test") == True
+    assert validate_experiment_name("test_test-test.123") == True
+    assert validate_experiment_name("test?") == False
+    assert (
+        validate_experiment_name(
+            "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"
+        )
+        == True
+    )
+    assert (
+        validate_experiment_name(
+            "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"
+        )
+        == False
+    )


### PR DESCRIPTION
## Motivation and Context

This changeset changes the data format of the HITL output to improve its functionality.
In this context, a "session" is a sequence of N episodes to be completed.

Instead of recording a single file for a session, the system now records a single file per episode, and a session metadata file. The following content is uploaded to S3:

```
output_{port}/
    {episode_id}.json.gz
    {episode_id}.json.gz
    session.json.gz
```

![session_output](https://github.com/user-attachments/assets/752307fa-4733-49e3-9235-f9eb566a284b)

Changes:
* Episodes are now recorded in individual files.
    * If the session fails (e.g. a user disconnects after completing some episodes), the completed episodes are uploaded.
* A lightweight `session.json.jz` file is created for each session, even if there is no episode.
    * The session contains vital data such as errors and total time spent.
* Data collection output is now structured.
* Empty frames are now recorded.
* Miscellaneous small improvements.

## How Has This Been Tested

Tested on single-user and multi-user sessions.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
