### PR TITLE
HITL - Add selection panel and object state manipulation UI.

### DIFF
--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -213,6 +213,12 @@ class UserData:
             self.gui_input,
         )
 
+        # HACK: Available actions are hardcoded by agent type.
+        #       Only humans can change object states.
+        can_change_object_states = isinstance(
+            self.gui_agent_controller, GuiHumanoidController
+        )
+
         self.ui = UI(
             hitl_config=app_service.hitl_config,
             user_index=user_index,
@@ -223,6 +229,7 @@ class UserData:
             gui_input=self.gui_input,
             gui_drawer=app_service.gui_drawer,
             camera_helper=self.camera_helper,
+            can_change_object_states=can_change_object_states,
         )
 
         self.end_episode_form = EndEpisodeForm(user_index, app_service)
@@ -232,6 +239,7 @@ class UserData:
         self.ui.on_place.registerCallback(self._on_place)
         self.ui.on_open.registerCallback(self._on_open)
         self.ui.on_close.registerCallback(self._on_close)
+        self.ui.on_state_change.registerCallback(self._on_state_change)
 
         self.end_episode_form.on_cancel.registerCallback(
             self._on_episode_form_cancelled
@@ -388,6 +396,16 @@ class UserData:
                 "type": "close",
                 "obj_handle": e.object_handle,
                 "obj_id": e.object_id,
+            }
+        )
+
+    def _on_state_change(self, e: UI.StateChangeEventData):
+        self.ui_events.append(
+            {
+                "type": "state_change",
+                "obj_handle": e.object_handle,
+                "state_name": e.state_name,
+                "new_value": e.new_value,
             }
         )
 

--- a/examples/hitl/rearrange_v2/ui_overlay.py
+++ b/examples/hitl/rearrange_v2/ui_overlay.py
@@ -22,11 +22,17 @@ FONT_SIZE_LARGE: Final[int] = 32
 FONT_SIZE_SMALL: Final[int] = 24
 FONT_COLOR_WARNING: Final[List[float]] = [1.0, 0.75, 0.5, 1.0]
 PANEL_BACKGROUND_COLOR: Final[List[float]] = [0.7, 0.7, 0.7, 0.3]
+TOGGLE_COLOR_AVAILABLE: Final[List[float]] = [0.1, 0.8, 0.8, 1.0]
+TOGGLE_COLOR_RECENTLY_CHANGED: Final[List[float]] = [0.1, 0.8, 0.1, 1.0]
 SPACE_SIZE = 6
 
 
 @dataclass
 class ObjectStateControl:
+    """
+    Collection of information that allows for displaying and manipulating object states.
+    """
+
     spec: ObjectStateSpec
     value: bool
     enabled: bool
@@ -228,9 +234,6 @@ class UIOverlay:
             if object_category_name is None:
                 return
 
-            color_available = [0.1, 0.8, 0.8, 1.0]
-            color_changed = [0.1, 0.8, 0.1, 1.0]
-
             ctx.canvas_properties(
                 padding=12, background_color=PANEL_BACKGROUND_COLOR
             )
@@ -265,15 +268,13 @@ class UIOverlay:
             )
 
             def create_toggle(osc: ObjectStateControl) -> str:
-                # ctx.spacer(size=SPACE_SIZE)
-
                 spec = cast(BooleanObjectState, osc.spec)
                 item_key = f"select_{spec.name}"
                 color = None
                 if osc.recently_changed:
-                    color = color_changed
+                    color = TOGGLE_COLOR_RECENTLY_CHANGED
                 elif osc.available:
