### PR TITLE
HITL - Add hover information panel.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -624,12 +624,9 @@ class UI:
                 if primary_region is not None:
                     primary_region_name = primary_region.category.name()
 
-        if primary_region_name is not None and object_category is not None:
-            # TODO: Draw UI
-            # print(f"Region: {primary_region_name}")
-            # print(f"Category: {object_category}")
-            # print(f"States: {object_states}")
-            pass
+        self._ui_overlay.update_hovered_object_info_panel(
+            object_category, object_states, primary_region_name
+        )
 
     def _update_selected_object_ui(self):
         """Draw a UI for the currently selected object."""

--- a/examples/hitl/rearrange_v2/ui_overlay.py
+++ b/examples/hitl/rearrange_v2/ui_overlay.py
@@ -141,3 +141,62 @@ class UIOverlay:
                         text_right=control[1],
                         font_size=FONT_SIZE_SMALL,
                     )
+
+    def update_hovered_object_info_panel(
+        self,
+        object_category_name: Optional[str],
+        object_states: List[Tuple[str, str]],
+        primary_region_name: Optional[str],
+    ):
+        """
+        Update the panel that shows information about the hovered object.
+        """
+        manager = self._ui_manager
+        with manager.update_canvas("bottom", self._dest_mask) as ctx:
+            if object_category_name is None:
+                return
+
+            ctx.canvas_properties(
+                padding=12, background_color=PANEL_BACKGROUND_COLOR
+            )
+
+            title = self._title_str(object_category_name)
+
+            ctx.label(
+                text=title,
+                font_size=FONT_SIZE_LARGE,
+                horizontal_alignment=HorizontalAlignment.CENTER,
+            )
+
+            ctx.spacer(size=SPACE_SIZE)
+
+            region_name = (
+                self._title_str(primary_region_name)
+                if primary_region_name is not None
+                else "None"
+            )
+            ctx.list_item(
+                text_left="Room",
+                text_right=region_name,
+                font_size=FONT_SIZE_SMALL,
+            )
+
+            def create_list_item(left: str, right: str):
+                ctx.list_item(
+                    text_left=left,
+                    text_right=right,
+                    font_size=FONT_SIZE_SMALL,
+                )
+
+            for state in object_states:
+                create_list_item(state[0], state[1])
+
+    @staticmethod
+    def _title_str(string: str):
+        """Convert 'snake_case' to 'Title Case'."""
+        return (
+            string.replace("_", " ")
+            .replace("-", " ")
+            .replace(".", " ")
+            .title()
+        )


### PR DESCRIPTION
## Motivation and Context

This changeset adds an information panel that shows information about the hovered object.
Builds on top of the following recent changes:
* https://github.com/facebookresearch/habitat-lab/pull/2031
* https://github.com/facebookresearch/habitat-lab/pull/2035
* https://github.com/facebookresearch/habitat-lab/pull/2041

https://github.com/user-attachments/assets/fbf2ac02-992f-4429-a3ad-f2c44f6ac719

## How Has This Been Tested

Tested on multiplayer HITL server with Unity client.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
