### PR TITLE
HITL - Add XR reader application.

### DIFF
--- a/examples/hitl/experimental/xr_reader/README.md
+++ b/examples/hitl/experimental/xr_reader/README.md
@@ -1,0 +1,47 @@
+# XR reader application
+
+A simple HITL application that displays XR input from a remote client.
+
+## Client Application
+
+This is an experimental server. The client application is currently unavailable.
+
+## Setup
+
+### Quest
+
+#### Requirements:
+
+* Quest headset (preferably Quest 3)
+* Meta account
+* Device set up in [Developer Mode](https://developers.meta.com/horizon/documentation/native/android/mobile-device-setup/)
+* A client capable of installing applications on Quest.
+  * On MacOS, [Meta Quest Developer Hub](https://developers.meta.com/horizon/documentation/unity/ts-odh/) is recommended.
+  * [SideQuest](https://sidequestvr.com/) is also an option.
+* Have both the headset and server on the same network.
+
+#### Setup:
+
+1. Install the client to the headset.
+2. Launch the server. See the launch command below.
+3. Launch the application on the headset.
+
+The headset should automatically discover and connect to the server.
+
+#### Troubleshooting:
+
+If the headset cannot connect to the server, check the following items:
+
+1. Make sure that both devices are on the same network.
+   * Otherwise, make sure that the devices can communicate to each other. See the step below.
+2. If the server has a firewall, make sure that the following ports are open:
+   * Discovery: `UDP` on `12345`.
+   * Connection: `TCP` on `18000`.
+
+## Launch Command
+
+Run the following command from the root `habitat-lab` directory:
+
+```bash
+python examples/hitl/experimental/xr_reader/xr_reader.py
+```

--- a/examples/hitl/experimental/xr_reader/config/xr_reader.yaml
+++ b/examples/hitl/experimental/xr_reader/config/xr_reader.yaml
@@ -1,0 +1,23 @@
+# @package _global_
+
+defaults:
+  - hitl_defaults
+  - _self_
+
+habitat_hitl:
+  driver: "SimDriver"
+  disable_policies_and_stepping: True
+  window:
+    title: "XR Reader"
+  networking:
+    enable: True
+    max_client_count: 1
+    http_availability_server:
+      enable: False
+    enable_connections_by_default: True
+    client_sync:
+      # The client controls its own camera.
+      server_camera: False
+      server_input: True
+      # This is a first-person application. We don't need to transmit skinned mesh poses.
+      skinning: False

--- a/examples/hitl/experimental/xr_reader/xr_reader.py
+++ b/examples/hitl/experimental/xr_reader/xr_reader.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import hydra
+import magnum as mn
+
+from habitat_hitl.app_states.app_service import AppService
+from habitat_hitl.app_states.app_state_abc import AppState
+from habitat_hitl.core.hitl_main import hitl_main
+from habitat_hitl.core.hydra_utils import register_hydra_plugins
+from habitat_hitl.core.key_mapping import KeyCode, XRButton
+from habitat_hitl.core.text_drawer import TextOnScreenAlignment
+
+
+class AppStateXRReader(AppState):
+    def __init__(
+        self,
+        app_service: AppService,
+    ):
+        self._app_service = app_service
+        self._gui_input = self._app_service.gui_input
+        self._xr_input = self._app_service.remote_client_state.get_xr_input()
+        self._app_service.users.activate_user(0)
+
+    def get_sim(self):
+        return self._app_service.sim
+
+    def on_environment_reset(self, episode_recorder_dict):
+        pass
+
+    def sim_update(self, dt, post_sim_update_dict):
+        if self._app_service.gui_input.get_key_down(KeyCode.ESC):
+            self._app_service.end_episode()
+            post_sim_update_dict["application_exit"] = True
+        post_sim_update_dict["cam_transform"] = mn.Matrix4.identity_init()
+
+        left = self._xr_input.left_controller
+        right = self._xr_input.right_controller
+        state = self._app_service.remote_client_state
+
+        def btn(button_list: list[XRButton]) -> str:
+            button_names = [
+                button.name
+                for button in button_list
+                if isinstance(button, XRButton)
+            ]
+            return f"[{', '.join(button_names)}]"
+
+        def pos(
+            legacy_tuple: Optional[tuple[mn.Vector3, mn.Quaternion]]
+        ) -> str:
+            if legacy_tuple is None:
+                return "None"
+            v = legacy_tuple[0]
+            if v is None:
+                return "None"
+            return f"{f'{v.x:.2f}'}, {f'{v.y:.2f}'}, {f'{v.z:.2f}'}"
+
+        text = f"""
+        Left Controller:
+        - Position:     {pos(state.get_hand_pose(0, 0))}
+        - Keys held:    {btn(left._buttons_held)}
+        - Keys down:    {btn(left._buttons_down)}
+        - Keys up:      {btn(left._buttons_up)}
+        - Keys touched: {btn(left._buttons_touched)}
+        - Hand trigger: {left.get_hand_trigger()}
+        - Idx trigger:  {left.get_index_trigger()}
+        - Thumbstick:   {left.get_thumbstick()}
+        - In hand:      {left.get_is_controller_in_hand()}
+        """
+
+        # TODO: Magnum crashes when rendering more than 512 characters.
+        #       > Text::Renderer::render(): capacity 512 too small to render 584 glyphs
+        text = text[0:512]
+        self._app_service.text_drawer.add_text(
+            text,
+            TextOnScreenAlignment.TOP_LEFT,
+        )
+
+        text = f"""
+        Right Controller:
+        - Position:     {pos(state.get_hand_pose(0, 1))}
+        - Keys held:    {btn(right._buttons_held)}
+        - Keys down:    {btn(right._buttons_down)}
+        - Keys up:      {btn(right._buttons_up)}
+        - Keys touched: {btn(right._buttons_touched)}
+        - Hand trigger: {right.get_hand_trigger()}
+        - Idx trigger:  {right.get_index_trigger()}
+        - Thumbstick:   {right.get_thumbstick()}
+        - In hand:      {right.get_is_controller_in_hand()}
+        """
+
+        # TODO: Magnum crashes when rendering more than 512 characters.
+        #       > Text::Renderer::render(): capacity 512 too small to render 584 glyphs
+        text = text[0:512]
+        self._app_service.text_drawer.add_text(
+            text,
+            TextOnScreenAlignment.TOP_CENTER,
+        )
+
+        text = f"""
+        HMD:
+        - Position:     {pos(state.get_head_pose(0))}
+        """
+
+        # TODO: Magnum crashes when rendering more than 512 characters.
+        #       > Text::Renderer::render(): capacity 512 too small to render 584 glyphs
+        text = text[0:512]
+        self._app_service.text_drawer.add_text(
+            text,
+            TextOnScreenAlignment.TOP_RIGHT,
+        )
+
+
+@hydra.main(version_base=None, config_path="config", config_name="xr_reader")
+def main(config):
+    hitl_main(
+        config,
+        lambda app_service: AppStateXRReader(app_service),
+    )
+
+
+if __name__ == "__main__":
+    register_hydra_plugins()
+    main()

--- a/examples/hitl/experimental/xr_reader/xr_reader.py
+++ b/examples/hitl/experimental/xr_reader/xr_reader.py
@@ -73,10 +73,6 @@ class AppStateXRReader(AppState):
         - Thumbstick:   {left.get_thumbstick()}
         - In hand:      {left.get_is_controller_in_hand()}
         """
-
-        # TODO: Magnum crashes when rendering more than 512 characters.
-        #       > Text::Renderer::render(): capacity 512 too small to render 584 glyphs
-        text = text[0:512]
         self._app_service.text_drawer.add_text(
             text,
             TextOnScreenAlignment.TOP_LEFT,
@@ -94,10 +90,6 @@ class AppStateXRReader(AppState):
         - Thumbstick:   {right.get_thumbstick()}
         - In hand:      {right.get_is_controller_in_hand()}
         """
-
-        # TODO: Magnum crashes when rendering more than 512 characters.
-        #       > Text::Renderer::render(): capacity 512 too small to render 584 glyphs
-        text = text[0:512]
         self._app_service.text_drawer.add_text(
             text,
             TextOnScreenAlignment.TOP_CENTER,
@@ -107,10 +99,6 @@ class AppStateXRReader(AppState):
         HMD:
         - Position:     {pos(state.get_head_pose(0))}
         """
-
-        # TODO: Magnum crashes when rendering more than 512 characters.
-        #       > Text::Renderer::render(): capacity 512 too small to render 584 glyphs
-        text = text[0:512]
         self._app_service.text_drawer.add_text(
             text,
             TextOnScreenAlignment.TOP_RIGHT,

--- a/habitat-hitl/habitat_hitl/core/text_drawer.py
+++ b/habitat-hitl/habitat_hitl/core/text_drawer.py
@@ -159,6 +159,9 @@ if not use_headless_text_drawer:
                 :param text_delta_y: pixels delta to move/adjust window text anchor along Y axis,
             """
 
+            # TODO: Magnum crashes when rendering more than 512 characters.
+            truncated_text = text_to_add[0:512]
+
             # text object transform in window space is Projection matrix times Translation Matrix
             # put text in top left of window
             align_y, align_x = alignment.value
@@ -170,12 +173,12 @@ if not use_headless_text_drawer:
                 + mn.Vector2(text_delta_x, text_delta_y)
             )
             self._text_transform_pairs.append(
-                (text_to_add, window_text_transform)
+                (truncated_text, window_text_transform)
             )
 
             if self._client_message_manager:
                 self._client_message_manager.add_text(
-                    text_to_add, [align_x, align_y], destination_mask
+                    truncated_text, [align_x, align_y], destination_mask
                 )
 
         def draw_text(self):


### PR DESCRIPTION
## Motivation and Context

This adds an experimental XR reader HITL application.
This application simply displays all XR input coming from a remote client. It is meant to develop and assess XR capabilities.

Note that the accompanying `.apk` is not yet included.

## How Has This Been Tested

Tested with custom Unity client.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
