### PR TITLE
fix: use int32 bounds for semantic sensor observation space

### DIFF
--- a/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat-lab/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -208,8 +208,8 @@ class HabitatSimSemanticSensor(SemanticSensor, HabitatSimSensor):
 
     def _get_observation_space(self, *args: Any, **kwargs: Any):
         return spaces.Box(
-            low=np.iinfo(np.uint32).min,
-            high=np.iinfo(np.uint32).max,
+            low=np.iinfo(np.int32).min,
+            high=np.iinfo(np.int32).max,
             shape=(self.config.height, self.config.width, 1),
             dtype=np.int32,
         )

--- a/habitat-lab/requirements.txt
+++ b/habitat-lab/requirements.txt
@@ -1,5 +1,5 @@
 gym>=0.22.0,<0.23.1
-numpy==1.26.4
+numpy>=1.26.4
 numpy-quaternion>=2019.3.18.14.33.20
 attrs>=19.1.0
 opencv-python>=3.3.0


### PR DESCRIPTION
## Summary

- Relaxes numpy version requirement to `>=1.26.4`
- Fixes `OverflowError` in `HabitatSimSemanticSensor._get_observation_space` when running with NumPy 2.0+

The semantic sensor declared `dtype=np.int32` but used `np.iinfo(np.uint32)` for `low`/`high` bounds. NumPy <2.0 silently wrapped `uint32` max (4294967295) to `-1`; NumPy 2.0+ enforces strict integer bounds checking and raises:

```
OverflowError: Python integer 4294967295 out of bounds for int32
```

## Test plan

- [x] Run any config with `semantic_sensor` enabled under NumPy 2.0+
- [x] Verify observation space dtype is `int32` and bounds are within range

🤖 Generated with [Claude Code](https://claude.com/claude-code)