### PR TITLE
Added missing import

### DIFF
--- a/habitat-lab/habitat/config/__init__.py
+++ b/habitat-lab/habitat/config/__init__.py
@@ -7,5 +7,6 @@
 
 from habitat.config.default import DictConfig, get_config
 from habitat.config.read_write import read_write
+from habitat.config.default_structured_configs import *  # Add this import
 
 __all__ = ["get_config", "read_write", "default_structured_configs"]


### PR DESCRIPTION
## Motivation and Context

The `habitat/config/__init__.py` file currently lists `default_structured_configs` in its `__all__` but doesn't import it. This is incorrect because:

1. It promises to export a name that isn't actually available in the module
2. It could cause errors when users try to use `from habitat.config import *`
3. It's inconsistent with the actual module exports

This fix ensures that the module's exports match its declarations in `__all__`.

## How Has This Been Tested

The fix has been tested by:
1. Verifying that `from habitat.config import *` works without errors
2. Confirming that `default_structured_configs` is properly imported and available
3. Checking that existing imports of `default_structured_configs` from other files continue to work

## Types of changes

- **[Bug Fix]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.

## Code Changes

```python
# habitat/config/__init__.py
from habitat.config.default import DictConfig, get_config
from habitat.config.read_write import read_write
from habitat.config.default_structured_configs import *  # Added missing import

__all__ = ["get_config", "read_write", "default_structured_configs"]