### PR TITLE
Add config type annotations to rearrange_sim.

### DIFF
--- a/habitat-baselines/habitat_baselines/common/obs_transformers.py
+++ b/habitat-baselines/habitat_baselines/common/obs_transformers.py
@@ -841,7 +841,7 @@ def get_cubemap_projections(
 
 
 class Cube2Equirect(ProjectionConverter):
-    """This is the backend Cube2Equirect nn.module that does the stiching.
+    """This is the backend Cube2Equirect nn.module that does the stitching.
     Inspired from https://github.com/fuenwang/PanoramaUtility and
     optimized for modern PyTorch."""
 
@@ -970,7 +970,7 @@ class CubeMap2Equirect(ProjectionTransformer):
     has the 6 sensors in the proper orientations. This code also assumes a 90
     FOV.
 
-    Sensor order for cubemap stiching is Back, Down, Front, Left, Right, Up.
+    Sensor order for cubemap stitching is Back, Down, Front, Left, Right, Up.
     The output will be written the UUID of the first sensor.
     """
 
@@ -1063,7 +1063,7 @@ class CubeMap2Fisheye(ProjectionTransformer):
     has the 6 sensors in the proper orientations. This code also assumes a 90
     FOV.
 
-    Sensor order for cubemap stiching is Back, Down, Front, Left, Right, Up.
+    Sensor order for cubemap stitching is Back, Down, Front, Left, Right, Up.
     The output will be written the UUID of the first sensor.
     """
 

--- a/habitat-baselines/habitat_baselines/rl/ddppo/data_generation/create_gibson_large_dataset.py
+++ b/habitat-baselines/habitat_baselines/rl/ddppo/data_generation/create_gibson_large_dataset.py
@@ -44,7 +44,7 @@ def _generate_fn(scene):
     with habitat.config.read_write(cfg):
         cfg.habitat.simulator.scene = scene
         agent_config = get_agent_config(cfg.habitat.simulator)
-        agent_config.sensors.clear()
+        agent_config.sim_sensors.clear()
 
     sim = habitat.sims.make_sim("Sim-v0", config=cfg.habitat.simulator)
 

--- a/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
+++ b/habitat-lab/habitat/articulated_agent_controllers/humanoid_rearrange_controller.py
@@ -131,7 +131,7 @@ class HumanoidRearrangeController(HumanoidBaseController):
                 self.hand_processed_data[hand_name] = None
 
     def set_framerate_for_linspeed(
-        self, lin_speed: float, ang_speed: float, ctrl_freq: int
+        self, lin_speed: float, ang_speed: float, ctrl_freq: float
     ) -> None:
         """
         Set the linear and angular speed of the humanoid's root motion based on the relative framerate of the simulator and the motion trajectory.
@@ -141,6 +141,7 @@ class HumanoidRearrangeController(HumanoidBaseController):
         :param ctrl_freq: Simulator step frequency. How many times does Simulator step to progress 1 second.
         """
 
+        assert ctrl_freq > 0, "`ctrl_freq` must be strictly greater than zero."
         seconds_per_step = 1.0 / ctrl_freq
         meters_per_step = lin_speed * seconds_per_step
         frames_per_step = meters_per_step / self.dist_per_step_size

--- a/habitat-lab/habitat/config/default.py
+++ b/habitat-lab/habitat/config/default.py
@@ -20,9 +20,6 @@ from habitat.config.default_structured_configs import (
 )
 from habitat.config.read_write import read_write
 
-# from omegaconf import DictConfig, OmegaConf
-
-
 if TYPE_CHECKING:
     from omegaconf import DictConfig, OmegaConf
 

--- a/habitat-lab/habitat/config/default.py
+++ b/habitat-lab/habitat/config/default.py
@@ -8,9 +8,10 @@ import inspect
 import os.path as osp
 import threading
 from functools import partial
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 from hydra import compose, initialize_config_dir
+from omegaconf import DictConfig, OmegaConf
 
 from habitat.config.default_structured_configs import (
     AgentConfig,
@@ -19,10 +20,6 @@ from habitat.config.default_structured_configs import (
     register_hydra_plugin,
 )
 from habitat.config.read_write import read_write
-
-if TYPE_CHECKING:
-    from omegaconf import DictConfig, OmegaConf
-
 
 _HABITAT_CFG_DIR = osp.dirname(inspect.getabsfile(inspect.currentframe()))
 # Habitat config directory inside the installed package.

--- a/habitat-lab/habitat/config/default.py
+++ b/habitat-lab/habitat/config/default.py
@@ -8,16 +8,24 @@ import inspect
 import os.path as osp
 import threading
 from functools import partial
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from hydra import compose, initialize_config_dir
-from omegaconf import DictConfig, OmegaConf
 
 from habitat.config.default_structured_configs import (
+    AgentConfig,
     HabitatConfigPlugin,
+    SimulatorConfig,
     register_hydra_plugin,
 )
 from habitat.config.read_write import read_write
+
+# from omegaconf import DictConfig, OmegaConf
+
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig, OmegaConf
+
 
 _HABITAT_CFG_DIR = osp.dirname(inspect.getabsfile(inspect.currentframe()))
 # Habitat config directory inside the installed package.
@@ -56,8 +64,8 @@ Returns absolute path to the habitat yaml config file if exists, else raises Run
 
 
 def get_agent_config(
-    sim_config: DictConfig, agent_id: Optional[int] = None
-) -> DictConfig:
+    sim_config: SimulatorConfig, agent_id: Optional[int] = None
+) -> AgentConfig:
     r"""Returns agent's config node of default agent or based on index of the agent.
 
     :param sim_config: config of :ref:`habitat.core.simulator.Simulator`.

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1476,7 +1476,7 @@ class TaskConfig(HabitatBaseConfig):
 
 @dataclass
 class SimulatorSensorConfig(HabitatBaseConfig):
-    uuid: str = MISSING
+    uuid: Optional[str] = None
     type: str = MISSING
     height: int = 480
     width: int = 640

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1476,6 +1476,7 @@ class TaskConfig(HabitatBaseConfig):
 
 @dataclass
 class SimulatorSensorConfig(HabitatBaseConfig):
+    uuid: str = MISSING
     type: str = MISSING
     height: int = 480
     width: int = 640
@@ -1667,7 +1668,7 @@ class AgentConfig(HabitatBaseConfig):
     max_climb: float = 0.2
     max_slope: float = 45.0
     grasp_managers: int = 1
-    sim_sensors: Dict[str, SimulatorSensorConfig] = field(default_factory=dict)
+    sim_sensors: Dict[str, Any] = field(default_factory=dict)
     is_set_start_state: bool = False
     start_position: List[float] = field(default_factory=lambda: [0, 0, 0])
     start_rotation: List[float] = field(default_factory=lambda: [0, 0, 0, 1])

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -1476,7 +1476,6 @@ class TaskConfig(HabitatBaseConfig):
 
 @dataclass
 class SimulatorSensorConfig(HabitatBaseConfig):
-    uuid: Optional[str] = None
     type: str = MISSING
     height: int = 480
     width: int = 640

--- a/habitat-lab/habitat/config/read_write.py
+++ b/habitat-lab/habitat/config/read_write.py
@@ -3,23 +3,21 @@
 # LICENSE file in the root directory of this source tree.
 
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generator
+from typing import Any, Generator
 
-from omegaconf import OmegaConf
+from omegaconf import Container, OmegaConf
 from omegaconf.base import Node
-
-if TYPE_CHECKING:
-    from omegaconf import Container
 
 
 @contextmanager
-def read_write(config: "Container") -> Generator[Node, None, None]:
+def read_write(config: Any) -> Generator[Node, None, None]:
     r"""
     Temporarily authorizes the modification of a OmegaConf configuration
     within a context. Use the 'with' statement to enter the context.
 
     :param config: The configuration object that should get writing access
     """
+    assert isinstance(config, Container)
     prev_state_readonly = config._get_node_flag("readonly")
     prev_state_struct = config._get_node_flag("struct")
     try:

--- a/habitat-lab/habitat/core/simulator.py
+++ b/habitat-lab/habitat/core/simulator.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
         pass
     from omegaconf import DictConfig
 
+    from habitat.config.default_structured_configs import SimulatorConfig
+
 VisualObservation = Union[np.ndarray, "Tensor"]
 
 
@@ -280,7 +282,7 @@ class Simulator:
     :data habitat_config: The Dictconfig object containing configuration parameters specifically pertaining to the habitat Simulator.
     """
 
-    habitat_config: "DictConfig"
+    habitat_config: "SimulatorConfig"
 
     def __init__(self, *args, **kwargs) -> None:
         pass

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -48,9 +48,11 @@ from habitat.core.spaces import Space
 if TYPE_CHECKING:
     from torch import Tensor
 
+    from habitat.config.default_structured_configs import SimulatorConfig
+
 
 def overwrite_config(
-    config_from: DictConfig,
+    config_from: Any,
     config_to: Any,
     ignore_keys: Optional[Set[str]] = None,
     trans_dict: Optional[Dict[str, Callable]] = None,
@@ -275,7 +277,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
         config: configuration for initializing the simulator.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, config: "SimulatorConfig") -> None:
         self.habitat_config = config
 
         sim_sensors = []
@@ -507,7 +509,7 @@ class HabitatSim(habitat_sim.Simulator, Simulator):
 
     def reconfigure(
         self,
-        habitat_config: DictConfig,
+        habitat_config: "SimulatorConfig",
         ep_info: Optional[Episode] = None,
         should_close_on_new_scene: bool = True,
     ) -> None:

--- a/habitat-lab/habitat/tasks/nav/shortest_path_follower.py
+++ b/habitat-lab/habitat/tasks/nav/shortest_path_follower.py
@@ -48,7 +48,7 @@ class ShortestPathFollower:
         self._sim = sim
         self._goal_radius = goal_radius
         self._follower: Optional[habitat_sim.GreedyGeodesicFollower] = None
-        self._current_scene = None
+        self._current_scene: Optional[str] = None
         self._stop_on_error = stop_on_error
 
     def _build_follower(self):

--- a/habitat-lab/habitat/tasks/rearrange/actions/oracle_nav_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/oracle_nav_action.py
@@ -255,7 +255,7 @@ class OracleNavAction(BaseVelAction, HumanoidJointAction):
 @registry.register_task_action
 class OracleNavCoordinateAction(BaseVelAction, HumanoidJointAction):  # type: ignore
     """
-    An action to drive the anget to a given coordinate
+    An action to drive the agent to a given coordinate
     """
 
     def __init__(self, *args, task, **kwargs):

--- a/habitat-lab/habitat/tasks/rearrange/articulated_agent_manager.py
+++ b/habitat-lab/habitat/tasks/rearrange/articulated_agent_manager.py
@@ -33,6 +33,10 @@ from habitat.tasks.rearrange.utils import (
 if TYPE_CHECKING:
     from omegaconf import DictConfig
 
+    from habitat.config.default_structured_configs import (
+        AgentConfig,
+        SimulatorConfig,
+    )
     from habitat_sim.simulator import Simulator
 
 
@@ -44,7 +48,7 @@ class ArticulatedAgentData:
 
     articulated_agent: MobileManipulator
     grasp_mgrs: List[RearrangeGraspManager]
-    cfg: "DictConfig"
+    cfg: "AgentConfig"
     start_js: np.ndarray
     is_pb_installed: bool
     _ik_helper: Optional[IkHelper] = None
@@ -69,7 +73,7 @@ class ArticulatedAgentManager:
     Handles creating, updating and managing all agent instances.
     """
 
-    def __init__(self, cfg: "DictConfig", sim: "Simulator"):
+    def __init__(self, cfg: "SimulatorConfig", sim: "Simulator"):
         self._sim = sim
         self._all_agent_data: List[ArticulatedAgentData] = []
         self._is_pb_installed = is_pb_installed()

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_grasp_manager.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_grasp_manager.py
@@ -19,9 +19,8 @@ from habitat_sim.physics import (
 )
 
 if TYPE_CHECKING:
-    from omegaconf import DictConfig
-
     from habitat.articulated_agents.manipulator import Manipulator
+    from habitat.config.default_structured_configs import SimulatorConfig
     from habitat.tasks.rearrange.rearrange_sim import RearrangeSim
 
 
@@ -33,7 +32,7 @@ class RearrangeGraspManager:
     def __init__(
         self,
         sim: "RearrangeSim",
-        config: "DictConfig",
+        config: "SimulatorConfig",
         articulated_agent: "Manipulator",
         ee_index=0,
     ) -> None:

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sim.py
@@ -59,12 +59,12 @@ from habitat_sim.sim import SimulatorBackend
 from habitat_sim.utils.common import quat_from_magnum
 
 if TYPE_CHECKING:
-    from omegaconf import DictConfig
+    from habitat.config.default_structured_configs import SimulatorConfig
 
 
 @registry.register_simulator(name="RearrangeSim-v0")
 class RearrangeSim(HabitatSim):
-    def __init__(self, config: "DictConfig"):
+    def __init__(self, config: "SimulatorConfig"):
         if len(config.agents) > 1:
             with read_write(config):
                 for agent_name, agent_cfg in config.agents.items():
@@ -285,7 +285,9 @@ class RearrangeSim(HabitatSim):
             self._sleep_all_objects()
 
     @add_perf_timing_func()
-    def reconfigure(self, config: "DictConfig", ep_info: RearrangeEpisode):
+    def reconfigure(
+        self, config: "SimulatorConfig", ep_info: RearrangeEpisode
+    ):
         self._handle_to_goal_name = ep_info.info["object_labels"]
 
         self.ep_info = ep_info
@@ -309,7 +311,7 @@ class RearrangeSim(HabitatSim):
             # delete old KRM when scene is hard reset
             self.kinematic_relationship_manager = None
             with read_write(config):
-                config["scene"] = ep_info.scene_id
+                config.scene = ep_info.scene_id
             t_start = time.time()
             super().reconfigure(config, should_close_on_new_scene=False)
             self.add_perf_timing("super_reconfigure", t_start)

--- a/test/test_baseline_agents.py
+++ b/test/test_baseline_agents.py
@@ -48,22 +48,22 @@ def test_ppo_agents(input_type, resolution):
         benchmark = habitat.Benchmark(config_paths=CFG_TEST)
         with habitat.config.read_write(config_env):
             agent_config = get_agent_config(config_env.habitat.simulator)
-            agent_config.sim_sensors.rgb_sensor.update(
+            agent_config.sim_sensors["rgb_sensor"].update(
                 {
                     "height": resolution,
                     "width": resolution,
                 }
             )
-            agent_config.sim_sensors.depth_sensor.update(
+            agent_config.sim_sensors["depth_sensor"].update(
                 {
                     "height": resolution,
                     "width": resolution,
                 }
             )
             if input_type in ["depth", "blind"]:
-                del agent_config.sim_sensors.rgb_sensor
+                del agent_config.sim_sensors["rgb_sensor"]
             if input_type in ["rgb", "blind"]:
-                del agent_config.sim_sensors.depth_sensor
+                del agent_config.sim_sensors["depth_sensor"]
 
         del benchmark._env
         benchmark._env = habitat.Env(config=config_env)

--- a/test/test_baseline_trainers.py
+++ b/test/test_baseline_trainers.py
@@ -176,14 +176,14 @@ def test_cpca():
 )
 @pytest.mark.parametrize("camera", ["equirect", "fisheye", "cubemap"])
 @pytest.mark.parametrize("sensor_type", ["rgb", "depth"])
-def test_cubemap_stiching(
+def test_cubemap_stitching(
     test_cfg_path: str, mode: str, camera: str, sensor_type: str
 ):
     meta_config = get_config(config_path=test_cfg_path)
     with read_write(meta_config):
         config = meta_config.habitat
         CAMERA_NUM = 6
-        orient = [
+        orient: list[list[float]] = [
             [0, math.pi, 0],  # Back
             [-math.pi / 2, 0, 0],  # Down
             [0, 0, 0],  # Front
@@ -204,7 +204,7 @@ def test_cubemap_stiching(
             }
         else:
             raise ValueError(
-                "Typo in the sensor type in test_cubemap_stiching"
+                "Typo in the sensor type in test_cubemap_stitching"
             )
 
         sensor = agent_config.sim_sensors[f"{sensor_type}_sensor"]
@@ -431,7 +431,7 @@ def test_batch_obs(sensor_device, batched_device):
         "cuda" in (sensor_device, batched_device)
         and not torch.cuda.is_available()
     ):
-        pytest.skip("CUDA not avaliable")
+        pytest.skip("CUDA not available")
 
     sensor_device = torch.device(sensor_device)
     batched_device = torch.device(batched_device)

--- a/test/test_mp3d_eqa.py
+++ b/test/test_mp3d_eqa.py
@@ -174,14 +174,14 @@ def test_mp3d_eqa_sim():
                 assert "rgb" in obs, "RGB image is missing in observation."
                 agent_config = get_agent_config(eqa_config.habitat.simulator)
                 assert obs["rgb"].shape[:2] == (
-                    agent_config.sim_sensors.rgb_sensor.height,
-                    agent_config.sim_sensors.rgb_sensor.width,
+                    agent_config.sim_sensors["rgb_sensor"].height,
+                    agent_config.sim_sensors["rgb_sensor"].width,
                 ), (
                     "Observation resolution {} doesn't correspond to config "
                     "({}, {}).".format(
                         obs["rgb"].shape[:2],
-                        eqa_config.habitat.simulator.rgb_sensor.height,
-                        eqa_config.habitat.simulator.rgb_sensor.width,
+                        eqa_config.habitat.simulator["rgb_sensor"].height,
+                        eqa_config.habitat.simulator["rgb_sensor"].width,
                     )
                 )
 

--- a/test/test_r2r_vln.py
+++ b/test/test_r2r_vln.py
@@ -146,18 +146,18 @@ def test_r2r_vln_sim():
                     assert (
                         obs["instruction"]["text"]
                         == env.current_episode.instruction.instruction_text
-                    ), "Instruction from sensor does not match the intruction from the episode"
+                    ), "Instruction from sensor does not match the instruction from the episode"
                     agent_config = get_agent_config(
                         vln_config.habitat.simulator
                     )
                     assert obs["rgb"].shape[:2] == (
-                        agent_config.sim_sensors.rgb_sensor.height,
-                        agent_config.sim_sensors.rgb_sensor.width,
+                        agent_config.sim_sensors["rgb_sensor"].height,
+                        agent_config.sim_sensors["rgb_sensor"].width,
                     ), (
                         "Observation resolution {} doesn't correspond to config "
                         "({}, {}).".format(
                             obs["rgb"].shape[:2],
-                            vln_config.habitat.simulator.rgb_sensor.height,
-                            vln_config.habitat.simulator.rgb_sensor.width,
+                            vln_config.habitat.simulator["rgb_sensor"].height,
+                            vln_config.habitat.simulator["rgb_sensor"].width,
                         )
                     )

--- a/test/test_sensors.py
+++ b/test/test_sensors.py
@@ -575,13 +575,15 @@ def test_noise_models_rgbd():
 
     with habitat.config.read_write(config):
         agent_config = get_agent_config(config.habitat.simulator)
-        agent_config.sim_sensors.rgb_sensor.noise_model = "GaussianNoiseModel"
-        agent_config.sim_sensors.rgb_sensor.noise_model_kwargs.intensity_constant = (
-            0.5
-        )
-        agent_config.sim_sensors.depth_sensor.noise_model = (
-            "RedwoodDepthNoiseModel"
-        )
+        agent_config.sim_sensors[
+            "rgb_sensor"
+        ].noise_model = "GaussianNoiseModel"
+        agent_config.sim_sensors["rgb_sensor"].noise_model_kwargs[
+            "intensity_constant"
+        ] = 0.5
+        agent_config.sim_sensors[
+            "depth_sensor"
+        ].noise_model = "RedwoodDepthNoiseModel"
 
     with habitat.Env(config=config, dataset=None) as env:
         env.episode_iterator = iter([test_episode])


### PR DESCRIPTION
## Motivation and Context

This changeset annotates the `rearrange_sim` config types to provide type annotations for configs.

## How Has This Been Tested

CI

## Types of changes

- **\[Refactoring\]** Large changes to the code that improve its functionality or performance

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