-                    color = color_available
+                    color = TOGGLE_COLOR_AVAILABLE
                 ctx.toggle(
                     uid=item_key,
                     text_false=spec.display_name_false,

--- a/examples/hitl/rearrange_v2/ui_overlay.py
+++ b/examples/hitl/rearrange_v2/ui_overlay.py
@@ -7,8 +7,13 @@
 from __future__ import annotations
 
 import textwrap
-from typing import Callable, Dict, Final, List, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Final, List, Optional, Tuple, cast
 
+from habitat.sims.habitat_simulator.object_state_machine import (
+    BooleanObjectState,
+    ObjectStateSpec,
+)
 from habitat_hitl.app_states.app_service import AppService
 from habitat_hitl.core.ui_elements import HorizontalAlignment
 from habitat_hitl.core.user_mask import Mask
@@ -18,6 +23,21 @@ FONT_SIZE_SMALL: Final[int] = 24
 FONT_COLOR_WARNING: Final[List[float]] = [1.0, 0.75, 0.5, 1.0]
 PANEL_BACKGROUND_COLOR: Final[List[float]] = [0.7, 0.7, 0.7, 0.3]
 SPACE_SIZE = 6
+
+
+@dataclass
+class ObjectStateControl:
+    spec: ObjectStateSpec
+    value: bool
+    enabled: bool
+    available: bool
+    callback: Optional[
+        Callable[
+            [str, str, Any], None  # object_handle  # state_name  # state_value
+        ]
+    ]
+    tooltip: Optional[str]
+    recently_changed: bool
 
 
 class UIOverlay:
@@ -190,6 +210,85 @@ class UIOverlay:
 
             for state in object_states:
                 create_list_item(state[0], state[1])
+
+    def update_selected_object_panel(
+        self,
+        object_category_name: Optional[str],
+        object_state_controls: List[ObjectStateControl],
+        primary_region_name: Optional[str],
+        contextual_info: Optional[str],
+        contextual_color: Optional[List[float]],
+    ):
+        """
+        Draw a panel that shows information about the selected object.
+        Allow for editing object states.
+        """
+        manager = self._ui_manager
+        with manager.update_canvas("bottom_left", self._dest_mask) as ctx:
+            if object_category_name is None:
+                return
+
+            color_available = [0.1, 0.8, 0.8, 1.0]
+            color_changed = [0.1, 0.8, 0.1, 1.0]
+
+            ctx.canvas_properties(
+                padding=12, background_color=PANEL_BACKGROUND_COLOR
+            )
+
+            title = self._title_str(object_category_name)
+
+            ctx.label(
+                text=title,
+                font_size=FONT_SIZE_LARGE,
+                horizontal_alignment=HorizontalAlignment.CENTER,
+            )
+
+            if contextual_info is not None:
+                ctx.label(
+                    text=contextual_info,
+                    font_size=FONT_SIZE_SMALL,
+                    horizontal_alignment=HorizontalAlignment.CENTER,
+                    color=contextual_color,
+                )
+
+            ctx.spacer(size=SPACE_SIZE)
+
+            region_name = (
+                self._title_str(primary_region_name)
+                if primary_region_name is not None
+                else "None"
+            )
+            ctx.list_item(
+                text_left="Room",
+                text_right=region_name,
+                font_size=FONT_SIZE_SMALL,
+            )
+
+            def create_toggle(osc: ObjectStateControl) -> str:
+                # ctx.spacer(size=SPACE_SIZE)
+
+                spec = cast(BooleanObjectState, osc.spec)
+                item_key = f"select_{spec.name}"
+                color = None
+                if osc.recently_changed:
+                    color = color_changed
+                elif osc.available:
+                    color = color_available
+                ctx.toggle(
+                    uid=item_key,
+                    text_false=spec.display_name_false,
+                    text_true=spec.display_name_true,
+                    toggled=osc.value,
+                    enabled=osc.enabled and osc.available,
+                    tooltip=osc.tooltip,
+                    color=color,
+                )
+                return item_key
+
+            for osc in object_state_controls:
+                button_key = create_toggle(osc)
+                if osc.callback is not None:
+                    self._buttons[button_key] = osc.callback
 
     @staticmethod
     def _title_str(string: str):


### PR DESCRIPTION
## Motivation and Context

This changeset adds a selection panel and object state manipulation controls.
The object state change event is recorded to HITL output.

The selection panel shows:
* Object name.
* Region name.
* Contextual information.
    * Contextual controls.
    * Why an action (pick/place/open/close) cannot be done.
* Object state toggles.

Builds on top of the following recent changes:
* https://github.com/facebookresearch/habitat-lab/pull/2031
* https://github.com/facebookresearch/habitat-lab/pull/2035
* https://github.com/facebookresearch/habitat-lab/pull/2041
* https://github.com/facebookresearch/habitat-lab/pull/2042

**Held object contextual information:**

https://github.com/user-attachments/assets/b69c3980-d484-4ac2-8459-40182999d895

**Object state manipulation:**

https://github.com/user-attachments/assets/ea93de0c-d50d-43f4-aa1e-1b4b987be448

## How Has This Been Tested

Tested on multiplayer HITL server with Unity clients.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
