### PR TITLE
[BE] - fix inconsistent base_rot property 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
               . activate habitat
               git lfs install
               conda install -y gitpython git-lfs
-              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm hab3_bench_assets ycb rearrange_dataset_v2 --data-path habitat-sim/data/ --no-replace --no-prune
+              python -m habitat_sim.utils.datasets_download --uids ci_test_assets franka_panda hab_spot_arm hab3_bench_assets habitat_humanoids ycb rearrange_dataset_v2 --data-path habitat-sim/data/ --no-replace --no-prune
       - run:
           name: Run sim benchmark
           command: |

--- a/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
+++ b/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
@@ -184,10 +184,13 @@ class ArticulatedAgentBase(ArticulatedAgentInterface):
         # NOTE: if the quaternion axis is inverted (-Y) then the angle will be negated
         if self.sim_obj.rotation.axis()[1] < 0:
             angle = -1 * angle
-        while angle > mn.math.pi:
+        # NOTE: This offsetting gives us guarantees of consistency in the (-pi, pi) range.
+        if angle > mn.math.pi:
             angle -= mn.math.pi * 2
-        while angle < -mn.math.pi:
+        elif angle < -mn.math.pi:
             angle += mn.math.pi * 2
+        # NOTE: This final fmod ensures that large angles are mapped back into the -2pi, 2pi range.
+        angle = mn.math.fmod(angle, 2 * mn.math.pi)
         return angle
 
     @base_rot.setter

--- a/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
+++ b/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
@@ -187,7 +187,7 @@ class ArticulatedAgentBase(ArticulatedAgentInterface):
         # NOTE: This offsetting gives us guarantees of consistency in the (-pi, pi) range.
         if angle > mn.math.pi:
             angle -= mn.math.pi * 2
-        elif angle < -mn.math.pi:
+        elif angle <= -mn.math.pi:
             angle += mn.math.pi * 2
         # NOTE: This final fmod ensures that large angles are mapped back into the -2pi, 2pi range.
         angle = mn.math.fmod(angle, 2 * mn.math.pi)

--- a/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
+++ b/habitat-lab/habitat/articulated_agents/articulated_agent_base.py
@@ -176,10 +176,25 @@ class ArticulatedAgentBase(ArticulatedAgentInterface):
 
     @property
     def base_rot(self) -> float:
-        return float(self.sim_obj.rotation.angle())
+        """
+        Returns scalar rotation angle of the agent around the Y axis.
+        Within range (-pi,pi) consistency with setter is tested. Outside that range, an equivalent but distinct rotation angle may be returned (e.g. 2pi == -2pi == 0).
+        """
+        angle = float(self.sim_obj.rotation.angle())
+        # NOTE: if the quaternion axis is inverted (-Y) then the angle will be negated
+        if self.sim_obj.rotation.axis()[1] < 0:
+            angle = -1 * angle
+        while angle > mn.math.pi:
+            angle -= mn.math.pi * 2
+        while angle < -mn.math.pi:
+            angle += mn.math.pi * 2
+        return angle
 
     @base_rot.setter
     def base_rot(self, rotation_y_rad: float):
