### PR TITLE
CI: pin numpy<2.4 to fix numba/habitat-sim conda solve

### DIFF
--- a/.github/actions/install_ubuntu_deps/action.yml
+++ b/.github/actions/install_ubuntu_deps/action.yml
@@ -54,7 +54,7 @@ runs:
     run: |-
       echo "Install conda and dependencies"
       conda install -y pytorch torchvision pytorch-cuda=12.4 -c pytorch -c nvidia
-      conda install -y -c conda-forge ninja numpy=1.26.4 pytest pytest-cov ccache hypothesis pytest-mock
+      conda install -y -c conda-forge ninja "numpy>=2.0.0,<2.4" pytest pytest-cov ccache hypothesis pytest-mock
       pip install pytest-sugar pytest-xdist pytest-benchmark opencv-python cython pygame mock flaky pytest pytest-mock pytest-cov psutil
     shell: bash -el {0}
   - name: Validate Pytorch Installation


### PR DESCRIPTION
## Motivation and Context

The 'Run sim benchmark' CI step is failing with:

```
ImportError: Numba needs NumPy 2.3 or less. Got NumPy 2.4.
```

Additionally, habitat-sim's latest nightly (`0.3.3.2026.05.06`) declares `numpy >=2.0.0,<2.4`, which is incompatible with the prior `numpy=1.26.4` pin in `install_ubuntu_deps`, causing the conda env solve to fail outright.

## How Has This Been Tested

CI on this PR.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation if required. (N/A)
- [x] I have read the CONTRIBUTING document.
- [x] I have completed my CLA (see CONTRIBUTING)
- [x] I have added tests to cover my changes if applicable. (N/A — CI config)