### PR TITLE
HITL - Null check for _is_object_visible raycast.

### DIFF
--- a/examples/hitl/rearrange_v2/ui.py
+++ b/examples/hitl/rearrange_v2/ui.py
@@ -639,7 +639,10 @@ class UI:
             )
 
         hit_info = self._raycast(ray, discriminator)
-        return hit_info.object_id == object_id
+        if hit_info is not None:
+            return hit_info.object_id == object_id
+        else:
+            return False
 
     def _update_hovered_object_ui(self):
         """Draw a UI when hovering an object with the cursor."""


### PR DESCRIPTION
## Motivation and Context

This changeset adds a nullcheck to `rearrange_v2`'s UI in `_is_object_visible()`, which caused failures in some rare cases.

## How Has This Been Tested

Stress tested on 100k episodes.

## Types of changes

- **\[Bug Fix\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
