### PR TITLE
[bugfix] in support surface selection and KRM hard failure 

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
@@ -199,8 +199,8 @@ class KinematicRelationshipManager:
                 obj is not None
             ), f"Object with handle '{obj_handle}' could not be found in the scene. Has the Episode been initialized?"
             if rec_unique_name not in unique_name_to_rec:
-                print(
-                    f"Cannot find active receptacle {rec_unique_name}, so cannot create a parent relationship. Skipping."
+                logger.error(
+                    f"Cannot find active receptacle {rec_unique_name}, so cannot create a parent relationship. Skipping. Note that episode is likely invalid."
                 )
                 continue
             rec = unique_name_to_rec[rec_unique_name]

--- a/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/kinematic_relationship_manager.py
@@ -198,6 +198,11 @@ class KinematicRelationshipManager:
             assert (
                 obj is not None
             ), f"Object with handle '{obj_handle}' could not be found in the scene. Has the Episode been initialized?"
+            if rec_unique_name not in unique_name_to_rec:
+                print(
+                    f"Cannot find active receptacle {rec_unique_name}, so cannot create a parent relationship. Skipping."
+                )
+                continue
             rec = unique_name_to_rec[rec_unique_name]
             parent_obj = sutils.get_obj_from_handle(
                 self.sim, rec.parent_object_handle

--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -1481,7 +1481,9 @@ def get_obj_receptacle_and_confidence(
         if raycast_results.has_hits():
             for hit in raycast_results.hits:
                 if hit.object_id != obj.object_id:
+                    # get the first ray hit against a different object
                     support_surface_id = hit.object_id
+                    break
         if support_surface_id is None:
             info_text = "No support surface found for object."
             return [], 1.0, info_text


### PR DESCRIPTION
## Motivation and Context

Fixes a bug causing the last hit to be used as the default support surface for rec match. Usually this is the stage, so no matches were being found with furniture.

Also prevents program crash when Episode contains a non-active object->receptacle match. Logs an error and skips the kinematic relationship creation.

## How Has This Been Tested

Locally.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation if required.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
