### PR TITLE
Allow disabling agent sensors auto-update.

### DIFF
--- a/examples/hitl/rearrange_v2/config/language_rearrange.yaml
+++ b/examples/hitl/rearrange_v2/config/language_rearrange.yaml
@@ -62,6 +62,10 @@ habitat:
     agents_order:
       - agent_0
 
+    agents:
+      agent_0:
+        auto_update_sensor_transform: False
+
     kinematic_mode: True
     ac_freq_ratio: 1
     step_physics: False

--- a/examples/hitl/rearrange_v2/config/language_rearrange_multi_agent.yaml
+++ b/examples/hitl/rearrange_v2/config/language_rearrange_multi_agent.yaml
@@ -27,3 +27,6 @@ habitat:
     agents_order:
       - agent_0
       - agent_1
+    agents:
+      agent_1:
+        auto_update_sensor_transform: False

--- a/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
+++ b/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
@@ -59,6 +59,8 @@ class KinematicHumanoid(MobileManipulator):
     def __init__(
         self, agent_cfg, sim, limit_robo_joints=False, fixed_base=False
     ):
+        auto_update_sensor_transform = agent_cfg.auto_update_sensor_transform
+
         super().__init__(
             self._get_humanoid_params(),
             agent_cfg,
@@ -66,6 +68,7 @@ class KinematicHumanoid(MobileManipulator):
             limit_robo_joints,
             fixed_base,
             maintain_link_order=True,
+            auto_update_sensor_transform=auto_update_sensor_transform,
         )
 
         # The offset and base transform are used so that the
@@ -164,7 +167,7 @@ class KinematicHumanoid(MobileManipulator):
         """Updates the camera transformations and performs necessary checks on
         joint limits and sleep states.
         """
-        if self._cameras is not None:
+        if self._cameras is not None and self._auto_update_sensor_transforms:
             # get the transformation
             agent_node = self._sim._default_agent.scene_node
             inv_T = agent_node.transformation.inverted()

--- a/habitat-lab/habitat/articulated_agents/manipulator.py
+++ b/habitat-lab/habitat/articulated_agents/manipulator.py
@@ -17,7 +17,7 @@ from habitat_sim.utils.common import orthonormalize_rotation_shear
 
 
 class Manipulator(ArticulatedAgentInterface):
-    """Generic manupulator interface defines standard API functions. Robot with a controllable arm."""
+    """Generic manipulator interface defines standard API functions. Robot with a controllable arm."""
 
     def __init__(
         self,
@@ -28,6 +28,7 @@ class Manipulator(ArticulatedAgentInterface):
         fixed_based: bool = True,
         sim_obj=None,
         maintain_link_order=False,
+        auto_update_sensor_transform=True,
         **kwargs,
     ):
         r"""Constructor"""
@@ -40,6 +41,7 @@ class Manipulator(ArticulatedAgentInterface):
         self._fixed_base = fixed_based
         self.sim_obj = sim_obj
         self._maintain_link_order = maintain_link_order
+        self._auto_update_sensor_transforms = auto_update_sensor_transform
 
         # Adapt Manipulator params to support multiple end effector indices
         # NOTE: the follow members cache static info for improved efficiency over querying the API
@@ -140,7 +142,7 @@ class Manipulator(ArticulatedAgentInterface):
         """Updates the camera transformations and performs necessary checks on
         joint limits and sleep states.
         """
-        if self._cameras is not None:
+        if self._cameras is not None and self._auto_update_sensor_transforms:
             # get the transformation
             agent_node = self._sim._default_agent.scene_node
             inv_T = agent_node.transformation.inverted()

--- a/habitat-lab/habitat/articulated_agents/mobile_manipulator.py
+++ b/habitat-lab/habitat/articulated_agents/mobile_manipulator.py
@@ -120,6 +120,7 @@ class MobileManipulator(Manipulator, ArticulatedAgentBase):
         limit_robo_joints: bool = True,
         fixed_base: bool = True,
         maintain_link_order: bool = False,
+        auto_update_sensor_transform=True,
         base_type="mobile",
     ):
         r"""Constructor
@@ -142,6 +143,7 @@ class MobileManipulator(Manipulator, ArticulatedAgentBase):
             params=params,
             sim=sim,
             limit_robo_joints=limit_robo_joints,
+            auto_update_sensor_transform=auto_update_sensor_transform,
         )
         # instantiate a robotBase
         ArticulatedAgentBase.__init__(

--- a/habitat-lab/habitat/articulated_agents/static_manipulator.py
+++ b/habitat-lab/habitat/articulated_agents/static_manipulator.py
@@ -64,6 +64,7 @@ class StaticManipulator(Manipulator):
         sim: Simulator,
         limit_robo_joints: bool = True,
         fixed_base: bool = True,
+        auto_update_sensor_transform=False,
     ):
         r"""Constructor
         :param params: The parameter of the manipulator robot.
@@ -81,6 +82,7 @@ class StaticManipulator(Manipulator):
             sim=sim,
             limit_robo_joints=limit_robo_joints,
             fixed_based=fixed_base,
+            auto_update_sensor_transform=auto_update_sensor_transform,
         )
 
     def reconfigure(self) -> None:

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1681,7 +1681,10 @@ class AgentConfig(HabitatBaseConfig):
     # File to motion data, used to play pre-recorded motions
     motion_data_path: str = ""
     auto_update_sensor_transform: bool = True
-    """If True, the agent's sensor transforms are automatically updated every frame."""
+    """
+    If `True`, the agent's sensor transforms are automatically updated every frame.
+    """
+    # TODO: Remove this flag once sensors are decoupled from agents.
 
 
 @dataclass

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1680,6 +1680,8 @@ class AgentConfig(HabitatBaseConfig):
     ik_arm_urdf: Optional[str] = None
     # File to motion data, used to play pre-recorded motions
     motion_data_path: str = ""
+    auto_update_sensor_transform: bool = True
+    """If True, the agent's sensor transforms are automatically updated every frame."""
 
 
 @dataclass

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -348,6 +348,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
                 "max_climb",
                 "max_slope",
                 "joint_start_override",
+                "auto_update_sensor_transform",
             },
         )
 


### PR DESCRIPTION
## Motivation and Context

In the current state, agent sensor transforms are automatically updated every frame based on the agent position.

In HITL and other GUI-controlled apps, the camera is controlled via GUI (e.g. first person camera). Here, it is desirable to synchronize the sensor transforms with the user view. Because the `Manipulator` objects override the transforms, there is a discrepancy between the _real_ camera and the sensors.

This changeset introduces a configuration field that disables this behavior so that HITL can control the sensor transforms.

**Note:** This is hacky, but I did not find a cleaner solution that doesn't involve refactoring. This is nonetheless better than carrying cherry-picks in experiments. Suggestions are welcome.

## How Has This Been Tested

Tested on HITL single-learn application.

## Types of changes

- **\[Bug Fix\]**
- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
