### PR TITLE
HITL - Add APIs to get and set XR origin.

### DIFF
--- a/examples/hitl/pick_throw_vr/pick_throw_vr.py
+++ b/examples/hitl/pick_throw_vr/pick_throw_vr.py
@@ -140,7 +140,7 @@ class AppStatePickThrowVr(AppState):
 
         client_message_manager = self._app_service.client_message_manager
         if client_message_manager:
-            client_message_manager.change_humanoid_position(human_pos)
+            client_message_manager.rebase_xr_headset_position(human_pos)
             client_message_manager.signal_scene_change()
             client_message_manager.update_navmesh_triangles(
                 self._get_navmesh_triangle_vertices()

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -236,7 +236,12 @@ class ClientMessageManager:
             if pos is not None and len(pos) == 3:
                 message["setXrOriginPosition"] = [pos[0], pos[1], pos[2]]
             if rot is not None and len(rot) == 4:
-                message["setXrOriginPosition"] = [pos[0], pos[1], pos[2]]
+                message["setXrOriginRotation"] = [
+                    rot[0],
+                    rot[1],
+                    rot[2],
+                    rot[3],
+                ]
 
     def signal_scene_change(self, destination_mask: Mask = Mask.ALL) -> None:
         r"""

--- a/habitat-hitl/habitat_hitl/core/client_message_manager.py
+++ b/habitat-hitl/habitat_hitl/core/client_message_manager.py
@@ -210,16 +210,33 @@ class ClientMessageManager:
                     }
                 )
 
-    def change_humanoid_position(
+    def rebase_xr_headset_position(
         self, pos: List[float], destination_mask: Mask = Mask.ALL
     ) -> None:
         r"""
-        Change the position of the humanoid.
-        Used to synchronize the humanoid position in the client when changing scene.
+        Move the headset position to the specified world position.
+        Under the hood, this moves the XR origin on the horizontal plane such as the headset position matches the input.
         """
         for user_index in self._users.indices(destination_mask):
             message = self._messages[user_index]
-            message["teleportAvatarBasePosition"] = [pos[0], pos[1], pos[2]]
+            message["rebaseXrHeadsetPosition"] = [pos[0], pos[1], pos[2]]
+
+    def set_xr_origin_transform(
+        self,
+        pos: Optional[List[float]] = None,
+        rot: Optional[List[float]] = None,
+        destination_mask: Mask = Mask.ALL,
+    ) -> None:
+        r"""
+        Set the XR origin world position and rotation.
+        Use `None` to retain the same position or rotation.
+        """
+        for user_index in self._users.indices(destination_mask):
+            message = self._messages[user_index]
+            if pos is not None and len(pos) == 3:
+                message["setXrOriginPosition"] = [pos[0], pos[1], pos[2]]
+            if rot is not None and len(rot) == 4:
+                message["setXrOriginPosition"] = [pos[0], pos[1], pos[2]]
 
     def signal_scene_change(self, destination_mask: Mask = Mask.ALL) -> None:
         r"""

--- a/habitat-hitl/habitat_hitl/core/remote_client_state.py
+++ b/habitat-hitl/habitat_hitl/core/remote_client_state.py
@@ -395,6 +395,14 @@ class RemoteClientState:
                                     ctrl_input._buttons_up.add(
                                         XRButton(button)
                                     )
+                    origin = xr.get("origin", None)
+                    if origin is not None:
+                        pos = origin.get("position", None)
+                        if pos is not None:
+                            xr_input._origin_position = pos
+                        rot = origin.get("rotation", None)
+                        if rot is not None:
+                            xr_input._origin_rotation = rot
 
             # Update other inputs from the latest data.
             last_client_state = client_states[-1]

--- a/habitat-hitl/habitat_hitl/core/xr_input.py
+++ b/habitat-hitl/habitat_hitl/core/xr_input.py
@@ -81,6 +81,9 @@ class XRInput:
         for _ in range(NUM_CONTROLLERS):
             self._controllers.append(XRController())
 
+        self._origin_position: list[float] = [0.0, 0.0, 0.0]
+        self._origin_rotation: list[float] = [0.0, 0.0, 0.0, 0.0]
+
     @property
     def controllers(self):
         return self._controllers
@@ -92,6 +95,14 @@ class XRInput:
     @property
     def right_controller(self):
         return self._controllers[HAND_RIGHT]
+
+    @property
+    def origin_position(self):
+        return self._origin_position
+
+    @property
+    def origin_rotation(self):
+        return self._origin_rotation
 
     def reset(self, reset_continuous_input: bool = True):
         """


### PR DESCRIPTION
## Motivation and Context

This changeset adds a set of APIs to read and write the XR origin.

**Example:**
```python
if gui_input.get_key_down(KeyCode.P):
    # Get the XR input of the `user 0`.
    xr_input = self._app_service.remote_client_state.get_xr_input(0)

    # Read XR origin.
    pos = xr_input.origin_position
    rot = xr_input.origin_rotation

    # Move the origin by 1m on the X axis.
    pos[0] += 1.0

    # Send the new origin to the client.
    self._app_service.client_message_manager.set_xr_origin_transform(pos, rot)
    # or
    self._app_service.client_message_manager.set_xr_origin_transform(pos, None)
```

**Result:**


https://github.com/user-attachments/assets/7405441d-ec07-4771-8c59-1409b681f5bf



## How Has This Been Tested

HITL + Remote Unity Client.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
