### PR TITLE
HITL - Configure camera height based on the agent height.

### DIFF
--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -26,6 +26,9 @@ from ui import UI
 from util import UP
 from world import World
 
+from habitat.articulated_agents.humanoids.kinematic_humanoid import (
+    HUMANOID_CAMERA_HEIGHT_OFFSET,
+)
 from habitat_hitl._internal.networking.average_rate_tracker import (
     AverageRateTracker,
 )
@@ -269,10 +272,6 @@ class UserData:
         # TODO: Communicate to the controller via action hints.
         gui_agent_controller._gui_input = self.gui_input
 
-    def reset(self):
-        self.camera_helper.update(self._get_camera_lookat_pos(), dt=0)
-        self.ui.reset()
-
         # If networking is enabled...
         if self.app_service.client_message_manager:
             # Assign user agent objects to their own layer.
@@ -292,6 +291,9 @@ class UserData:
                 visible_layer_ids=Mask.all_except_index(agent_index),
                 destination_mask=Mask.from_index(self.user_index),
             )
+
+        self.camera_helper.update(self._get_camera_lookat_pos(), dt=0)
+        self.ui.reset()
 
     def update(self, dt: float):
         if self.end_episode_form.is_form_shown():
@@ -365,11 +367,32 @@ class UserData:
         return events
 
     def _get_camera_lookat_pos(self) -> mn.Vector3:
+        # HACK: Estimate camera height.
+        # TODO: GuiController should have knowledge on the agent type it controls, and should provide an API to get the camera height.
+        gui_agent_controller = self.gui_agent_controller
+        sim = self.app_service.sim
+        agent_data = self.agent_data
+        camera_height_offset = 1.0
+        if isinstance(gui_agent_controller, GuiRobotController):
+            # The robot camera height is defined in `spot_robot.py`.
+            # It's directly attached to the 6th articulated object link, without a height offset.
+            agent = sim.agents_mgr[agent_data.agent_index].articulated_agent
+            root = agent.sim_obj
+            head_link = root.get_link_scene_node(6)
+            head_link_height = head_link.absolute_translation.y
+            base_link = root.get_link_scene_node(-1)
+            base_link_height = base_link.absolute_translation.y
+            camera_height_offset = head_link_height - base_link_height
+        elif isinstance(gui_agent_controller, GuiHumanoidController):
+            # The humanoid camera height is defined in `kinematic_humanoid.py`.
+            # It is an offset relative to the agent base position.
+            camera_height_offset = HUMANOID_CAMERA_HEIGHT_OFFSET
+
         agent_root = get_agent_art_obj_transform(
             self.app_service.sim,
             self.gui_agent_controller._agent_idx,
         )
-        lookat_y_offset = UP
+        lookat_y_offset = UP * camera_height_offset
         lookat = agent_root.translation + lookat_y_offset
         return lookat
 
@@ -634,9 +657,6 @@ class AppStateRearrangeV2(AppStateBase):
                 self._agent_data[
                     agent_index
                 ].task_instruction = task_instruction
-
-        for user_index in self._users.indices(Mask.ALL):
-            self._user_data[user_index].reset()
 
         # Insert a keyframe immediately.
         self._app_service.sim.gfx_replay_manager.save_keyframe()

--- a/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
+++ b/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
@@ -16,6 +16,8 @@ from habitat.articulated_agents.mobile_manipulator import (
 )
 from habitat_sim.utils.common import orthonormalize_rotation_shear
 
+HUMANOID_CAMERA_HEIGHT_OFFSET = 0.5
+
 
 class KinematicHumanoid(MobileManipulator):
     def _get_humanoid_params(self):
@@ -36,8 +38,12 @@ class KinematicHumanoid(MobileManipulator):
             ee_constraint=np.zeros((2, 2, 3)),
             cameras={
                 "head": ArticulatedAgentCameraParams(
-                    cam_offset_pos=mn.Vector3(0.0, 0.5, 0.25),
-                    cam_look_at_pos=mn.Vector3(0.0, 0.5, 0.75),
+                    cam_offset_pos=mn.Vector3(
+                        0.0, HUMANOID_CAMERA_HEIGHT_OFFSET, 0.25
+                    ),
+                    cam_look_at_pos=mn.Vector3(
+                        0.0, HUMANOID_CAMERA_HEIGHT_OFFSET, 0.75
+                    ),
                     attached_link_id=-1,
                 ),
                 "third": ArticulatedAgentCameraParams(


### PR DESCRIPTION
## Motivation and Context

This changeset sets the HITL first person camera height from the agent type they are controlling.

This is hacky - This will be moved into a purposeful API in the HITL controllers.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Development\]**

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
