### PR TITLE
Filter deactivated sensors.

### DIFF
--- a/habitat-lab/habitat/core/env.py
+++ b/habitat-lab/habitat/core/env.py
@@ -111,6 +111,18 @@ class Env:
         else:
             self.number_of_episodes = None
 
+        # Filter out inactive sensors from habitat-sim config.
+        active_sensors = config.gym.obs_keys
+        agent_configs = config.simulator.agents
+        with read_write(agent_configs):
+            for agent_name, agent_config in agent_configs.items():
+                active_sim_sensors = {}
+                for sensor_key, sensor_config in agent_config.sim_sensors.items():
+                    sensor_uuid = f"{agent_name}_{sensor_config.uuid}"
+                    if sensor_uuid in active_sensors:
+                        active_sim_sensors[sensor_key] = sensor_config
+                agent_config.sim_sensors = active_sim_sensors
+
         self._sim = make_sim(
             id_sim=self._config.simulator.type, config=self._config.simulator
         )


### PR DESCRIPTION
## Motivation and Context

This change ensures that only "active" sensors are rendered.

In lab, only the sensors listed in `gym.obs_keys` can be read. However, all other sensors are still rendered.
Therefore, when pulling agents from configs, **all their sensors are rendered**.

For example, if a human and spot are instantiated, the following sensors are rendered:
![image (6)](https://github.com/user-attachments/assets/64ce09d7-8dbe-4b56-845e-364cd15c731d)

## Performance

Here's the difference on a single-learn HITL session with 3 visual sensors.

| Before  | After |
| ------------- | ------------- |
| ![sensor_filter_before2](https://github.com/user-attachments/assets/3bb854c6-4c62-4ff0-824f-acb19afd27ae) | ![sensor_filter_after](https://github.com/user-attachments/assets/a6751213-df37-41ed-b695-45158d22dc0f) |

## How Has This Been Tested

Tested locally and profiled.
**_Running unit tests on CI._**

## Types of changes

- **\[Bug Fix\]**

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
