### PR TITLE
HITL - Add a discovery server.

### DIFF
--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -40,6 +40,11 @@ habitat_hitl:
       code_available: 200  # "Ok"
       code_unavailable: 503  # "Service Unavailable"
 
+    # HITL clients may emit UDP broadcasts to auto-discover an available HITL server on the local network. If the discovery server is enabled, the HITL port will be given as a response to these broadcasts allowing for a simplified connection flow.
+    discovery_server:
+      enable: True
+      port: 12345
+
     # Optionally kick an idle client after n seconds.
     client_max_idle_duration: ~
 


### PR DESCRIPTION
## Motivation and Context

This changeset adds a discovery server to HITL so that clients can automatically discover available HITL servers on the network.
This makes testing and rapid iterations easier by removing the need to specify specific IP addresses in VR headsets or in complex networks.

**How it works:**
1. A client sends a UDP broadcast at the discovery port.
2. A server receives the packet, and replies with its open HITL port.
3. The client initiates connection, or tries again if the server becomes unavailable in the meantime.

**Note:**
* This should not be used for discovering cloud services.
* The discovery and HITL ports need to be open on the server.

## How Has This Been Tested

Tested locally with VR and WebGL.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
