### PR TITLE
add debug_draw callback to DebugVisualizer

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/debug_visualizer.py
@@ -8,7 +8,7 @@
 
 import math
 import os
-from typing import List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import magnum as mn
 import numpy as np
@@ -267,6 +267,11 @@ class DebugVisualizer:
         self.debug_line_render = sim.get_debug_line_render()
         self.sensor: habitat_sim.simulator.Sensor = None
         self.agent: habitat_sim.simulator.Agent = None
+
+        # optionally set a debug_draw callback function to be run every time a frame is rendered
+        self.dblr_callback: Callable = None
+        self.dblr_callback_params: Dict[str, Any] = None  # kwargs
+
         self.agent_id = 0
         # default black background
         self.clear_color = (
@@ -475,6 +480,8 @@ class DebugVisualizer:
 
         if look_at is not None:
             self.look_at(look_at, look_from)
+        if self.dblr_callback is not None:
+            self.dblr_callback(**self.dblr_callback_params)
         self.sensor.draw_observation()
         return DebugObservation(self.sensor.get_observation())
 


### PR DESCRIPTION
## Motivation and Context

This PR adds the option to specify a callback function with keyword arguments for a DebugVisualizer instance to use when rendering each observation.

## How Has This Been Tested

Locally.
Example of peeking an object with Receptacle meshes overlayed on each frame:
```
from habitat.datasets.rearrange.samplers.receptacle import get_scene_rec_filter_filepath, get_excluded_recs_from_filter_file, Receptacle, find_receptacles
from habitat.sims.habitat_simulator.debug_visualizer import DebugVisualizer
from habitat_sim import Simulator
from habitat_sim.physics import ManagedRigidObject

def draw_receptacles(sim:Simulator, receptacles:List[Receptacle]):
  """Debug draw callback for dbv to render the Receptacles."""
  scene_filter_file = get_scene_rec_filter_filepath(sim.metadata_mediator, sim.curr_scene_name)
  filter_strings = get_excluded_recs_from_filter_file(scene_filter_file)
  for rec in receptacles:
      color = mn.Color4.green()
      if rec.unique_name in filter_strings:
          color = mn.Color4.red()
      rec.debug_draw(sim, color=color)

def dbv_peek_objs_with_recs(sim:Simulator, obj:ManagedRigidObject):
  """Create a dbv and render an all-axis peek of a Receptacle parent object with debug drawn Receptacle overlay in all frames and hit a breakpoint to wait for user to evaluate the result."""
  dbv = DebugVisualizer(sim)  
  receptacles = find_receptacles(sim)

  dbv.dblr_callback = draw_receptacles
  #NOTE: the keyword args are passed as a simple Dict[str, Any]
  dbv.dblr_callback_params = {"sim":sim, "receptacles":receptacles}

  dbv.peek(obj, peek_all_axis=True).show()
  breakpoint()
  #clean up the dbv instance
  dbv.remove_dbv_agent()
```
Example Output:
![dbv_example](https://github.com/user-attachments/assets/55ce72a9-7679-49ce-95f8-72646f34452f)


## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
