### PR TITLE
[Docs change] Minor fix to URL on README.md linking to habitat-baselines instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Can't find the answer to your question? Look up for [common issues](./TROUBLESHO
 [Common task and episode datasets used with Habitat-Lab](DATASETS.md).
 
 ## Baselines
-Habitat-Lab includes reinforcement learning (via PPO) baselines. For running PPO training on sample data and more details refer [habitat_baselines/README.md](habitat-baselines/habitat_baselines/README.md).
+Habitat-Lab includes reinforcement learning (via PPO) baselines. For running PPO training on sample data and more details refer [habitat_baselines/README.md](habitat_baselines/README.md).
 
 ## ROS-X-Habitat
 ROS-X-Habitat (https://github.com/ericchen321/ros_x_habitat) is a framework that bridges the AI Habitat platform (Habitat Lab + Habitat Sim) with other robotics resources via ROS. ROS-X-Habitat places emphasis on 1) leveraging Habitat Sim v2's physics-based simulation capability and 2) allowing roboticists to access simulation assets from ROS. The work has also been made public as a [paper](https://arxiv.org/abs/2109.07703).

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Can't find the answer to your question? Look up for [common issues](./TROUBLESHO
 [Common task and episode datasets used with Habitat-Lab](DATASETS.md).
 
 ## Baselines
-Habitat-Lab includes reinforcement learning (via PPO) baselines. For running PPO training on sample data and more details refer [habitat_baselines/README.md](habitat_baselines/README.md).
+Habitat-Lab includes reinforcement learning (via PPO) baselines. For running PPO training on sample data and more details refer [habitat-baselines/README.md](habitat-baselines/README.md).
 
 ## ROS-X-Habitat
 ROS-X-Habitat (https://github.com/ericchen321/ros_x_habitat) is a framework that bridges the AI Habitat platform (Habitat Lab + Habitat Sim) with other robotics resources via ROS. ROS-X-Habitat places emphasis on 1) leveraging Habitat Sim v2's physics-based simulation capability and 2) allowing roboticists to access simulation assets from ROS. The work has also been made public as a [paper](https://arxiv.org/abs/2109.07703).


### PR DESCRIPTION
## Motivation and Context

After the subfolder was nested from `/habitat_baselines/` into `/habitat-baselines/habitat-baselines`, the README.md was brought up a level (`/habitat-baselines/habitat-baselines/README.md` -> `/habitat-baselines/README.md`) and the link not updated.

## How Has This Been Tested

Clicking the link now takes you to the right page.

## PR Checklist

- [X] My code follows the code style of this project. (Marking since it’s only a README.md chance)
- [X] I have updated the documentation if required.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [X] I have added tests to cover my changes if required. (Again, marking since it’s only a README.md chance)