+        """
+        Set the scalar rotation angle of the agent around the Y axis.
+        """
         if self._base_type == "mobile" or self._base_type == "leg":
             self.sim_obj.rotation = mn.Quaternion.rotation(
                 mn.Rad(rotation_y_rad), mn.Vector3(0, 1, 0)

--- a/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
+++ b/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
@@ -145,10 +145,28 @@ class KinematicHumanoid(MobileManipulator):
 
     @property
     def base_rot(self) -> float:
-        return float(self.sim_obj.rotation.angle() + mn.Rad(self.offset_rot))
+        """
+        Returns scalar rotation angle of the humanoid around the Y axis.
+        Within range (-pi,pi) consistency with setter is tested. Outside that range, an equivalent but distinct rotation angle may be returned (e.g. 2pi == -2pi == 0).
+        NOTE: for humanoid, an additional offset_rot is considered between the model and this wrapper class.
+        """
+        angle = float(self.sim_obj.rotation.angle())
+        # NOTE: if the quaternion axis is inverted (-Y) then the angle will be negated
+        if self.sim_obj.rotation.axis()[1] < 0:
+            angle = -1 * angle
+        angle += float(mn.Rad(self.offset_rot))
+        while angle > mn.math.pi:
+            angle -= mn.math.pi * 2
+        while angle < -mn.math.pi:
+            angle += mn.math.pi * 2
+        return angle
 
     @base_rot.setter
     def base_rot(self, rotation_y_rad: float):
+        """
+        Set the scalar rotation angle of the humanoid around the Y axis.
+        NOTE: for humanoid, an additional offset_rot is considered between the model and this wrapper class.
+        """
         if self._base_type == "mobile" or self._base_type == "leg":
             angle_rot = -self.offset_rot
             self.sim_obj.rotation = mn.Quaternion.rotation(

--- a/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
+++ b/habitat-lab/habitat/articulated_agents/humanoids/kinematic_humanoid.py
@@ -155,10 +155,13 @@ class KinematicHumanoid(MobileManipulator):
         if self.sim_obj.rotation.axis()[1] < 0:
             angle = -1 * angle
         angle += float(mn.Rad(self.offset_rot))
-        while angle > mn.math.pi:
+        # NOTE: This offsetting gives us guarantees of consistency in the (-pi, pi) range.
+        if angle > mn.math.pi:
             angle -= mn.math.pi * 2
-        while angle < -mn.math.pi:
+        elif angle < -mn.math.pi:
             angle += mn.math.pi * 2
+        # NOTE: This final fmod ensures that large angles are mapped back into the -2pi, 2pi range.
+        angle = mn.math.fmod(angle, 2 * mn.math.pi)
         return angle
 
     @base_rot.setter

--- a/test/test_robot_wrapper.py
+++ b/test/test_robot_wrapper.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 from os import path as osp
 
 import numpy as np
@@ -701,6 +702,77 @@ def test_spot_robot_wrapper(fixed_base):
                 "color_sensor",
                 "color",
                 "test_spot_robot_wrapper__fixed_base=" + str(fixed_base),
+                open_vid=True,
+            )
+
+
+@pytest.mark.skipif(
+    not osp.exists("data/robots/hab_spot_arm"),
+    reason="Test requires Spot w/ arm robot URDF and assets.",
+)
+@pytest.mark.skipif(
+    not habitat_sim.built_with_bullet,
+    reason="Robot wrapper API requires Bullet physics.",
+)
+def test_base_rot():
+    # set this to output test results as video for easy investigation
+    produce_debug_video = False
+    observations = []
+    cfg_settings = default_sim_settings.copy()
+    cfg_settings["scene"] = "NONE"
+    cfg_settings["enable_physics"] = True
+
+    # loading the physical scene
+    hab_cfg = make_cfg(cfg_settings)
+
+    with habitat_sim.Simulator(hab_cfg) as sim:
+        # setup the camera for debug video (looking at 0,0,0)
+        sim.agents[0].scene_node.translation = [0.0, -1.0, 2.0]
+
+        # add the robot to the world via the wrapper
+        robot_path = "data/robots/hab_spot_arm/urdf/hab_spot_arm.urdf"
+        agent_config = DictConfig({"articulated_agent_urdf": robot_path})
+        spot = spot_robot.SpotRobot(agent_config, sim)
+        spot.reconfigure()
+        spot.update()
+
+        # check that for range (-pi, pi) getter and setter are consistent
+        num_samples = 100
+        for i in range(1, num_samples):
+            angle = -math.pi + (math.pi * 2 * i) / num_samples
+            spot.base_rot = angle
+            assert np.allclose(angle, spot.base_rot, atol=1e-5)
+            if produce_debug_video:
+                observations.append(sim.get_sensor_observations())
+
+        # check that for range [-2pi, 2pi] increment is accurate
+        spot.base_rot = -math.pi * 2
+        inc = (math.pi * 4) / num_samples
+        rot_check = -math.pi * 2
+        for _ in range(0, num_samples):
+            spot.base_rot = spot.base_rot + inc
+            rot_check += inc
+            # NOTE: here we check that the angle is accurate (allow an offset of one full rotation to cover redundant options)
+            accurate_angle = False
+            for offset in [0, math.pi * 2, math.pi * -2]:
+                if np.allclose(rot_check, spot.base_rot + offset, atol=1e-5):
+                    accurate_angle = True
+                    break
+            assert (
+                accurate_angle
+            ), f"should be {rot_check}, but was {spot.base_rot}."
+            if produce_debug_video:
+                observations.append(sim.get_sensor_observations())
+
+        # produce some test debug video
+        if produce_debug_video:
+            from habitat_sim.utils import viz_utils as vut
+
+            vut.make_video(
+                observations,
+                "color_sensor",
+                "color",
+                "test_base_rot",
                 open_vid=True,
             )
 

--- a/test/test_robot_wrapper.py
+++ b/test/test_robot_wrapper.py
@@ -354,7 +354,8 @@ def test_fetch_robot_wrapper(fixed_base):
 
         # set base ground position using object transformation approach
         target_base_pos = sim.pathfinder.snap_point(fetch.sim_obj.translation)
-        target_base_rots = [0.0, np.pi * 0.25, np.pi * 0.50, np.pi]
+        # Note, don't test equivalency of pi, because that is the wrap point and is often negated.
+        target_base_rots = [0.0, np.pi * 0.25, np.pi * 0.50, np.pi * 0.99]
         for target_base_rot in target_base_rots:
             set_agent_base_via_obj_trans(
                 target_base_pos, target_base_rot, fetch
@@ -615,7 +616,8 @@ def test_spot_robot_wrapper(fixed_base):
 
         # set base ground position using object transformation approach
         target_base_pos = sim.pathfinder.snap_point(spot.sim_obj.translation)
-        target_base_rots = [0.0, np.pi * 0.25, np.pi * 0.50, np.pi]
+        # Note, don't test equivalency of pi, because that is the wrap point and is often negated.
+        target_base_rots = [0.0, np.pi * 0.25, np.pi * 0.50, np.pi * 0.99]
         for target_base_rot in target_base_rots:
             set_agent_base_via_obj_trans(
                 target_base_pos, target_base_rot, spot
@@ -835,7 +837,8 @@ def test_stretch_robot_wrapper(fixed_base):
         target_base_pos = sim.pathfinder.snap_point(
             stretch.sim_obj.translation
         )
-        target_base_rots = [0.0, np.pi * 0.25, np.pi * 0.50, np.pi]
+        # Note, don't test equivalency of pi, because that is the wrap point and is often negated.
+        target_base_rots = [0.0, np.pi * 0.25, np.pi * 0.50, np.pi * 0.99]
         for target_base_rot in target_base_rots:
             set_agent_base_via_obj_trans(
                 target_base_pos, target_base_rot, stretch


### PR DESCRIPTION
## Motivation and Context

This PR addresses a long-standing bug in the `articulated_agent.base_rot` property API.

**The bug:** :bug: 
Rotations are stored internally as `Magnum.Quaternion` objects. The `base_rot` property operates in scalar space, namely the angle of rotation about the Y axis. This means that every call to the setter creates a Quaternion from a rotation angle and Y axis, while the getter deconstructs a Quaternion into an angle [using 2arccos](https://magnum.graphics/doc/magnum/classMagnum_1_1Math_1_1Quaternion.html#ae8e09c06b590ce0c8676f83ed771d395). 
While the result is correct in some sense, it does not account for:
1. Inversion of the axis
2. redundancies in SO3
This results in the potential for several nasty bugs. The most obvious being that getting an angle after settings does not return the same scalar value (it could be a correct, but different angle) and could return an erroneous value (e.g. if the quaternion axis is inverted during normalization).

**The solution:**
This PR modifies the getter to:
1. check for inverted Y axis and negate the angle if detected. This prevents cases where an erroneous angle would be returned due to unknown inversion of the axis.
2. clamping the output range to [-2pi, 2pi] by adding or subtracting 2pi overflows.

Together, these changes result in a few nice guarantees from the function:
1. Testable consistency between the getter and setter within the range (-pi, pi). Note the end points are excluded because `-pi ==pi`. This means, e.g. `base_rot = pi/2` guarantees `base_rot == pi/2`.
2. The getter can be used in the setter to increment the rotation like: `base_rot = base_rot + 0.1` with the expected outcome of continual rotation.
4. The getter will always return a value in the range [-2pi, 2pi] and it will always be an equivalent rotation to that which was set (though the scalar value may be different outside the range (-pi,pi))

## How Has This Been Tested

Added unit tests for robot wrapper and humanoid wrapper.
This includes changes from #2084. Note that CI was failing there and is now passing. 

https://github.com/user-attachments/assets/68aa6a40-3d74-4635-bcf0-5645f757c483


## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance
- **\[Bug Fix\]** (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
