### PR TITLE
ManagedObject to Receptacle matching

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -571,6 +571,7 @@ class UI:
         ) = sutils.get_obj_receptacle_and_confidence(
             sim=self._sim,
             obj=sutils.get_obj_from_id(self._sim, self._held_object_id),
+            obj_bottom_location=point,
             support_surface_id=receptacle_object_id,
             candidate_receptacles=self._sim.receptacles,
             island_index=self._sim._largest_indoor_island_idx,

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -554,6 +554,20 @@ class UI:
         # Cannot place on objects held by agents.
         if self._world.is_any_agent_holding_object(receptacle_object_id):
             return False
+        (
+            matching_rec_names,
+            _conf,
+            _info_text,
+        ) = sutils.get_obj_receptacle_and_confidence(
+            sim=self._sim,
+            obj=sutils.get_obj_from_id(self._sim, self._held_object_id),
+            support_surface_id=receptacle_object_id,
+            candidate_receptacles=self._sim.receptacles,
+            island_index=self._sim._largest_indoor_island_idx,
+        )
+        if len(matching_rec_names) == 0:
+            # TODO: _info_text contains the reason for the failure
+            return False
         return True
 
     def _raycast(

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -1475,20 +1475,13 @@ def get_obj_receptacle_and_confidence(
 
     # find a support surface if one was not provided
     if support_surface_id is None:
-        # TODO: This hack is the solution to the Bullet physics raycast margin bug. It should be migrated into every raycast from habitat-sim and then removed here.
-        y_buffer = 0.08
         raycast_results = sim.cast_ray(
-            habitat_sim.geo.Ray(
-                center + mn.Vector3(0, y_buffer, 0), grav_vector
-            )
+            habitat_sim.geo.Ray(center, grav_vector)
         )
         if raycast_results.has_hits():
             for hit in raycast_results.hits:
                 if hit.object_id != obj.object_id:
                     support_surface_id = hit.object_id
-                    # print(f"first_hit true dist = {hit.ray_distance - y_buffer}")
-                    if hit.ray_distance >= y_buffer:
-                        break
         if support_surface_id is None:
             info_text = "No support surface found for object."
             return [], 1.0, info_text

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -1439,9 +1439,9 @@ def point_to_tri_dist(
 def get_obj_receptacle_and_confidence(
     sim: habitat_sim.Simulator,
     obj: habitat_sim.physics.ManagedRigidObject,
+    candidate_receptacles: Dict[str, "Receptacle"],
     support_surface_id: Optional[int] = None,
     max_dist_to_rec: float = 0.25,
-    candidate_receptacles: Optional[Dict[str, "Receptacle"]] = None,
     island_index: int = -1,
 ) -> Tuple[List[str], float, str]:
     """
@@ -1462,9 +1462,6 @@ def get_obj_receptacle_and_confidence(
     grav_vector = mn.Vector3(0, -1, 0)
     dist, center = get_obj_size_along(sim, obj.object_id, grav_vector)
     obj_bottom_point = center + grav_vector * dist
-
-    if candidate_receptacles is None:
-        candidate_receptacles = sim.receptacles
 
     # find a support surface if one was not provided
     if support_surface_id is None:


### PR DESCRIPTION
## Motivation and Context

This PR adds a set of utils targeting the application of matching an object or candidate object placement location to nearby  Receptacles.

The util involves a few primary components:
- `point_to_tri_dist` - a vectorized 3D point to triangle mesh distance computation util
  - TODO: should be moved to sim geometry utils
- `dist_to_rec` - a function for Receptacles (only implemented for `TriangleMeshReceptacle` currently) to get distance to the receptacle from a point
- `get_obj_receptacle_and_confidence` - a utility function for matching objects to receptacles. Includes logic for "floor" receptacles and region matching. Returns matches, a distance based confidence score, and a info_text string with a message explaining failure if applicable.

The util is then integrated with HitL ui to constraint object placements to active Receptacles for better alignment with oracle skills.

## How Has This Been Tested

Initially tested in HitL app.
This version tested in episode validation work.
TODO: no unit tests for this functionality yet.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Development\]** A pull request that add new features to the [habitat-lab](/habitat-lab) task and environment codebase. Development Pull Requests must be small (less that 500 lines of code change), have unit testing, very extensive documentation and examples. These are typically new tasks, environments, sensors, etc... The review process for these Pull Request is longer because these changes will be maintained by our core team of developers, so make sure your changes are easy to understand!


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
