### PR TITLE
HITL - Change default port numbers.

### DIFF
--- a/examples/hitl/pick_throw_vr/README.md
+++ b/examples/hitl/pick_throw_vr/README.md
@@ -203,7 +203,7 @@ See [the troubleshooting steps on siro_hitl_unity_client](https://github.com/eun
 
 ### Connection Issues
 
-* Make sure that your server firewall allows incoming connections to the port `8888`.
+* Make sure that your server firewall allows incoming connections to the port `18000`.
 * Check that the Unity client `config.txt` file lists to the correct address. See [this section](#connection).
 * Make sure that both devices are on the same network.
 * Corporate networks may introduce additional hurdles. To circumvent these, you can use the wifi hotspot on your phone or a separate router.

--- a/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
+++ b/habitat-hitl/habitat_hitl/config/hitl_defaults.yaml
@@ -27,15 +27,15 @@ habitat_hitl:
     enable_connections_by_default: True
 
     # We'll listen for incoming client connections at this port.
-    port: 8888
+    port: 18000
 
     # If True, NetworkManager will wait until the application issues ClientMessageManager.signal_app_ready before sending the first gfx-replay keyframe to the client. This gives the application an opportunity to e.g. change scenes when a client connects. If False, NetworkManager will start sending keyframes immediately upon connect.
     wait_for_app_ready_signal: False
 
-    # Used with AWS elastic load balancer (ELB) health checks. If enabled, we run a separate HTTP server that returns a code based on whether the HITL server is available to accept new client connections. Note this HTTP server doesn't serve any files or other content. Note the current HITL server implementation only handles one client at a time, so the expected behavior is that it becomes "unavailable" once it has a connected client. The HTTP server can be tested locally with e.g. curl -i 0.0.0.0:8889.
+    # Used with AWS elastic load balancer (ELB) health checks. If enabled, we run a separate HTTP server that returns a code based on whether the HITL server is available to accept new client connections. Note this HTTP server doesn't serve any files or other content. Note the current HITL server implementation only handles one client at a time, so the expected behavior is that it becomes "unavailable" once it has a connected client. The HTTP server can be tested locally with e.g. curl -i 0.0.0.0:18100.
     http_availability_server:
       enable: False
-      port: 8889
+      port: 18100
       # HTTP codes
       code_available: 200  # "Ok"
       code_unavailable: 503  # "Service Unavailable"
@@ -43,7 +43,7 @@ habitat_hitl:
     # HITL clients may emit UDP broadcasts to auto-discover an available HITL server on the local network. If the discovery server is enabled, the HITL port will be given as a response to these broadcasts allowing for a simplified connection flow.
     discovery_server:
       enable: True
-      port: 12345
+      port: 18200
 
     # Optionally kick an idle client after n seconds.
     client_max_idle_duration: ~

--- a/habitat-hitl/habitat_hitl/scripts/stub_client.html
+++ b/habitat-hitl/habitat_hitl/scripts/stub_client.html
@@ -29,7 +29,7 @@
                 <label for="serverPort">Port:</label>
             </td>
             <td>
-                <input type="text" id="serverPort" value="8888" style="width: 500px">
+                <input type="text" id="serverPort" value="18000" style="width: 500px">
             </td>
         </tr>
     </table>


### PR DESCRIPTION
## Motivation and Context

This changes the default HITL port numbers.
`8888` interferes with Zoom, which is problematic for some people.

## How Has This Been Tested

Tested locally.

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
