### PR TITLE
[bugfix] - re-initialize the KRM from episode contents in rearrange_sim 

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -706,15 +706,15 @@ class RearrangeSim(HabitatSim):
                     for motor_id in ao.existing_joint_motor_ids:
                         ao.remove_joint_motor(motor_id)
                 self.art_objs.append(ao)
-            if self._kinematic_mode:
-                # initialize KRM with parent->child relationships from the RearrangeEpisode
-                self.kinematic_relationship_manager = (
-                    KinematicRelationshipManager(self)
-                )
-                self.kinematic_relationship_manager.initialize_from_obj_to_rec_pairs(
-                    ep_info.name_to_receptacle,
-                    list(self._receptacles.values()),
-                )
+        if self._kinematic_mode and new_scene or should_add_objects:
+            # initialize KRM with parent->child relationships from the RearrangeEpisode
+            self.kinematic_relationship_manager = KinematicRelationshipManager(
+                self
+            )
+            self.kinematic_relationship_manager.initialize_from_obj_to_rec_pairs(
+                ep_info.name_to_receptacle,
+                list(self._receptacles.values()),
+            )
 
     def _create_recep_info(
         self, scene_id: str, ignore_handles: List[str]


### PR DESCRIPTION
## Motivation and Context

re-initialize the KRM from episode contents in rearrange_sim any time add_objs is called to add new objects or initialize a new scene

## How Has This Been Tested
CI? Mikael will validate against test cases

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
