### PR TITLE
HITL - Highlight default receptacles

### DIFF
--- a/examples/hitl/rearrange_v2/config/hitl_multi.yaml
+++ b/examples/hitl/rearrange_v2/config/hitl_multi.yaml
@@ -13,6 +13,7 @@ habitat_hitl:
 
 
 rearrange_v2:
+  highlight_default_receptacles: True
   agents:
     agent_0:
       head_sensor_substring: "head"

--- a/examples/hitl/rearrange_v2/config/hitl_single.yaml
+++ b/examples/hitl/rearrange_v2/config/hitl_single.yaml
@@ -9,6 +9,7 @@ defaults:
 
 
 rearrange_v2:
+  highlight_default_receptacles: True
   agents:
     agent_0:
       head_sensor_substring: "head"

--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -23,7 +23,7 @@ from app_states import (
 from end_episode_form import EndEpisodeForm, ErrorReport
 from metrics import Metrics
 from session import Session
-from ui import UI
+from ui import UI, UISettings
 from util import UP
 from world import World
 
@@ -242,6 +242,7 @@ class UserData:
         world: World,
         agent_data: AgentData,
         server_sps_tracker: AverageRateTracker,
+        rearrange_v2_config: RearrangeV2Config,
     ):
         self.app_service = app_service
         self.user_index = user_index
@@ -284,7 +285,10 @@ class UserData:
             gui_input=self.gui_input,
             gui_drawer=app_service.gui_drawer,
             camera_helper=self.camera_helper,
-            can_change_object_states=agent_data.can_change_object_states,
+            ui_settings=UISettings(
+                can_change_object_states=agent_data.can_change_object_states,
+                highlight_default_receptacles=rearrange_v2_config.highlight_default_receptacles,
+            ),
         )
 
         self.end_episode_form = EndEpisodeForm(user_index, app_service)
@@ -537,13 +541,24 @@ class RearrangeV2AgentConfig:
 
 @dataclass
 class RearrangeV2Config:
+    """
+    Parameters of the RearrangeV2 application.
+    """
+
     agents: Dict[int, RearrangeV2AgentConfig]
+
+    highlight_default_receptacles: bool
 
     @staticmethod
     def load(
         raw_config: Dict[str, Any], sim: "RearrangeSim"
     ) -> RearrangeV2Config:
-        output = RearrangeV2Config(agents={})
+        output = RearrangeV2Config(
+            agents={},
+            highlight_default_receptacles=raw_config.get(
+                "highlight_default_receptacles", False
+            ),
+        )
         agents: Dict[str, Any] = raw_config.get("agents", {})
         for agent_name, agent_cfg in agents.items():
             agent_index = sim.agents_mgr.get_agent_index_from_name(agent_name)
@@ -652,6 +667,7 @@ class AppStateRearrangeV2(AppStateBase):
                     world=self._world,
                     agent_data=agent_data,
                     server_sps_tracker=self._sps_tracker,
+                    rearrange_v2_config=rearrange_v2_config,
                 )
             )
 

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -798,7 +798,7 @@ class UI:
                     if self._ui_settings.highlight_default_receptacles:
                         contextual_info.append(
                             (
-                                "Highlighted receptacle\nmay contain objects.",
+                                "Yellow container\nmay have objects.",
                                 color_ui_object_info,
                             )
                         )

--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -795,23 +795,13 @@ class UI:
                                     )
                                 )
 
-                        if self._ui_settings.highlight_default_receptacles:
-                            if link_index == sutils.get_ao_default_link(
-                                ao, True
-                            ):
-                                contextual_info.append(
-                                    (
-                                        "May contain objects.",
-                                        color_ui_object_info,
-                                    )
-                                )
-                            else:
-                                contextual_info.append(
-                                    (
-                                        "May not contain objects.",
-                                        color_ui_invalid,
-                                    )
-                                )
+                    if self._ui_settings.highlight_default_receptacles:
+                        contextual_info.append(
+                            (
+                                "Highlighted receptacle\nmay contain objects.",
+                                color_ui_object_info,
+                            )
+                        )
 
         # Update the UI.
         self._ui_overlay.update_selected_object_panel(

--- a/examples/hitl/rearrange_v2/ui_overlay.py
+++ b/examples/hitl/rearrange_v2/ui_overlay.py
@@ -222,8 +222,7 @@ class UIOverlay:
         object_category_name: Optional[str],
         object_state_controls: List[ObjectStateControl],
         primary_region_name: Optional[str],
-        contextual_info: Optional[str],
-        contextual_color: Optional[List[float]],
+        contextual_info: List[Tuple[str, Optional[List[float]]]],
     ):
         """
         Draw a panel that shows information about the selected object.
@@ -246,12 +245,12 @@ class UIOverlay:
                 horizontal_alignment=HorizontalAlignment.CENTER,
             )
 
-            if contextual_info is not None:
+            for info_label in contextual_info:
                 ctx.label(
-                    text=contextual_info,
+                    text=info_label[0],
                     font_size=FONT_SIZE_SMALL,
                     horizontal_alignment=HorizontalAlignment.CENTER,
-                    color=contextual_color,
+                    color=info_label[1],
                 )
 
             ctx.spacer(size=SPACE_SIZE)


### PR DESCRIPTION
## Motivation and Context

This changeset adds a contextual UI that shows the default receptacle.

The following changes are included:
* Add support for multiple contextual info labels.
* Add default receptacle highlight and contextual info.
* Add feature flag.

https://github.com/user-attachments/assets/ac71dd3e-a523-4d37-a05b-8254c4ebf06a

## How Has This Been Tested

Tested on HITL application.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
