### PR TITLE
Dataset Processing: Transform collada files to match Habitat coordinate system.

### DIFF
--- a/scripts/habitat_dataset_processing/habitat_dataset_processing/util.py
+++ b/scripts/habitat_dataset_processing/habitat_dataset_processing/util.py
@@ -7,6 +7,7 @@
 import os
 import re
 import xml.etree.ElementTree as et
+from pathlib import Path
 
 
 def resolve_relative_path(path: str) -> str:
@@ -39,6 +40,12 @@ def resolve_relative_path_with_wildcard(path: str) -> str:
         else:
             break
     return resolve_relative_path(path)
+
+
+def is_file_collada(path: str) -> bool:
+    """Returns true if the path is a collada (`.dae`) file."""
+    extension = Path(path).suffix.lower()
+    return extension == ".dae"
 
 
 def get_dependencies_urdf(urdf_file_path: str) -> set[str]:

--- a/scripts/habitat_dataset_processing/requirements.txt
+++ b/scripts/habitat_dataset_processing/requirements.txt
@@ -1,0 +1,1 @@
+pycollada


### PR DESCRIPTION
## Motivation and Context

Habitat [ignores the up direction of Collada files](https://github.com/facebookresearch/habitat-sim/blob/main/src/esp/assets/ResourceManager.cpp#L145).

```
#ifdef ESP_BUILD_ASSIMP_SUPPORT
  if (Cr::PluginManager::PluginMetadata* const assimpmetadata = importerManager_.metadata("AssimpImporter")) {
    assimpmetadata->configuration().setValue("ImportColladaIgnoreUpDirection", "true");
  }
#endif
```

Therefore, other engines cannot accurately determine the coordinate system of Habitat Collada files.

This changeset forces a Collada up vector so that third party engines can interpret the Collada coordinate systems like Habitat.

## How Has This Been Tested

Tested with Unity.

## Types of changes

- **\[Development\]**

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
