### PR TITLE
HITL - Rename HITL output directory and ignore it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ data
 /train_dir
 /tb
 
+# HITL outputs
+/hitl_output*
+
 # outputs from other libraries
 /sandbox
 /plots/outputs

--- a/examples/hitl/rearrange_v2/app_state_end_session.py
+++ b/examples/hitl/rearrange_v2/app_state_end_session.py
@@ -96,7 +96,7 @@ class AppStateEndSession(AppStateBase):
 
         # Use the port as a discriminator for when there are multiple concurrent servers.
         output_folder_suffix = str(config.habitat_hitl.networking.port)
-        output_folder = f"output_{output_folder_suffix}"
+        output_folder = f"hitl_output_{output_folder_suffix}"
 
         # Delete previous output directory
         if os.path.exists(output_folder):


### PR DESCRIPTION
## Motivation and Context

This changes the HITL output folder name and adds it to `.gitignore`.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Refactoring\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
