### PR TITLE
Fix KRM initialization when loading consecutive episodes in the same scene.

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -352,7 +352,9 @@ class RearrangeSim(HabitatSim):
 
         # add episode clutter objects additional to base scene objects
         if self._load_objs:
-            self._add_objs(ep_info, should_add_objects, new_scene=is_hard_reset)
+            self._add_objs(
+                ep_info, should_add_objects, new_scene=is_hard_reset
+            )
         self._setup_targets(ep_info)
 
         self._add_markers(ep_info)

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -318,8 +318,6 @@ class RearrangeSim(HabitatSim):
         is_hard_reset = new_scene or should_add_objects
 
         if is_hard_reset:
-            # delete old KRM when scene is hard reset
-            self.kinematic_relationship_manager = None
             with read_write(config):
                 config["scene"] = ep_info.scene_id
             t_start = time.time()
@@ -353,7 +351,7 @@ class RearrangeSim(HabitatSim):
         # add episode clutter objects additional to base scene objects
         if self._load_objs:
             self._add_objs(
-                ep_info, should_add_objects, new_scene=is_hard_reset
+                ep_info, should_add_objects, hard_reset=is_hard_reset
             )
         self._setup_targets(ep_info)
 
@@ -607,7 +605,7 @@ class RearrangeSim(HabitatSim):
         self,
         ep_info: RearrangeEpisode,
         should_add_objects: bool,
-        new_scene: bool,
+        hard_reset: bool,
     ) -> None:
         # Load clutter objects:
         rom = self.get_rigid_object_manager()
@@ -681,7 +679,7 @@ class RearrangeSim(HabitatSim):
 
             obj_counts[obj_handle] += 1
 
-        if new_scene:
+        if hard_reset:
             self._receptacles = self._create_recep_info(
                 ep_info.scene_id, list(self._handle_to_object_id.keys())
             )

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -327,11 +327,6 @@ class RearrangeSim(HabitatSim):
             self.add_perf_timing("super_reconfigure", t_start)
             # The articulated object handles have changed.
             self._start_art_states = {}
-            if self._kinematic_mode:
-                # NOTE: scene must be loaded so articulated objects are available before KRM initialization
-                self.kinematic_relationship_manager = (
-                    KinematicRelationshipManager(self)
-                )
 
         if new_scene:
             self.agents_mgr.on_new_scene()
@@ -357,7 +352,7 @@ class RearrangeSim(HabitatSim):
 
         # add episode clutter objects additional to base scene objects
         if self._load_objs:
-            self._add_objs(ep_info, should_add_objects, new_scene)
+            self._add_objs(ep_info, should_add_objects, new_scene=is_hard_reset)
         self._setup_targets(ep_info)
 
         self._add_markers(ep_info)


### PR DESCRIPTION
## Motivation and Context

This fixes a crash when interacting with the KRM (e.g. `update_snapshots`) in a new episode that shares the same scene as the previous one.

The crash occurs when `new_scene == False`, but `hard_reset == True`. In this case, the KRM is re-created but never initialized. This happens when `should_add_objects == True` and `new_scene == False`.

In pseudocode:
```
is_hard_reset = new_scene or should_add_objects

if is_hard_reset:
    delete krm

if new_scene:
    delete krm
    initialize krm
```

## How Has This Been Tested

Tested locally on HITL application.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
