### PR TITLE
[BE] - add humnaoid data to CI download to activate the test_humanoid.py pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
               . activate habitat
               git lfs install
               conda install -y gitpython git-lfs
-              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm hab3_bench_assets ycb rearrange_dataset_v2 --data-path habitat-sim/data/ --no-replace --no-prune
+              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm hab3_bench_assets habitat_humanoids ycb rearrange_dataset_v2 --data-path habitat-sim/data/ --no-replace --no-prune
       - run:
           name: Run sim benchmark
           command: |


### PR DESCRIPTION
## Motivation and Context

I realized that test_humanoids.py pytest was being skipped on CI because the humanoid data was missing from the download. Added this back and now expecting the tests to run.

## How Has This Been Tested

Should run the tests on CI now.
TODO: I noticed this fails locally due to missing config fields. Fix incoming.

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
