### PR TITLE
HITL - Remove redundant camera update.

### DIFF
--- a/examples/hitl/rearrange_v2/rearrange_v2.py
+++ b/examples/hitl/rearrange_v2/rearrange_v2.py
@@ -352,9 +352,6 @@ class UserData:
                 self.server_sps_tracker.get_smoothed_rate(),
             )
 
-        self.camera_helper.update(self._get_camera_lookat_pos(), dt)
-        self.agent_data.cam_transform = self.camera_helper.get_cam_transform()
-
         self._update_camera()
         self.ui.update()
         self.ui.draw_ui()


### PR DESCRIPTION
## Motivation and Context

This removes a redundant camera update, which would cause the camera movements to respond twice as fast to input.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
