### PR TITLE
HITL - Fix viewport visibility layer initialization.

### DIFF
--- a/examples/hitl/rearrange_v2/app_state_load_episode.py
+++ b/examples/hitl/rearrange_v2/app_state_load_episode.py
@@ -17,6 +17,7 @@ from session import Session
 from util import get_top_down_view
 
 from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.client_message_manager import MAIN_VIEWPORT
 from habitat_hitl.core.user_mask import Mask
 
 
@@ -138,7 +139,7 @@ class AppStateLoadEpisode(AppStateBase):
                 destination_mask=Mask.ALL,
             )
         app_service.client_message_manager.set_viewport_properties(
-            viewport_id=-1,
+            viewport_id=MAIN_VIEWPORT,
             visible_layer_ids=Mask.all_except_index(1),
             destination_mask=Mask.ALL,
         )

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -30,6 +30,7 @@ from habitat_hitl._internal.networking.average_rate_tracker import (
     AverageRateTracker,
 )
 from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.core.client_message_manager import MAIN_VIEWPORT
 from habitat_hitl.core.key_mapping import KeyCode
 from habitat_hitl.core.user_mask import Mask, Users
 from habitat_hitl.environment.camera_helper import CameraHelper
@@ -288,7 +289,7 @@ class UserData:
             # Show all layers except "user_index" in the default viewport.
             # This hides the user's own agent in the first person view.
             self.app_service.client_message_manager.set_viewport_properties(
-                viewport_id=-1,
+                viewport_id=MAIN_VIEWPORT,
                 visible_layer_ids=Mask.all_except_index(agent_index),
                 destination_mask=Mask.from_index(self.user_index),
             )

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -310,7 +310,7 @@ class ClientMessageManager:
                             In window normalized coordinates, i.e. all values in range [0,1] relative to window size.
         visible_layer_ids: Visibility layers. Only objects assigned to these layers will be visible to this viewport.
         """
-        layers = Users(8)  # Maximum of 8 layers.
+        layers = Users(8, activate_users=True)  # Maximum of 8 layers.
         for user_index in self._users.indices(destination_mask):
             message = self._messages[user_index]
             viewport_properties = _obtain_viewport_properties(


### PR DESCRIPTION
## Motivation and Context

This fixes viewport visibility layer initialization.
Here, the `Users` mask is used to calculate layer masks.  `Users` should be renamed as it's used in more places now.

**Context:**

Regression source:
* https://github.com/facebookresearch/habitat-lab/pull/2019

Impacted feature:
* https://github.com/facebookresearch/habitat-lab/pull/1959

## How Has This Been Tested

Tested on multiplayer HITL application.

## Types of changes

- **\[Bug Fix\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
