### PR TITLE
Revert "fix bug in region_center"

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/sim_utilities.py
@@ -1054,7 +1054,7 @@ def get_floor_point_in_region(
     # first try aiming at the center (nice for convex regions)
     if max_center_samples > 0:
         # get the center of the region's bounds and attempt to snap it to the navmesh
-        region_center = region.aabb.center
+        region_center = region.aabb.center()
         region_center_snap = sim.pathfinder.snap_point(
             region_center, island_index=island_index
         )


### PR DESCRIPTION
Reverts facebookresearch/habitat-lab#2147

This change worked because an older version of habitat-sim was installed on the test platform and should be reverted.
