### PR TITLE
[do not merge] - update default_link util 

### DIFF
--- a/test/test_sim_utils.py
+++ b/test/test_sim_utils.py
@@ -544,7 +544,7 @@ def test_ao_open_close_queries():
         default_link = sutils.get_ao_default_link(
             kitchen_counter, compute_if_not_found=True
         )
-        assert default_link == 6
+        assert default_link == 1
 
         # NOTE: sim bug here doesn't break the feature
         # test setting the default link in template metadata


### PR DESCRIPTION
## Motivation and Context

Current implementation chooses the link with the lowest global bounding box corner y value. When an AO has multiple links which should be equivalent, there is potential for floating point error to determine which one gets picked. 

This change considers 1cm difference in y value or less as equal and then breaks ties using lowest link index which should result in more deterministic behavior.

**NOTE: This is a breaking change since some previously detected default_links may have changed with the index tie breaker.**

TODO: all HSSD receptacle filter files with automatically computed active sets using default_link will need to be updated.

## How Has This Been Tested

Locally

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
