### PR TITLE
Add switch for allowing to control humanoid velocity from config.

### DIFF
--- a/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
+++ b/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
@@ -28,6 +28,7 @@ THRESHOLD_ROTATE_NOT_MOVE: float = 20.0  # The rotation angle above which we sho
 DIST_TO_STOP: float = (
     1e-9  # If the amount to move is this distance, just stop the character
 )
+DEFINE_VELOCITY_FROM_CONFIG: bool = True
 
 from typing import List, Tuple
 
@@ -83,6 +84,7 @@ class HumanoidRearrangeController(HumanoidBaseController):
 
         self.prev_orientation = None
         self.walk_mocap_frame = 0
+        self.meters_per_step = 0.0
 
         self.hand_processed_data = {}
         self._hand_names = ["left_hand", "right_hand"]
@@ -125,8 +127,8 @@ class HumanoidRearrangeController(HumanoidBaseController):
         """
 
         seconds_per_step = 1.0 / ctrl_freq
-        meters_per_step = lin_speed * seconds_per_step
-        frames_per_step = meters_per_step / self.dist_per_step_size
+        self.meters_per_step = lin_speed * seconds_per_step
+        frames_per_step = self.meters_per_step / self.dist_per_step_size
         self.motion_fps = self.walk_motion.fps / frames_per_step
         rotate_amount = ang_speed * seconds_per_step
         rotate_amount = rotate_amount * 180.0 / np.pi
@@ -270,7 +272,14 @@ class HumanoidRearrangeController(HumanoidBaseController):
         # The base_transform here is independent of transforms caused by the current
         # motion pose.
         obj_transform_base = look_at_path_T
-        forward_V_dist = forward_V * dist_diff * distance_multiplier
+
+        # TODO: Switch between animation-driven speed and config-driven speed.
+        if DEFINE_VELOCITY_FROM_CONFIG:
+            forward_V_dist = (
+                forward_V * self.meters_per_step * distance_multiplier
+            )
+        else:
+            forward_V_dist = forward_V * dist_diff * distance_multiplier
         obj_transform_base.translation += forward_V_dist
 
         rot_offset = mn.Matrix4.rotation(
@@ -445,7 +454,14 @@ class HumanoidRearrangeController(HumanoidBaseController):
         # The base_transform here is independent of transforms caused by the current
         # motion pose.
         obj_transform_base = look_at_path_T
-        forward_V_dist = forward_V * dist_diff * distance_multiplier
+
+        # TODO: Switch between animation-driven speed and config-driven speed.
+        if DEFINE_VELOCITY_FROM_CONFIG:
+            forward_V_dist = (
+                forward_V * self.meters_per_step * distance_multiplier
+            )
+        else:
+            forward_V_dist = forward_V * dist_diff * distance_multiplier
         obj_transform_base.translation += forward_V_dist
 
         rot_offset = mn.Matrix4.rotation(


### PR DESCRIPTION
## Motivation and Context

**WIP - Open for discussion.**

In the current state of the code, the humanoid speed _is capped by the estimated speed of the animation_.
This is cosmetic - it prevents the walking animation to have a gliding appearance. I believe that this comes from early VR integrations.

In practice, this means that the `lin_speed` config field has no effect past a certain value.

This brings the following issues:
* The humanoid speed is not driven by config.
* Many experiments must cherry-pick this hack to work as intended.
* In HITL, the humanoid is too slow, which greatly increases episode completion speed.

**Proposed change:**
* By default, the humanoid should follow `lin_speed` perfectly, like the other agent types.
    * **This may impact training.**

**Proposed BE Improvements:**
* To keep the animation in-sync with the humanoid velocity, the animation framerate should change.
* Refactors:
    * This class should get its configuration from a single source of truth.
    * Calculations should be simplified.

## How Has This Been Tested

Tested on HITL application.

## Types of changes

- **\[Development\]**

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
