### PR TITLE
static non-agent AOs for rearrange_sim navmesh

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -507,7 +507,7 @@ class RearrangeSim(HabitatSim):
         navmesh_settings.include_static_objects = True
 
         agent_object_ids = []
-        for articulated_agent in self.agent_mgr.articulated_agents_iter:
+        for articulated_agent in self.agents_mgr.articulated_agents_iter:
             agent_object_ids.extend(
                 [articulated_agent.sim_obj.object_id]
                 + [*articulated_agent.sim_obj.link_object_ids.keys()]

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -371,7 +371,7 @@ class RearrangeSim(HabitatSim):
         }
 
         if new_scene:
-            self._recompute_navmesh(ep_info)
+            self._recompute_navmesh()
 
         # Get the starting positions of the target objects.
         scene_pos = self.get_scene_pos()


### PR DESCRIPTION
## Motivation and Context

Patches the load_navmesh function called when a new rearrange_sim scene is loaded to always recompute the navmesh and to always include all non-agent ArticulatedObjects as STATIC navmesh components.

## How Has This Been Tested

Should be deployed in HitL test to fix issues walking through furniture.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
