### PR TITLE
[Dependency Upgrade] migrate habitat-lab from gym to gymnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you use the Habitat platform in your research, please cite the [Habitat 1.0](
     which uses [`habitat-lab/habitat/config/benchmark/rearrange/skills/pick.yaml`](habitat-lab/habitat/config/benchmark/rearrange/skills/pick.yaml) for configuration of task and agent. The script roughly does this:
 
     ```python
-    import gym
+    import gymnasium as gym
     import habitat.gym
 
     # Load embodied AI task (RearrangePick) and a pre-specified virtual robot

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ sys.path = [os.path.join(os.path.dirname(__file__), "../")] + sys.path
 
 import habitat  # isort:skip
 
-import gym  # isort:skip
+import gymnasium as gym  # isort:skip
 import typing  # isort:skip
 
 # Override the typing annotation of _np_random of gym.Env since the type provided is

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import gym
+import gymnasium as gym
 
 import habitat.gym  # noqa: F401
 

--- a/examples/register_new_sensors_and_measures.py
+++ b/examples/register_new_sensors_and_measures.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 from omegaconf import MISSING
 
 import habitat

--- a/examples/tutorials/nb_python/Habitat2_Quickstart.py
+++ b/examples/tutorials/nb_python/Habitat2_Quickstart.py
@@ -51,7 +51,7 @@ except Exception:
 import os
 
 import git
-import gym
+import gymnasium as gym
 import imageio
 import numpy as np
 from hydra.core.config_store import ConfigStore

--- a/examples/tutorials/nb_python/Habitat_Lab.py
+++ b/examples/tutorials/nb_python/Habitat_Lab.py
@@ -30,7 +30,7 @@ import random
 
 import git
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 # %matplotlib inline
 from matplotlib import pyplot as plt

--- a/examples/tutorials/nb_python/habitat2_gym_tutorial.py
+++ b/examples/tutorials/nb_python/habitat2_gym_tutorial.py
@@ -57,7 +57,7 @@ os.chdir(dir_path)
 
 # %%
 # The ONLY two lines you need to add to start importing Habitat 2.0 Gym environments.
-import gym
+import gymnasium as gym
 
 # flake8: noqa
 import habitat.gym

--- a/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb
+++ b/examples/tutorials/notebooks/Habitat2_Quickstart.ipynb
@@ -62,7 +62,7 @@
     "import os\n",
     "\n",
     "import git\n",
-    "import gym\n",
+    "import gymnasium as gym\n",
     "import imageio\n",
     "import numpy as np\n",
     "from hydra.core.config_store import ConfigStore\n",

--- a/examples/tutorials/notebooks/Habitat_Lab.ipynb
+++ b/examples/tutorials/notebooks/Habitat_Lab.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "import git\n",
     "import numpy as np\n",
-    "from gym import spaces\n",
+    "from gymnasium import spaces\n",
     "\n",
     "%matplotlib inline\n",
     "from matplotlib import pyplot as plt\n",

--- a/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb
+++ b/examples/tutorials/notebooks/habitat2_gym_tutorial.ipynb
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "# The ONLY two lines you need to add to start importing Habitat 2.0 Gym environments.\n",
-    "import gym\n",
+    "import gymnasium as gym\n",
     "\n",
     "# flake8: noqa\n",
     "import habitat.gym"

--- a/habitat-baselines/habitat_baselines/agents/ppo_agents.py
+++ b/habitat-baselines/habitat_baselines/agents/ppo_agents.py
@@ -12,9 +12,9 @@ from typing import Dict, Optional
 
 import numpy as np
 import torch
-from gym.spaces import Box
-from gym.spaces import Dict as SpaceDict
-from gym.spaces import Discrete
+from gymnasium.spaces import Box
+from gymnasium.spaces import Dict as SpaceDict
+from gymnasium.spaces import Discrete
 from omegaconf import DictConfig, OmegaConf
 
 import habitat
@@ -102,7 +102,7 @@ class PPOAgent(Agent):
 
         else:
             habitat.logger.error(
-                "Model checkpoint wasn't loaded, evaluating " "a random model."
+                "Model checkpoint wasn't loaded, evaluating a random model."
             )
 
         self.test_recurrent_hidden_states: Optional[torch.Tensor] = None

--- a/habitat-baselines/habitat_baselines/common/env_spec.py
+++ b/habitat-baselines/habitat_baselines/common/env_spec.py
@@ -3,7 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import attr
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 
 
 @attr.s(auto_attribs=True, slots=True)

--- a/habitat-baselines/habitat_baselines/common/obs_transformers.py
+++ b/habitat-baselines/habitat_baselines/common/obs_transformers.py
@@ -20,6 +20,7 @@ fake or modify sensor input from the simulator.
 
 This module API is experimental and likely to change
 """
+
 import abc
 import copy
 import numbers
@@ -28,7 +29,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from gym import spaces
+from gymnasium import spaces
 from torch import nn
 
 from habitat.core.logging import logger
@@ -815,13 +816,14 @@ def get_cubemap_projections(
     The rotation matrices are equivalent to
     .. code-block:: python
         from scipy.spatial.transform import Rotation
+
         rotations = [
             Rotation.from_euler("y", 180, degrees=True),  # Back
             Rotation.from_euler("x", -90, degrees=True),  # Down
             Rotation.from_euler("x", 0, degrees=True),  # Front
             Rotation.from_euler("y", -90, degrees=True),  # Left
             Rotation.from_euler("y", 90, degrees=True),  # Right
-            Rotation.from_euler("x", 90, degrees=True)  # Up
+            Rotation.from_euler("x", 90, degrees=True),  # Up
         ]
     """
     rotations = [
@@ -918,7 +920,7 @@ class ProjectionTransformer(ObservationTransformer):
             in_len = self.converter.input_len
             logger.info(
                 f"Overwrite sensor: {key} from size of ({h}, {w}) to image of"
-                f" {self.img_shape} from sensors: {self.sensor_uuids[i*in_len:(i+1)*in_len]}"
+                f" {self.img_shape} from sensors: {self.sensor_uuids[i * in_len : (i + 1) * in_len]}"
             )
             if (h, w) != self.img_shape:
                 observation_space.spaces[key] = overwrite_gym_box_shape(

--- a/habitat-baselines/habitat_baselines/rl/ddppo/policy/resnet_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/ddppo/policy/resnet_policy.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
-from gym import spaces
+from gymnasium import spaces
 from torch import nn as nn
 from torch.nn import functional as F
 from torchvision import transforms as T

--- a/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hierarchical_policy.py
@@ -6,7 +6,7 @@ import os.path as osp
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 import torch.nn as nn
@@ -191,7 +191,7 @@ class HierarchicalPolicy(nn.Module, Policy):
         ):
             cur_skill_idx = self._cur_skills[i]
             ret_policy_info: Dict[str, Any] = {
-                "cur_skill": self._idx_to_name[cur_skill_idx],
+                "cur_skill": self._idx_to_name[int(cur_skill_idx)],
                 **policy_info,
             }
 
@@ -584,7 +584,8 @@ class HierarchicalPolicy(nn.Module, Policy):
                 batch_idx=batch_ids,
                 log_info=log_info,
                 skill_name=[
-                    self._idx_to_name[self._cur_skills[i]] for i in batch_ids
+                    self._idx_to_name[int(self._cur_skills[i])]
+                    for i in batch_ids
                 ],
             )
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/hl/high_level_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hl/high_level_policy.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import torch
 import torch.nn as nn
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/hl/neural_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hl/neural_policy.py
@@ -6,7 +6,7 @@ import logging
 from itertools import chain
 from typing import Any, List
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 import torch.nn as nn

--- a/habitat-baselines/habitat_baselines/rl/hrl/hl/planner_policy.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/hl/planner_policy.py
@@ -5,9 +5,9 @@
 import random
 from collections import deque
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import torch
 
 from habitat.tasks.rearrange.multi_task.pddl_action import PddlAction
@@ -295,7 +295,9 @@ class PlannerHighLevelPolicy(HighLevelPolicy):
         batch_size = masks.shape[0]
         all_pred_vals = observations["all_predicates"]
         next_skill = torch.zeros(batch_size)
-        skill_args_data = [None for _ in range(batch_size)]
+        skill_args_data: List[Optional[List[str]]] = [
+            None for _ in range(batch_size)
+        ]
         immediate_end = torch.zeros(batch_size, dtype=torch.bool)
 
         if (~masks).sum() > 0:
@@ -315,7 +317,9 @@ class PlannerHighLevelPolicy(HighLevelPolicy):
             )
             if cur_ac is not None:
                 next_skill[batch_idx] = self._skill_name_to_idx[cur_ac.name]
-                skill_args_data[batch_idx] = [param.name for param in cur_ac.param_values]  # type: ignore[call-overload]
+                skill_args_data[batch_idx] = [
+                    param.name for param in cur_ac.param_values
+                ]  # type: ignore[call-overload]
             else:
                 # If we have no next action, do nothing.
                 next_skill[batch_idx] = self._skill_name_to_idx["wait"]

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/nav.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/nav.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import torch
 
 from habitat.tasks.rearrange.rearrange_sensors import (

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/nn_skill.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/nn_skill.py
@@ -4,7 +4,7 @@
 
 from collections import OrderedDict
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/noop.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/noop.py
@@ -4,7 +4,7 @@
 
 from typing import Any
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import torch
 
 from habitat_baselines.rl.hrl.skills.skill import SkillPolicy

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/reset.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/reset.py
@@ -4,7 +4,7 @@
 
 from typing import List, Tuple
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/skill.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/skill.py
@@ -5,7 +5,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import torch
 
 from habitat.core.simulator import Observations

--- a/habitat-baselines/habitat_baselines/rl/hrl/skills/wait.py
+++ b/habitat-baselines/habitat_baselines/rl/hrl/skills/wait.py
@@ -4,7 +4,7 @@
 
 from typing import Any
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import torch
 
 from habitat_baselines.rl.hrl.skills.skill import SkillPolicy

--- a/habitat-baselines/habitat_baselines/rl/models/action_embedding.py
+++ b/habitat-baselines/habitat_baselines/rl/models/action_embedding.py
@@ -6,7 +6,7 @@
 
 import math
 
-import gym
+import gymnasium as gym
 import numpy as np
 import torch
 import torch.nn as nn

--- a/habitat-baselines/habitat_baselines/rl/multi_agent/multi_agent_access_mgr.py
+++ b/habitat-baselines/habitat_baselines/rl/multi_agent/multi_agent_access_mgr.py
@@ -4,7 +4,7 @@
 
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 

--- a/habitat-baselines/habitat_baselines/rl/multi_agent/pop_play_wrappers.py
+++ b/habitat-baselines/habitat_baselines/rl/multi_agent/pop_play_wrappers.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 
@@ -383,8 +383,7 @@ class MultiPolicy(Policy):
                 lens.append(policy.policy_action_space.shape[0])
             else:
                 raise ValueError(
-                    f"Action distribution {policy.policy_action_space}"
-                    "not supported."
+                    f"Action distribution {policy.policy_action_space}not supported."
                 )
         return lens
 

--- a/habitat-baselines/habitat_baselines/rl/ppo/cpc_aux_loss.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/cpc_aux_loss.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import gym
+import gymnasium as gym
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/habitat-baselines/habitat_baselines/rl/ppo/policy.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/policy.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 import torch
-from gym import spaces
+from gymnasium import spaces
 from torch import nn as nn
 
 from habitat.tasks.nav.nav import (
@@ -281,8 +281,7 @@ class NetPolicy(nn.Module, Policy):
             )
         else:
             raise ValueError(
-                f"Action distribution {self.action_distribution_type}"
-                "not supported."
+                f"Action distribution {self.action_distribution_type}not supported."
             )
 
         self.critic = CriticHead(self.net.output_size)

--- a/habitat-baselines/habitat_baselines/rl/ppo/single_agent_access_mgr.py
+++ b/habitat-baselines/habitat_baselines/rl/ppo/single_agent_access_mgr.py
@@ -4,7 +4,7 @@
 
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 import torch.nn as nn
@@ -102,7 +102,7 @@ class SingleAgentAccessMgr(AgentAccessMgr):
             self._updater.load_state_dict(
                 {
                     "actor_critic." + k: v
-                    for k, v, in resume_state["state_dict"].items()
+                    for k, v in resume_state["state_dict"].items()
                 }
             )
 

--- a/habitat-baselines/habitat_baselines/utils/common.py
+++ b/habitat-baselines/habitat_baselines/utils/common.py
@@ -26,7 +26,7 @@ from typing import (
 import attr
 import numpy as np
 import torch
-from gym import spaces
+from gymnasium import spaces
 from PIL import Image
 from torch import Size, Tensor
 from torch import nn as nn
@@ -63,7 +63,8 @@ def cosine_decay(progress: float) -> float:
 
 class CustomFixedCategorical(torch.distributions.Categorical):  # type: ignore
     def sample(
-        self, sample_shape: Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: Size = torch.Size(),  # noqa: B008
     ) -> Tensor:
         return super().sample(sample_shape).unsqueeze(-1)
 
@@ -98,7 +99,8 @@ class CategoricalNet(nn.Module):
 
 class CustomNormal(torch.distributions.normal.Normal):
     def sample(
-        self, sample_shape: Size = torch.Size()  # noqa: B008
+        self,
+        sample_shape: Size = torch.Size(),  # noqa: B008
     ) -> Tensor:
         return self.rsample(sample_shape)
 
@@ -193,6 +195,7 @@ class _ObservationBatchingCache(metaclass=Singleton):
     r"""Helper for batching observations that maintains a cpu-side tensor
     that is the right size and is pinned to cuda memory
     """
+
     _pool: Dict[Any, Union[torch.Tensor, np.ndarray]] = {}
 
     def get(
@@ -248,9 +251,11 @@ class _ObservationBatchingCache(metaclass=Singleton):
     ) -> TensorDict:
         observations = [
             TensorOrNDArrayDict.from_tree(o).map(
-                lambda t: t.numpy()
-                if isinstance(t, torch.Tensor) and t.device.type == "cpu"
-                else t
+                lambda t: (
+                    t.numpy()
+                    if isinstance(t, torch.Tensor) and t.device.type == "cpu"
+                    else t
+                )
             )
             for o in observations
         ]
@@ -260,9 +265,11 @@ class _ObservationBatchingCache(metaclass=Singleton):
         # Order sensors by size, stack and move the largest first
         upload_ordering = sorted(
             range(len(observation_keys)),
-            key=lambda idx: 1
-            if isinstance(observation_tensors[0][idx], numbers.Number)
-            else int(np.prod(observation_tensors[0][idx].shape)),  # type: ignore
+            key=lambda idx: (
+                1
+                if isinstance(observation_tensors[0][idx], numbers.Number)
+                else int(np.prod(observation_tensors[0][idx].shape))
+            ),  # type: ignore
             reverse=True,
         )
 
@@ -361,9 +368,9 @@ def poll_checkpoint_folder(
         return checkpoint path if (previous_ckpt_ind + 1)th checkpoint is found
         else return None.
     """
-    assert os.path.isdir(checkpoint_folder), (
-        f"invalid checkpoint folder " f"path {checkpoint_folder}"
-    )
+    assert os.path.isdir(
+        checkpoint_folder
+    ), f"invalid checkpoint folder path {checkpoint_folder}"
     models_paths = list(
         filter(
             lambda name: "latest" not in name,
@@ -459,7 +466,7 @@ def tensor_to_depth_images(
 
 
 def tensor_to_bgr_images(
-    tensor: Union[torch.Tensor, Iterable[torch.Tensor]]
+    tensor: Union[torch.Tensor, Iterable[torch.Tensor]],
 ) -> List[np.ndarray]:
     r"""Converts tensor of n image tensors to list of n BGR images.
     Args:
@@ -620,7 +627,7 @@ def valid_sample(sample: Optional[Any]) -> bool:
 
 
 def img_bytes_2_np_array(
-    x: Tuple[int, torch.Tensor, bytes]
+    x: Tuple[int, torch.Tensor, bytes],
 ) -> Tuple[int, torch.Tensor, bytes, np.ndarray]:
     """Mapper function to convert image bytes in webdataset sample to numpy
     arrays.

--- a/habitat-hitl/habitat_hitl/environment/controllers/baselines_controller.py
+++ b/habitat-hitl/habitat_hitl/environment/controllers/baselines_controller.py
@@ -7,7 +7,7 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
-import gym.spaces as spaces
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 

--- a/habitat-lab/habitat/core/env.py
+++ b/habitat-lab/habitat/core/env.py
@@ -18,10 +18,10 @@ from typing import (
     cast,
 )
 
-import gym
+import gymnasium as gym
 import numba
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.config import read_write
 from habitat.core.dataset import BaseEpisode, Dataset, Episode, EpisodeIterator
@@ -233,11 +233,19 @@ class Env:
         self._elapsed_steps = 0
         self._episode_over = False
 
-    def reset(self) -> Observations:
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Observations:
         r"""Resets the environments and returns the initial observations.
 
         :return: initial observations from the environment.
         """
+        if seed is not None:
+            self.seed(seed)
+
         self._reset_stats()
 
         # Delete the shortest path cache of the current episode
@@ -420,9 +428,14 @@ class RLEnv(gym.Env):
 
     @profiling_wrapper.RangeContext("RLEnv.reset")
     def reset(
-        self, *, return_info: bool = False, **kwargs
+        self,
+        *,
+        return_info: bool = False,
+        seed: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> Union[Observations, Tuple[Observations, Dict]]:
-        observations = self._env.reset()
+        observations = self._env.reset(seed=seed, options=options)
         if return_info:
             return observations, self.get_info(observations)
         else:

--- a/habitat-lab/habitat/core/environments.py
+++ b/habitat-lab/habitat/core/environments.py
@@ -13,7 +13,7 @@ in habitat. Customized environments should be registered using
 import importlib
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Type, Union
 
-import gym
+import gymnasium as gym
 import numpy as np
 
 import habitat
@@ -57,9 +57,20 @@ class RLTaskEnv(habitat.RLEnv):
         ), "The key task.success_measure cannot be None"
 
     def reset(
-        self, *args, return_info: bool = False, **kwargs
+        self,
+        *args,
+        return_info: bool = False,
+        seed=None,
+        options=None,
+        **kwargs,
     ) -> Union[RLTaskEnvObsType, Tuple[RLTaskEnvObsType, Dict]]:
-        return super().reset(*args, return_info=return_info, **kwargs)
+        return super().reset(
+            *args,
+            return_info=return_info,
+            seed=seed,
+            options=options,
+            **kwargs,
+        )
 
     def step(
         self, *args, **kwargs
@@ -96,8 +107,42 @@ class RLTaskEnv(habitat.RLEnv):
         return self._env.get_metrics()
 
 
+class _OldGymPassthroughWrapper(gym.Wrapper):
+    def reset(self, *args, **kwargs):
+        return self.env.reset(*args, **kwargs)
+
+    def step(self, action):
+        return self.env.step(action)
+
+    def render(self, *args, **kwargs):
+        return self.env.render(*args, **kwargs)
+
+
+class _GymnasiumToOldGymAPIWrapper(_OldGymPassthroughWrapper):
+    def reset(self, *, return_info: bool = False, **kwargs):
+        reset_output = self.env.reset(**kwargs)
+        if not isinstance(reset_output, tuple):
+            return reset_output
+
+        obs, info = reset_output
+        if return_info:
+            return obs, info
+        return obs
+
+    def step(self, action):
+        step_output = self.env.step(action)
+        if len(step_output) == 4:
+            return step_output
+
+        obs, reward, terminated, truncated, info = step_output
+        info = dict(info)
+        if truncated and not terminated:
+            info.setdefault("TimeLimit.truncated", True)
+        return obs, reward, terminated or truncated, info
+
+
 @habitat.registry.register_env(name="GymRegistryEnv")
-class GymRegistryEnv(gym.Wrapper):
+class GymRegistryEnv(_OldGymPassthroughWrapper):
     """
     A registered environment that wraps a gym environment to be
     used with habitat-baselines
@@ -109,12 +154,12 @@ class GymRegistryEnv(gym.Wrapper):
         for dependency in config["env_task_gym_dependencies"]:
             importlib.import_module(dependency)
         env_name = config["env_task_gym_id"]
-        gym_env = gym.make(env_name)
+        gym_env = _GymnasiumToOldGymAPIWrapper(gym.make(env_name))
         super().__init__(gym_env)
 
 
 @habitat.registry.register_env(name="GymHabitatEnv")
-class GymHabitatEnv(gym.Wrapper):
+class GymHabitatEnv(_OldGymPassthroughWrapper):
     """
     A registered environment that wraps a RLTaskEnv with the HabGymWrapper
     to use the default gym API.

--- a/habitat-lab/habitat/core/registry.py
+++ b/habitat-lab/habitat/core/registry.py
@@ -191,7 +191,7 @@ class Registry(metaclass=Singleton):
                 If None will use the name of the class.
 
         """
-        from gym import Env
+        from gymnasium import Env
 
         return cls._register_impl("env", to_register, name, assert_type=Env)
 

--- a/habitat-lab/habitat/core/simulator.py
+++ b/habitat-lab/habitat/core/simulator.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """Defines the core Simulator and Sensor class wrapper APIs. The classes here are primarily defining abstract APIs which are implemented further downstream."""
+
 import abc
 import time
 from collections import OrderedDict
@@ -22,7 +23,7 @@ from typing import (
 import attr
 import numpy as np
 import quaternion
-from gym import Space, spaces
+from gymnasium import Space, spaces
 
 from habitat.core.dataset import Episode
 

--- a/habitat-lab/habitat/core/spaces.py
+++ b/habitat-lab/habitat/core/spaces.py
@@ -8,8 +8,8 @@ from collections import OrderedDict
 from collections.abc import Collection
 from typing import Dict, List, Union
 
-import gym
-from gym import Space
+import gymnasium as gym
+from gymnasium import Space
 
 
 class EmptySpace(Space):

--- a/habitat-lab/habitat/core/vector_env.py
+++ b/habitat-lab/habitat/core/vector_env.py
@@ -27,9 +27,9 @@ from typing import (
 )
 
 import attr
-import gym
+import gymnasium as gym
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 import habitat
 from habitat.core.batch_rendering.env_batch_renderer import EnvBatchRenderer
@@ -97,6 +97,7 @@ class _ReadWrapper:
     r"""Convenience wrapper to track if a connection to a worker process
     should have something to read.
     """
+
     read_fn: Callable[[], Any]
     rank: int
     is_waiting: bool = False
@@ -119,6 +120,7 @@ class _WriteWrapper:
     can be written to safely.  In other words, checks to make sure the
     result returned from the last write was read.
     """
+
     write_fn: Callable[[Any], None]
     read_wrapper: _ReadWrapper
 

--- a/habitat-lab/habitat/gym/gym_definitions.py
+++ b/habitat-lab/habitat/gym/gym_definitions.py
@@ -7,8 +7,8 @@
 import os.path as osp
 from typing import TYPE_CHECKING, Any, List, Optional
 
-import gym
-from gym.envs.registration import register, registry
+import gymnasium as gym
+from gymnasium.envs.registration import register, registry
 
 from habitat import get_config, read_write
 from habitat.config.default import _HABITAT_CFG_DIR, register_configs
@@ -93,16 +93,18 @@ def _make_habitat_gym_env(
 
 
 def _try_register(id_name, entry_point, kwargs):
-    if id_name in registry.env_specs:
+    if id_name in registry:
         return
     register(
         id_name,
         entry_point=entry_point,
         kwargs=kwargs,
+        order_enforce=False,
+        disable_env_checker=True,
     )
 
 
-if "Habitat-v0" not in registry.env_specs:
+if "Habitat-v0" not in registry:
     register_configs()
     # Generic supporting general configs
     _try_register(

--- a/habitat-lab/habitat/gym/gym_env_episode_count_wrapper.py
+++ b/habitat-lab/habitat/gym/gym_env_episode_count_wrapper.py
@@ -4,8 +4,8 @@
 
 from typing import Tuple, Union
 
-from gym import Env, Wrapper, spaces
-from gym.core import ActType, ObsType
+from gymnasium import Env, Wrapper, spaces
+from gymnasium.core import ActType, ObsType
 
 from habitat.core.dataset import Episode
 

--- a/habitat-lab/habitat/gym/gym_env_obs_dict_wrapper.py
+++ b/habitat-lab/habitat/gym/gym_env_obs_dict_wrapper.py
@@ -4,8 +4,8 @@
 
 from typing import Tuple, Union
 
-from gym import Env, Wrapper, spaces
-from gym.core import ActType, ObsType
+from gymnasium import Env, Wrapper, spaces
+from gymnasium.core import ActType, ObsType
 
 
 class EnvObsDictWrapper(Wrapper):
@@ -32,12 +32,11 @@ class EnvObsDictWrapper(Wrapper):
         return obs, reward, done, info
 
     def reset(self, **kwargs) -> Union[ObsType, Tuple[ObsType, dict]]:
-        if not self._requires_dict:
-            return self.env.reset(**kwargs)
         reset_output = self.env.reset(**kwargs)
+        if not self._requires_dict:
+            return reset_output
         if isinstance(reset_output, tuple):
-            obs, info = self.env.reset(**kwargs)
+            obs, info = reset_output
             return {self.OBSERVATION_KEY: obs}, info
-        else:
-            obs = self.env.reset(**kwargs)
-            return {self.OBSERVATION_KEY: obs}
+
+        return {self.OBSERVATION_KEY: reset_output}

--- a/habitat-lab/habitat/gym/gym_wrapper.py
+++ b/habitat-lab/habitat/gym/gym_wrapper.py
@@ -8,9 +8,9 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
-import gym
+import gymnasium as gym
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.batch_rendering.env_batch_renderer_constants import (
     KEYFRAME_OBSERVATION_KEY,
@@ -314,9 +314,20 @@ class HabGymWrapper(gym.Wrapper):
         return observation
 
     def reset(
-        self, *args, return_info: bool = False, **kwargs
+        self,
+        *args,
+        return_info: bool = False,
+        seed=None,
+        options=None,
+        **kwargs,
     ) -> Union[HabGymWrapperObsType, Tuple[HabGymWrapperObsType, dict]]:
-        obs = self.env.reset(*args, return_info=return_info, **kwargs)
+        obs = self.env.reset(
+            *args,
+            return_info=return_info,
+            seed=seed,
+            options=options,
+            **kwargs,
+        )
         if return_info:
             obs, info = obs
             self._last_obs = obs
@@ -328,17 +339,21 @@ class HabGymWrapper(gym.Wrapper):
     def render(self, mode: str = "human", **kwargs):
         last_infos = self.env.get_info(observations=None)
         if mode == "rgb_array":
-            frame = observations_to_image(self._last_obs, last_infos)
+            frame = np.asarray(
+                observations_to_image(self._last_obs, last_infos)
+            )
         elif mode == "human":
             if pygame is None:
                 raise ValueError(
                     "Render mode human not supported without pygame."
                 )
-            frame = observations_to_image(self._last_obs, last_infos)
+            frame = np.asarray(
+                observations_to_image(self._last_obs, last_infos)
+            )
             if self._screen is None:
                 pygame.init()
                 self._screen = pygame.display.set_mode(
-                    [frame.shape[1], frame.shape[0]]
+                    list(frame.shape[:2][::-1])
                 )
             draw_frame = np.transpose(
                 frame, (1, 0, 2)

--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -19,8 +19,8 @@ from typing import (
 
 import magnum as mn
 import numpy as np
-from gym import spaces
-from gym.spaces.box import Box
+from gymnasium import spaces
+from gymnasium.spaces.box import Box
 from omegaconf import DictConfig
 
 import habitat_sim

--- a/habitat-lab/habitat/tasks/eqa/eqa.py
+++ b/habitat-lab/habitat/tasks/eqa/eqa.py
@@ -7,7 +7,7 @@
 from typing import Any, Dict, List, Optional
 
 import attr
-from gym import Space, spaces
+from gymnasium import Space, spaces
 
 from habitat.core.embodied_task import Action, Measure
 from habitat.core.registry import registry
@@ -63,7 +63,7 @@ class QuestionSensor(Sensor):
         observations: Dict[str, Observations],
         episode: EQAEpisode,
         *args: Any,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         return episode.question.question_tokens
 

--- a/habitat-lab/habitat/tasks/nav/instance_image_nav_task.py
+++ b/habitat-lab/habitat/tasks/nav/instance_image_nav_task.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import attr
 import numpy as np
-from gym import Space, spaces
+from gymnasium import Space, spaces
 
 import habitat_sim
 from habitat.core.logging import logger

--- a/habitat-lab/habitat/tasks/nav/nav.py
+++ b/habitat-lab/habitat/tasks/nav/nav.py
@@ -6,13 +6,22 @@
 
 # TODO, lots of typing errors in here
 
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import attr
 import cv2
 import numpy as np
 import quaternion
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.config import read_write
 from habitat.config.default import get_agent_config
@@ -126,6 +135,7 @@ class PointGoalSensor(Sensor):
             in cartesian or polar coordinates.
         _dimensionality: number of dimensions used to specify the goal
     """
+
     cls_uuid: str = "pointgoal"
 
     def __init__(
@@ -219,6 +229,7 @@ class ImageGoalSensor(Sensor):
         sim: reference to the simulator for calculating task observations.
         config: config for the ImageGoal sensor.
     """
+
     cls_uuid: str = "imagegoal"
 
     def __init__(
@@ -306,6 +317,7 @@ class IntegratedPointGoalGPSAndCompassSensor(PointGoalSensor):
             in cartesian or polar coordinates.
         _dimensionality: number of dimensions used to specify the goal
     """
+
     cls_uuid: str = "pointgoal_with_gps_compass"
 
     def _get_uuid(self, *args: Any, **kwargs: Any) -> str:
@@ -333,6 +345,7 @@ class HeadingSensor(Sensor):
         sim: reference to the simulator for calculating task observations.
         config: config for the sensor.
     """
+
     cls_uuid: str = "heading"
 
     def __init__(
@@ -375,6 +388,7 @@ class EpisodicCompassSensor(HeadingSensor):
     r"""The agents heading in the coordinate frame defined by the episode,
     theta=0 is defined by the agents state at t=0
     """
+
     cls_uuid: str = "compass"
 
     def _get_uuid(self, *args: Any, **kwargs: Any) -> str:
@@ -406,6 +420,7 @@ class EpisodicGPSSensor(Sensor):
     Attributes:
         _dimensionality: number of dimensions used to specify the agents position
     """
+
     cls_uuid: str = "gps"
 
     def __init__(
@@ -461,6 +476,7 @@ class ProximitySensor(Sensor):
         sim: reference to the simulator for calculating task observations.
         config: config for the sensor.
     """
+
     cls_uuid: str = "proximity"
 
     def __init__(self, sim, config, *args: Any, **kwargs: Any):
@@ -724,13 +740,16 @@ class TopDownMap(Measure):
         return top_down_map
 
     def _draw_point(self, position, point_type):
+        top_down_map = self._top_down_map
+        assert top_down_map is not None
+        top_down_map_shape = cast(Tuple[int, int], top_down_map.shape)
         t_x, t_y = maps.to_grid(
             position[2],
             position[0],
-            (self._top_down_map.shape[0], self._top_down_map.shape[1]),
+            top_down_map_shape,
             sim=self._sim,
         )
-        self._top_down_map[
+        top_down_map[
             t_x - self.point_padding : t_x + self.point_padding + 1,
             t_y - self.point_padding : t_y + self.point_padding + 1,
         ] = point_type
@@ -776,6 +795,11 @@ class TopDownMap(Measure):
                     x_len, _, z_len = (
                         sem_scene.objects[object_id].aabb.sizes / 2.0
                     )
+                    top_down_map = self._top_down_map
+                    assert top_down_map is not None
+                    top_down_map_shape = cast(
+                        Tuple[int, int], top_down_map.shape
+                    )
                     # Nodes to draw rectangle
                     corners = [
                         center + np.array([x, 0, z])
@@ -793,17 +817,14 @@ class TopDownMap(Measure):
                         maps.to_grid(
                             p[2],
                             p[0],
-                            (
-                                self._top_down_map.shape[0],
-                                self._top_down_map.shape[1],
-                            ),
+                            top_down_map_shape,
                             sim=self._sim,
                         )
                         for p in corners
                     ]
 
                     maps.draw_path(
-                        self._top_down_map,
+                        top_down_map,
                         map_corners,
                         maps.MAP_TARGET_BOUNDING_BOX,
                         self.line_thickness,
@@ -820,17 +841,20 @@ class TopDownMap(Measure):
                     agent_position, episode.goals[0].position
                 )
             )
+            top_down_map = self._top_down_map
+            assert top_down_map is not None
+            top_down_map_shape = cast(Tuple[int, int], top_down_map.shape)
             self._shortest_path_points = [
                 maps.to_grid(
                     p[2],
                     p[0],
-                    (self._top_down_map.shape[0], self._top_down_map.shape[1]),
+                    top_down_map_shape,
                     sim=self._sim,
                 )
                 for p in _shortest_path_points
             ]
             maps.draw_path(
-                self._top_down_map,
+                top_down_map,
                 self._shortest_path_points,
                 maps.MAP_SHORTEST_PATH_COLOR,
                 self.line_thickness,
@@ -893,14 +917,17 @@ class TopDownMap(Measure):
 
     def update_map(self, agent_state: AgentState, agent_index: int):
         agent_position = agent_state.position
+        top_down_map = self._top_down_map
+        assert top_down_map is not None
+        top_down_map_shape = cast(Tuple[int, int], top_down_map.shape)
         a_x, a_y = maps.to_grid(
-            agent_position[2],
-            agent_position[0],
-            (self._top_down_map.shape[0], self._top_down_map.shape[1]),
+            float(agent_position[2]),
+            float(agent_position[0]),
+            top_down_map_shape,
             sim=self._sim,
         )
         # Don't draw over the source point
-        if self._top_down_map[a_x, a_y] != maps.MAP_SOURCE_POINT_INDICATOR:
+        if top_down_map[a_x, a_y] != maps.MAP_SOURCE_POINT_INDICATOR:
             color = 10 + min(
                 self._step_count * 245 // self._config.max_episode_steps, 245
             )
@@ -908,7 +935,7 @@ class TopDownMap(Measure):
             thickness = self.line_thickness
             if self._previous_xy_location[agent_index] is not None:
                 cv2.line(
-                    self._top_down_map,
+                    top_down_map,
                     self._previous_xy_location[agent_index],
                     (a_y, a_x),
                     color,
@@ -987,13 +1014,13 @@ class DistanceToGoal(Measure):
                 )
             else:
                 logger.error(
-                    f"Non valid distance_to parameter was provided: {self._distance_to }"
+                    f"Non valid distance_to parameter was provided: {self._distance_to}"
                 )
 
             self._previous_position = (
-                current_position[0],
-                current_position[1],
-                current_position[2],
+                float(current_position[0]),
+                float(current_position[1]),
+                float(current_position[2]),
             )
             self._metric = distance_to_target
 

--- a/habitat-lab/habitat/tasks/nav/object_nav_task.py
+++ b/habitat-lab/habitat/tasks/nav/object_nav_task.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 import attr
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.logging import logger
 from habitat.core.registry import registry
@@ -36,6 +36,7 @@ class ObjectGoalNavEpisode(NavigationEpisode):
 
     :param object_category: Category of the obect
     """
+
     object_category: Optional[str] = None
 
     @property
@@ -63,6 +64,7 @@ class ObjectViewLocation:
         1.0 if whole object is inside of the rectangle and no pixel inside
         the rectangle belongs to anything except the object.
     """
+
     agent_state: AgentState
     iou: Optional[float]
 
@@ -113,6 +115,7 @@ class ObjectGoalSensor(Sensor):
         dataset: a Object Goal navigation dataset that contains dictionaries
         of categories id to text mapping.
     """
+
     cls_uuid: str = "objectgoal"
 
     def __init__(

--- a/habitat-lab/habitat/tasks/rearrange/actions/actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/actions.py
@@ -8,7 +8,7 @@ from typing import Optional, cast
 
 import magnum as mn
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 import habitat_sim
 from habitat.articulated_agents.mobile_manipulator import (

--- a/habitat-lab/habitat/tasks/rearrange/actions/grip_actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/grip_actions.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 import magnum as mn
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.articulated_agents.robots.spot_robot import SpotRobot
 from habitat.articulated_agents.robots.stretch_robot import StretchRobot

--- a/habitat-lab/habitat/tasks/rearrange/actions/humanoid_actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/humanoid_actions.py
@@ -8,7 +8,7 @@ from enum import Enum
 
 import magnum as mn
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.articulated_agent_controllers import HumanoidRearrangeController
 from habitat.core.registry import registry

--- a/habitat-lab/habitat/tasks/rearrange/actions/oracle_nav_action.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/oracle_nav_action.py
@@ -5,7 +5,7 @@
 
 import magnum as mn
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 import habitat_sim
 from habitat.articulated_agent_controllers import HumanoidRearrangeController

--- a/habitat-lab/habitat/tasks/rearrange/actions/pddl_actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/actions/pddl_actions.py
@@ -3,7 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.registry import registry
 from habitat.tasks.rearrange.actions.grip_actions import ArticulatedAgentAction

--- a/habitat-lab/habitat/tasks/rearrange/multi_agent_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/multi_agent_sensors.py
@@ -3,7 +3,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.embodied_task import Measure
 from habitat.core.registry import registry

--- a/habitat-lab/habitat/tasks/rearrange/multi_task/pddl_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/multi_task/pddl_sensors.py
@@ -8,7 +8,7 @@
 from typing import List
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.embodied_task import Measure
 from habitat.core.registry import registry

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_sensors.py
@@ -8,7 +8,7 @@
 from collections import defaultdict, deque
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.articulated_agents.humanoids import KinematicHumanoid
 from habitat.core.embodied_task import Measure
@@ -76,7 +76,7 @@ class TargetCurrentSensor(UsesArticulatedAgentInterface, MultiObjSensor):
         scene_pos = self._sim.get_scene_pos()
         pos = scene_pos[idxs]
 
-        for i in range(pos.shape[0]):
+        for i in range(len(pos)):
             pos[i] = T_inv.transform_point(pos[i])
 
         return pos.reshape(-1)

--- a/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
+++ b/habitat-lab/habitat/tasks/rearrange/rearrange_task.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.dataset import Episode
 from habitat.core.registry import registry
@@ -287,8 +287,8 @@ class RearrangeTask(NavigationTask):
         idxs, goal_pos = self._sim.get_targets()
         scene_pos = self._sim.get_scene_pos()
         target_pos = scene_pos[idxs]
-        min_dist = np.min(
-            np.linalg.norm(target_pos - goal_pos, ord=2, axis=-1)
+        min_dist: float = float(
+            np.min(np.linalg.norm(target_pos - goal_pos, ord=2, axis=-1))
         )
         return (
             self._sim.grasp_mgr.is_grasped

--- a/habitat-lab/habitat/tasks/rearrange/robot_specific_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/robot_specific_sensors.py
@@ -8,7 +8,7 @@
 import warnings
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.registry import registry
 from habitat.core.simulator import Sensor, SensorTypes

--- a/habitat-lab/habitat/tasks/rearrange/social_nav/oracle_social_nav_actions.py
+++ b/habitat-lab/habitat/tasks/rearrange/social_nav/oracle_social_nav_actions.py
@@ -5,7 +5,7 @@
 
 import magnum as mn
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 import habitat_sim
 from habitat.core.registry import registry

--- a/habitat-lab/habitat/tasks/rearrange/social_nav/social_nav_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/social_nav/social_nav_sensors.py
@@ -6,7 +6,7 @@
 
 import magnum as mn
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 import habitat_sim
 from habitat.articulated_agents.humanoids.kinematic_humanoid import (

--- a/habitat-lab/habitat/tasks/rearrange/sub_tasks/articulated_object_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/sub_tasks/articulated_object_sensors.py
@@ -6,7 +6,7 @@
 
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.embodied_task import Measure
 from habitat.core.registry import registry

--- a/habitat-lab/habitat/tasks/rearrange/sub_tasks/nav_to_obj_sensors.py
+++ b/habitat-lab/habitat/tasks/rearrange/sub_tasks/nav_to_obj_sensors.py
@@ -6,7 +6,7 @@
 
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 import habitat_sim
 from habitat.core.embodied_task import Measure

--- a/habitat-lab/habitat/tasks/vln/vln.py
+++ b/habitat-lab/habitat/tasks/vln/vln.py
@@ -11,7 +11,7 @@
 from typing import Any, Dict, List, Optional
 
 import attr
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.core.registry import registry
 from habitat.core.simulator import Observations, Sensor
@@ -44,6 +44,7 @@ class VLNEpisode(NavigationEpisode):
         instruction: single natural language instruction guide to goal.
         trajectory_id: id of ground truth trajectory path.
     """
+
     reference_path: List[List[float]] = attr.ib(
         default=None, validator=not_none_validator
     )

--- a/habitat-lab/habitat/utils/test_utils.py
+++ b/habitat-lab/habitat/utils/test_utils.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from gym import spaces
+from gymnasium import spaces
 
 from habitat.tasks.nav.nav import StopAction
 

--- a/habitat-lab/requirements.txt
+++ b/habitat-lab/requirements.txt
@@ -1,4 +1,4 @@
-gym>=0.22.0,<0.23.1
+gymnasium>=0.29.1,<1.0.0
 numpy==1.26.4
 numpy-quaternion>=2019.3.18.14.33.20
 attrs>=19.1.0

--- a/test/test_baseline_resnet.py
+++ b/test/test_baseline_resnet.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-from gym import spaces
+from gymnasium import spaces
 
 try:
     import torch

--- a/test/test_ddppo_reduce.py
+++ b/test/test_ddppo_reduce.py
@@ -14,7 +14,7 @@ from habitat.tasks.nav.nav import IntegratedPointGoalGPSAndCompassSensor
 torch = pytest.importorskip("torch")
 habitat_baselines = pytest.importorskip("habitat_baselines")
 
-import gym
+import gymnasium as gym
 from torch import distributed as distrib
 from torch import nn
 

--- a/test/test_gym_wrapper.py
+++ b/test/test_gym_wrapper.py
@@ -6,9 +6,10 @@
 
 import importlib
 import sys
+from typing import Tuple, cast
 
-import gym
-import gym.spaces as spaces
+import gymnasium as gym
+import gymnasium.spaces as spaces
 import mock
 import numpy as np
 import pytest
@@ -69,9 +70,10 @@ def test_gym_wrapper_contract_continuous(
     obs, _, _, info = env.step(env.action_space.sample())
     assert isinstance(obs, expected_obs_type), f"Obs {obs}"
 
-    frame = env.render()
+    frame = np.asarray(env.render())
     assert isinstance(frame, np.ndarray)
-    assert len(frame.shape) == 3 and frame.shape[-1] == 3
+    frame_shape = cast(Tuple[int, int, int], frame.shape)
+    assert len(frame_shape) == 3 and frame_shape[-1] == 3
 
     env.close()
 
@@ -115,9 +117,10 @@ def test_gym_wrapper_contract_discrete(
     obs, _, _, info = env.step(env.action_space.sample())
     assert isinstance(obs, expected_obs_type), f"Obs {obs}"
 
-    frame = env.render()
+    frame = np.asarray(env.render())
     assert isinstance(frame, np.ndarray)
-    assert len(frame.shape) == 3 and frame.shape[-1] == 3
+    frame_shape = cast(Tuple[int, int, int], frame.shape)
+    assert len(frame_shape) == 3 and frame_shape[-1] == 3
 
     env.close()
 

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -11,7 +11,7 @@ from typing import List
 
 import numpy as np
 import pytest
-from gym import Wrapper
+from gymnasium import Wrapper
 
 import habitat
 from habitat.config.default import get_agent_config, get_config
@@ -228,9 +228,9 @@ def test_env(gpu2gpu):
             env.step(sample_non_stop_action(env.action_space))
 
         # check for steps limit on environment
-        assert env.episode_over is True, (
-            "episode should be over after " "max_episode_steps"
-        )
+        assert (
+            env.episode_over is True
+        ), "episode should be over after max_episode_steps"
 
         env.reset()
 

--- a/test/test_humanoid.py
+++ b/test/test_humanoid.py
@@ -7,7 +7,7 @@
 import math
 from os import path as osp
 
-import gym
+import gymnasium as gym
 import magnum as mn
 import numpy as np
 import pytest

--- a/test/test_obs_transformers.py
+++ b/test/test_obs_transformers.py
@@ -3,8 +3,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-from gym import spaces
-from gym.vector.utils.spaces import batch_space
+from gymnasium import spaces
+from gymnasium.vector.utils import batch_space
 
 from habitat_baselines.common.baseline_registry import baseline_registry
 from habitat_baselines.common.obs_transformers import (  # get_active_obs_transforms,
@@ -61,4 +61,4 @@ def test_transforms(obs_transform_config: ObsTransformConfig):
     )
     assert modified_obs_space.contains(
         {k: v[0] for k, v in transformed_obs.items()}
-    ), f"Observation transform generated the observation ({str({k: v.shape for k,v in transformed_obs.items()}) }) which is incompatible with the defined observation space {modified_obs_space}"
+    ), f"Observation transform generated the observation ({str({k: v.shape for k, v in transformed_obs.items()})}) which is incompatible with the defined observation space {modified_obs_space}"

--- a/test/test_pointnav_resnet_policy.py
+++ b/test/test_pointnav_resnet_policy.py
@@ -10,7 +10,7 @@ import subprocess
 import numpy as np
 import pytest
 import torch
-from gym import spaces
+from gymnasium import spaces
 
 from habitat import read_write
 from habitat_baselines.config.default import get_config

--- a/test/test_spaces.py
+++ b/test/test_spaces.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import gym
+import gymnasium as gym
 
 from habitat.core.spaces import ActionSpace, EmptySpace, ListSpace
 


### PR DESCRIPTION
## Motivation and Context

Importing Habitat currently pulls in the unmaintained `gym` dependency, which emits a warning in modern NumPy environments:

```bash
python -c 'import habitat'
```

```text
Gym has been unmaintained since 2022 and does not support NumPy 2.0 amongst other critical functionality.
Please upgrade to Gymnasium, the maintained drop-in replacement of Gym...
```

This PR migrates habitat-lab from `gym` to `gymnasium` so that importing Habitat no longer emits that warning. The change preserves Habitat's current env IDs and reset/step behavior without a broader public API transition to native gymnasium.

In short:
- replace `gym` imports/usages with `gymnasium`
- update compatibility points where the APIs differ
- refresh affected tests, examples, and docs references

## How Has This Been Tested

Tested locally with:

- `SKIP=mypy pre-commit run --all-files --hook-stage=manual`

## Types of changes

- **[Dependency Upgrade]** Upgrades one or several dependencies in habitat

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes if required.