### PR TITLE
HITL - Change object state check function signature.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -843,10 +843,10 @@ class UI:
         if osm is None or not self._can_change_object_states:
             return
 
-        success, _ = osm.try_execute_action(
+        result = osm.try_execute_action(
             state_name, target_value, object_handle
         )
-        if success:
+        if result.success:
             self._on_object_state_change.invoke(
                 UI.StateChangeEventData(
                     object_handle=object_handle,


### PR DESCRIPTION
## Motivation and Context

This changes the object state check function signature.
A result struct is used instead of a tuple.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
