### PR TITLE
rearrange_sim no navmesh caching

### DIFF
--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -507,7 +507,7 @@ class RearrangeSim(HabitatSim):
         navmesh_settings.include_static_objects = True
 
         agent_object_ids = []
-        for articulated_agent in self.agent_mgr.articulated_agents_iter:
+        for articulated_agent in self.agents_mgr.articulated_agents_iter:
             agent_object_ids.extend(
                 [articulated_agent.sim_obj.object_id]
                 + [*articulated_agent.sim_obj.link_object_ids.keys()]

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -495,30 +495,8 @@ class RearrangeSim(HabitatSim):
         navmesh_settings.agent_max_slope = agent_config.max_slope
         navmesh_settings.include_static_objects = True
 
-        # exclude any articulated agents from the navmesh
-        agent_object_ids = [
-            articulated_agent.sim_obj.object_id
-            for articulated_agent in self.agents_mgr.articulated_agents_iter
-        ]
-        # first cache AO motion types and set to STATIC for navmesh
-        ao_motion_types = []
-        self.agents_mgr
-        for ao in (
-            self.get_articulated_object_manager()
-            .get_objects_by_handle_substring()
-            .values()
-        ):
-            # ignore the articulated agents
-            if ao.object_id not in agent_object_ids:
-                ao_motion_types.append((ao, ao.motion_type))
-                ao.motion_type = habitat_sim.physics.MotionType.STATIC
-
         # recompute the navmesh
         self.recompute_navmesh(self.pathfinder, navmesh_settings)
-
-        # reset AO motion types from cache
-        for ao, ao_orig_motion_type in ao_motion_types:
-            ao.motion_type = ao_orig_motion_type
 
         # NOTE: allowing indoor islands only
         self._largest_indoor_island_idx = get_largest_island_index(

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -476,7 +476,7 @@ class RearrangeSim(HabitatSim):
     @add_perf_timing_func()
     def _recompute_navmesh(self) -> None:
         """
-        Recompute the navmesh including all non-agent ArticulatedObjects as static components (assuming they are furniture).
+        Recompute the navmesh including STATIC objects and using agent parameters.
         """
 
         navmesh_settings = NavMeshSettings()

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -371,7 +371,7 @@ class RearrangeSim(HabitatSim):
         }
 
         if new_scene:
-            self._recompute_navmesh(ep_info)
+            self._recompute_navmesh()
 
         # Get the starting positions of the target objects.
         scene_pos = self.get_scene_pos()


### PR DESCRIPTION
## Motivation and Context

This PR is a reduced version of #2077 which removes the hardcoded navmesh caching behavior but does not modify the AO motion_types.
Context: this seems like a more reasonable default behavior. AOS should be set to STATIC by the scene_instance or the explicitly by the user if they should be part of the navmesh.

An accompanying change is to ensure that scene_instances specify STATIC AOs and Furniture objects as necessary.

## How Has This Been Tested

CI

## Types of changes

<!--- What types of changes does your code introduce? Please mark the title of your pull request with one of the following -->
- **\[Refactoring\]** Large changes to the code that improve its functionality or performance


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes if required.
