### PR TITLE
[bugfix] use field(default_factory) for dataclass defaults

### DIFF
--- a/habitat-baselines/habitat_baselines/config/default_structured_configs.py
+++ b/habitat-baselines/habitat_baselines/config/default_structured_configs.py
@@ -277,7 +277,7 @@ class PolicyConfig(HabitatBaselinesBaseConfig):
     action_distribution_type: str = "categorical"  # or 'gaussian'
     # If the list is empty, all keys will be included.
     # For gaussian action distribution:
-    action_dist: ActionDistributionConfig = ActionDistributionConfig()
+    action_dist: ActionDistributionConfig = field(default_factory=ActionDistributionConfig)
     obs_transforms: Dict[str, ObsTransformConfig] = field(default_factory=dict)
     hierarchical_policy: HierarchicalPolicyConfig = MISSING
 
@@ -389,14 +389,14 @@ class AgentAccessMgrConfig(HabitatBaselinesBaseConfig):
 class RLConfig(HabitatBaselinesBaseConfig):
     """Reinforcement learning config"""
 
-    agent: AgentAccessMgrConfig = AgentAccessMgrConfig()
-    preemption: PreemptionConfig = PreemptionConfig()
+    agent: AgentAccessMgrConfig = field(default_factory=AgentAccessMgrConfig)
+    preemption: PreemptionConfig = field(default_factory=PreemptionConfig)
     policy: Dict[str, PolicyConfig] = field(
         default_factory=lambda: {"main_agent": PolicyConfig()}
     )
-    ppo: PPOConfig = PPOConfig()
-    ddppo: DDPPOConfig = DDPPOConfig()
-    ver: VERConfig = VERConfig()
+    ppo: PPOConfig = field(default_factory=PPOConfig)
+    ddppo: DDPPOConfig = field(default_factory=DDPPOConfig)
+    ver: VERConfig = field(default_factory=VERConfig)
     auxiliary_losses: Dict[str, AuxLossConfig] = field(default_factory=dict)
 
 
@@ -469,8 +469,8 @@ class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     force_blind_policy: bool = False
     verbose: bool = True
     # Creates the vectorized environment.
-    vector_env_factory: VectorEnvFactoryConfig = VectorEnvFactoryConfig()
-    evaluator: EvaluatorConfig = EvaluatorConfig()
+    vector_env_factory: VectorEnvFactoryConfig = field(default_factory=VectorEnvFactoryConfig)
+    evaluator: EvaluatorConfig = field(default_factory=EvaluatorConfig)
     eval_keys_to_include_in_name: List[str] = field(default_factory=list)
     # For our use case, the CPU side things are mainly memory copies
     # and nothing of substantive compute. PyTorch has been making
@@ -482,12 +482,12 @@ class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
     # set it to true and yours likely should too
     force_torch_single_threaded: bool = False
     # Weights and Biases config
-    wb: WBConfig = WBConfig()
+    wb: WBConfig = field(default_factory=WBConfig)
     # When resuming training or evaluating, will use the original
     # training config if load_resume_state_config is True
     load_resume_state_config: bool = True
-    eval: EvalConfig = EvalConfig()
-    profiling: ProfilingConfig = ProfilingConfig()
+    eval: EvalConfig = field(default_factory=EvalConfig)
+    profiling: ProfilingConfig = field(default_factory=ProfilingConfig)
     # Whether to log the infos that are only logged to a single process to the
     # CLI along with the other metrics.
     should_log_single_proc_infos: bool = False
@@ -499,7 +499,7 @@ class HabitatBaselinesConfig(HabitatBaselinesBaseConfig):
 
 @dataclass
 class HabitatBaselinesRLConfig(HabitatBaselinesConfig):
-    rl: RLConfig = RLConfig()
+    rl: RLConfig = field(default_factory=RLConfig)
 
 
 @dataclass

--- a/habitat-lab/habitat/config/default_structured_configs.py
+++ b/habitat-lab/habitat/config/default_structured_configs.py
@@ -120,7 +120,7 @@ class EnvironmentConfig(HabitatBaseConfig):
     """
     max_episode_steps: int = 1000
     max_episode_seconds: int = 10000000
-    iterator_options: IteratorOptionsConfig = IteratorOptionsConfig()
+    iterator_options: IteratorOptionsConfig = field(default_factory=IteratorOptionsConfig)
 
 
 # -----------------------------------------------------------------------------
@@ -787,7 +787,7 @@ class TopDownMapMeasurementConfig(MeasurementConfig):
     draw_goal_positions: bool = True
     # axes aligned bounding boxes
     draw_goal_aabbs: bool = True
-    fog_of_war: FogOfWarConfig = FogOfWarConfig()
+    fog_of_war: FogOfWarConfig = field(default_factory=FogOfWarConfig)
 
 
 @dataclass
@@ -1783,14 +1783,14 @@ class SimulatorConfig(HabitatBaseConfig):
     # if default navmesh is used, should it include static objects
     navmesh_include_static_objects: bool = False
 
-    habitat_sim_v0: HabitatSimV0Config = HabitatSimV0Config()
+    habitat_sim_v0: HabitatSimV0Config = field(default_factory=HabitatSimV0Config)
     # ep_info is added to the config in some rearrange tasks inside
     # merge_sim_episode_with_object_config
     ep_info: Optional[Any] = None
     # The offset id values for the object
     object_ids_start: int = 100
     # Configuration for rendering
-    renderer: RendererConfig = RendererConfig()
+    renderer: RendererConfig = field(default_factory=RendererConfig)
 
 
 @dataclass
@@ -1861,11 +1861,11 @@ class HabitatConfig(HabitatBaseConfig):
     # The key of the gym environment in the registry to use in GymRegistryEnv
     # for example: `Cartpole-v0`
     env_task_gym_id: str = ""
-    environment: EnvironmentConfig = EnvironmentConfig()
-    simulator: SimulatorConfig = SimulatorConfig()
+    environment: EnvironmentConfig = field(default_factory=EnvironmentConfig)
+    simulator: SimulatorConfig = field(default_factory=SimulatorConfig)
     task: TaskConfig = MISSING
     dataset: DatasetConfig = MISSING
-    gym: GymConfig = GymConfig()
+    gym: GymConfig = field(default_factory=GymConfig)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation and Context

This change is required to support Python 3.11 and newer. In recent Python versions, using mutable default arguments (like `dataclass` instances) directly in `dataclass` field definitions is disallowed, as it leads to all instances of the parent class sharing the same default object. This can cause unexpected behavior where modifying a configuration for one object inadvertently affects others.

This pull request fixes this issue by using `field(default_factory=...)`, which is the correct pattern for initializing mutable default values in `dataclasses`.

## How Has This Been Tested

This change applies a standard Python pattern for dataclass initialization. The correctness of this approach is established by Python's own documentation and behavior. 

## Types of changes

- **\[Bug Fix\]** (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.
